### PR TITLE
Fix `ZigBeeCoordinatorHandler.initialize()`

### DIFF
--- a/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -11,6 +11,7 @@ package org.openhab.binding.zigbee.handler;
 import static org.openhab.binding.zigbee.ZigBeeBindingConstants.*;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
@@ -198,7 +199,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
 
         // If no key exists, generate a random key and save it back to the configuration
         if (networkKey == null || networkKey.length != 16
-                || networkKey.equals(new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 })
+                || Arrays.equals(networkKey, new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 })
                 || networkKeyString.length() == 0) {
             networkKeyString = createNetworkKey();
             logger.debug("Key initialised String {}", networkKeyString);

--- a/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -209,13 +209,15 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
 
         logger.debug("Key final array {}", networkKey);
 
-        try {
-            // Reset the initialization flag
-            Configuration configuration = editConfiguration();
-            configuration.put(CONFIGURATION_INITIALIZE, false);
-            updateConfiguration(configuration);
-        } catch (IllegalStateException e) {
-            logger.debug("Error updating configuration: Unable to reset initialize flag.", e);
+        if (initializeNetwork) {
+            try {
+                // Reset the initialization flag
+                Configuration configuration = editConfiguration();
+                configuration.put(CONFIGURATION_INITIALIZE, false);
+                updateConfiguration(configuration);
+            } catch (IllegalStateException e) {
+                logger.debug("Error updating configuration: Unable to reset initialize flag.", e);
+            }
         }
     }
 

--- a/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -153,7 +153,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
                 logger.debug("Channel set to 11.");
 
                 try {
-                    // Reset the initialization flag
+                    // Update the channel id
                     Configuration configuration = editConfiguration();
                     configuration.put(CONFIGURATION_CHANNEL, channelId);
                     updateConfiguration(configuration);
@@ -167,7 +167,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
                 logger.debug("Created random ZigBee PAN ID [{}].", String.format("%04X", panId));
 
                 try {
-                    // Reset the initialization flag
+                    // Update the PAN id
                     Configuration configuration = editConfiguration();
                     configuration.put(CONFIGURATION_PANID, panId);
                     updateConfiguration(configuration);
@@ -181,7 +181,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
                 logger.debug("Created random ZigBee extended PAN ID [{}].", String.format("%016X", extendedPanId));
 
                 try {
-                    // Reset the initialization flag
+                    // Update the extended PAN id
                     Configuration configuration = editConfiguration();
                     configuration.put(CONFIGURATION_EXTENDEDPANID, String.format("%016X", extendedPanId));
                     updateConfiguration(configuration);

--- a/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -182,7 +182,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
                 try {
                     // Reset the initialization flag
                     Configuration configuration = editConfiguration();
-                    configuration.put(CONFIGURATION_EXTENDEDPANID, extendedPanId);
+                    configuration.put(CONFIGURATION_EXTENDEDPANID, String.format("%016X", extendedPanId));
                     updateConfiguration(configuration);
                 } catch (IllegalStateException e) {
                     logger.debug("Error updating configuration: Unable to set Extended PanID.", e);


### PR DESCRIPTION
Running the binding today, I encountered a few issues during the initialisation phase. My CC2531EMK Coordinator thing wouldn't come online, so I investigated and found two bugs. The first two commits in this PR fix those; the other two commits just improve the code a little.

The first issue I saw was a `ClassCastException` at `ZigBeeCoordinatorHandler.java:122`. In my setup, the configuration item `CONFIGURATION_EXTENDEDPANID` wasn't a string, but a `BigDecimal` -- even though it should be a string. It turned out to be due to the assignment during the initialisation, right after generating a new extended PAN id. Including the `String.format()` call fixes this.

The second issue I saw was due to the comparison of the network key array with a temporary array. The `equals()` method of an array only checks whether the two are the same, just like `==` would (see [this SO post](https://stackoverflow.com/questions/8777257/equals-vs-arrays-equals-in-java)). Using `Arrays.equals()` instead will compare the array contents.

Furthermore I found that the `initialize()` would update the configuration every time it was called, which I think is unnecessary. Adding a simple condition on `initializeNetwork` around it should avoid that.

Cheers!

Signed-off-by: Duncan van Roermund <<foss@duncanvr.eu>>