### PR TITLE
Added support for lights supporting only XY color

### DIFF
--- a/src/main/java/org/openhab/binding/zigbee/converter/ColorHelper.java
+++ b/src/main/java/org/openhab/binding/zigbee/converter/ColorHelper.java
@@ -70,9 +70,9 @@ public class ColorHelper {
         float g = X * Xy2Rgb[1][0] + Yo * Xy2Rgb[1][1] + Z * Xy2Rgb[1][2];
         float b = X * Xy2Rgb[2][0] + Yo * Xy2Rgb[2][1] + Z * Xy2Rgb[2][2];
 
-        r = gammaCompress(r * Y);
-        g = gammaCompress(g * Y);
-        b = gammaCompress(b * Y);
+        r = gammaCompress(r) * Y;
+        g = gammaCompress(g) * Y;
+        b = gammaCompress(b) * Y;
 
         return HSBType.fromRGB((int) (r * 255.0f + 0.5f), (int) (g * 255.0f + 0.5f), (int) (b * 255.0f + 0.5f));
     }

--- a/src/main/java/org/openhab/binding/zigbee/converter/ColorHelper.java
+++ b/src/main/java/org/openhab/binding/zigbee/converter/ColorHelper.java
@@ -51,18 +51,16 @@ public class ColorHelper {
     }
 
     /**
-     * Returns a HSBType object representing the provided xyY color values in CIE XY color model.
+     * Returns a HSBType object representing the provided xy color values in CIE XY color model.
      * Conversion from CIE XY color model to sRGB using D65 reference white
+     * Returned color is set to full brightness
      *
      * @param x, y color information 0.0 - 1.0
-     * @param Y relative luminance 0.0 - 1.0
      *
-     * @return new HSBType object representing the given CIE XY color
+     * @return new HSBType object representing the given CIE XY color, full brightness
      */
-    public static HSBType fromXY(float x, float y, float Y) {
-        // This makes sure we keep color information even if relative luminance is zero
+    public static HSBType fromXY(float x, float y) {
         float Yo = 1.0f;
-
         float X = (Yo / y) * x;
         float Z = (Yo / y) * (1.0f - x - y);
 
@@ -70,9 +68,14 @@ public class ColorHelper {
         float g = X * Xy2Rgb[1][0] + Yo * Xy2Rgb[1][1] + Z * Xy2Rgb[1][2];
         float b = X * Xy2Rgb[2][0] + Yo * Xy2Rgb[2][1] + Z * Xy2Rgb[2][2];
 
-        r = gammaCompress(r) * Y;
-        g = gammaCompress(g) * Y;
-        b = gammaCompress(b) * Y;
+        float max = r > g ? r : g;
+        if (b > max) {
+            max = b;
+        }
+
+        r = gammaCompress(r / max);
+        g = gammaCompress(g / max);
+        b = gammaCompress(b / max);
 
         return HSBType.fromRGB((int) (r * 255.0f + 0.5f), (int) (g * 255.0f + 0.5f), (int) (b * 255.0f + 0.5f));
     }

--- a/src/main/java/org/openhab/binding/zigbee/converter/ColorHelper.java
+++ b/src/main/java/org/openhab/binding/zigbee/converter/ColorHelper.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.openhab.binding.zigbee.converter;
+
+import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+
+/**
+ * The methods provided by this class should be merged into HSBType directly
+ * They are here only while these are merged into ESH HSBType class
+ *
+ * @author Pedro Garcia - CIE XY color conversions
+ *
+ */
+
+public class ColorHelper {
+    // 1931 CIE XYZ to sRGB (D65 reference white)
+    private static float Xy2Rgb[][] = { { 3.2406f, -1.5372f, -0.4986f }, { -0.9689f, 1.8758f, 0.0415f },
+            { 0.0557f, -0.2040f, 1.0570f } };
+
+    // sRGB to 1931 CIE XYZ (D65 reference white)
+    private static float Rgb2Xy[][] = { { 0.4124f, 0.3576f, 0.1805f }, { 0.2126f, 0.7152f, 0.0722f },
+            { 0.0193f, 0.1192f, 0.9505f } };
+
+    // Gamma compression (sRGB) for a single component, in the 0.0 - 1.0 range
+    private static float gammaCompress(float c) {
+        if (c < 0.0f) {
+            c = 0.0f;
+        } else if (c > 1.0f) {
+            c = 1.0f;
+        }
+
+        return c <= 0.0031308f ? 19.92f * c : (1.0f + 0.055f) * (float) Math.pow(c, 1.0f / 2.4f) - 0.055f;
+    }
+
+    // Gamma decompression (sRGB) for a single component, in the 0.0 - 1.0 range
+    private static float gammaDecompress(float c) {
+        if (c < 0.0f) {
+            c = 0.0f;
+        } else if (c > 1.0f) {
+            c = 1.0f;
+        }
+
+        return c <= 0.04045f ? c / 19.92f : (float) Math.pow((c + 0.055f) / (1.0f + 0.055f), 2.4f);
+    }
+
+    /**
+     * Returns a HSBType object representing the provided xyY color values in CIE XY color model.
+     * Conversion from CIE XY color model to sRGB using D65 reference white
+     *
+     * @param x, y color information 0.0 - 1.0
+     * @param Y relative luminance 0.0 - 1.0
+     *
+     * @return new HSBType object representing the given CIE XY color
+     */
+    public static HSBType fromXY(float x, float y, float Y) {
+        // This makes sure we keep color information even if relative luminance is zero
+        float Yo = 1.0f;
+
+        float X = (Yo / y) * x;
+        float Z = (Yo / y) * (1.0f - x - y);
+
+        float r = X * Xy2Rgb[0][0] + Yo * Xy2Rgb[0][1] + Z * Xy2Rgb[0][2];
+        float g = X * Xy2Rgb[1][0] + Yo * Xy2Rgb[1][1] + Z * Xy2Rgb[1][2];
+        float b = X * Xy2Rgb[2][0] + Yo * Xy2Rgb[2][1] + Z * Xy2Rgb[2][2];
+
+        r = gammaCompress(r * Y);
+        g = gammaCompress(g * Y);
+        b = gammaCompress(b * Y);
+
+        return HSBType.fromRGB((int) (r * 255.0f + 0.5f), (int) (g * 255.0f + 0.5f), (int) (b * 255.0f + 0.5f));
+    }
+
+    /**
+     * Returns the xyY values representing this object's color in CIE XY color model.
+     * Conversion from sRGB to CIE XY using D65 reference white
+     * xy pair contains color information
+     * Y represents relative luminance
+     *
+     * @param HSBType color object
+     * @return PercentType[x, y, Y] values in the CIE XY color model
+     */
+    public static PercentType[] toXY(HSBType HSB) {
+        // This makes sure we keep color information even if brightness is zero
+        PercentType sRGB[] = new HSBType(HSB.getHue(), HSB.getSaturation(), PercentType.HUNDRED).toRGB();
+
+        float r = gammaDecompress(sRGB[0].floatValue() / 100.0f);
+        float g = gammaDecompress(sRGB[1].floatValue() / 100.0f);
+        float b = gammaDecompress(sRGB[2].floatValue() / 100.0f);
+
+        float X = r * Rgb2Xy[0][0] + g * Rgb2Xy[0][1] + b * Rgb2Xy[0][2];
+        float Y = r * Rgb2Xy[1][0] + g * Rgb2Xy[1][1] + b * Rgb2Xy[1][2];
+        float Z = r * Rgb2Xy[2][0] + g * Rgb2Xy[2][1] + b * Rgb2Xy[2][2];
+
+        float x = X / (X + Y + Z);
+        float y = Y / (X + Y + Z);
+
+        return new PercentType[] { new PercentType(Float.valueOf(x * 100.0f).toString()),
+                new PercentType(Float.valueOf(y * 100.0f).toString()),
+                new PercentType(Float.valueOf(Y * HSB.getBrightness().floatValue()).toString()) };
+    }
+}

--- a/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeConverterColorColor.java
+++ b/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeConverterColorColor.java
@@ -25,11 +25,12 @@ import com.zsmartsystems.zigbee.zcl.ZclAttribute;
 import com.zsmartsystems.zigbee.zcl.ZclAttributeListener;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclColorControlCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclLevelControlCluster;
-import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclOnOffCluster;
 
 /**
  *
  * @author Chris Jackson - Initial Contribution
+ * @author Pedro Garcia - Added CIE XY color support
  *
  */
 public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implements ZclAttributeListener {
@@ -38,8 +39,23 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
     private HSBType currentHSB;
     private ZclColorControlCluster clusterColorControl;
     private ZclLevelControlCluster clusterLevelControl;
+    private ZclOnOffCluster clusterOnOff;
 
     private boolean initialised = false;
+    private PercentType lastBrightness = PercentType.HUNDRED;
+    private Object colorUpdateSync = new Object();
+
+    private boolean supportsHue = false;
+    private float lastHue = -1.0f;
+    private float lastSaturation = -1.0f;
+    private boolean hueChanged = false;
+    private boolean saturationChanged = false;
+
+    private boolean supportsXY = false;
+    private float lastX = -1.0f;
+    private float lastY = -1.0f;
+    private boolean xChanged = false;
+    private boolean yChanged = false;
 
     @Override
     public void initializeConverter() {
@@ -51,34 +67,87 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
 
         clusterColorControl = (ZclColorControlCluster) endpoint.getInputCluster(ZclColorControlCluster.CLUSTER_ID);
         if (clusterColorControl == null) {
-            logger.error("Error opening device control controls {}", endpoint.getIeeeAddress());
+            logger.error("Error opening device color controls {}", endpoint.getIeeeAddress());
             return;
         }
 
         clusterLevelControl = (ZclLevelControlCluster) endpoint.getInputCluster(ZclLevelControlCluster.CLUSTER_ID);
         if (clusterLevelControl == null) {
-            logger.error("Error opening device level controls {}", endpoint.getIeeeAddress());
-            return;
+            logger.warn("Device does not support level control {}", endpoint.getIeeeAddress());
         }
 
-        clusterColorControl.bind();
-        clusterLevelControl.bind();
+        clusterOnOff = (ZclOnOffCluster) endpoint.getInputCluster(ZclOnOffCluster.CLUSTER_ID);
+        if (clusterOnOff == null) {
+            logger.warn("Device does not support on/off control {}", endpoint.getIeeeAddress());
+        }
 
-        // Add a listener, then request the status
-        clusterColorControl.addAttributeListener(this);
-        clusterLevelControl.addAttributeListener(this);
-
-        clusterColorControl.getCurrentHue(0);
-        clusterColorControl.getCurrentSaturation(0);
-        clusterLevelControl.getCurrentLevel(0);
-
-        // Configure reporting - no faster than once per second - no slower than 10 minutes.
+        // Discover whether the device supports HUE/SAT or XY color set of commands
         try {
-            clusterColorControl.setCurrentHueReporting(1, 600, 1).get();
-            clusterColorControl.setCurrentSaturationReporting(1, 600, 1).get();
-            clusterLevelControl.setCurrentLevelReporting(1, 600, 1).get();
-        } catch (ExecutionException | InterruptedException e) {
-            logger.debug("Exception configuring color reporting", e);
+            if (!clusterColorControl.discoverAttributes(false).get()) {
+                logger.warn("{}: Cannot determine whether device supports RGB color. Assuming it supports HUE/SAT",
+                        endpoint.getIeeeAddress());
+                supportsHue = true;
+            } else if (clusterColorControl.getSupportedAttributes().contains(ZclColorControlCluster.ATTR_CURRENTHUE)) {
+                logger.debug("Device supports Hue/Saturation color set of commands {}", endpoint.getIeeeAddress());
+                supportsHue = true;
+            } else if (clusterColorControl.getSupportedAttributes().contains(ZclColorControlCluster.ATTR_CURRENTX)) {
+                logger.debug("Device supports XY color set of commands {}", endpoint.getIeeeAddress());
+                supportsXY = true;
+            } else {
+                logger.warn("Device does not support RGB color {}", endpoint.getIeeeAddress());
+                return;
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.warn(
+                    "{}: Exception checking whether device endpoint supports RGB color. Assuming it supports HUE/SAT",
+                    endpoint.getIeeeAddress(), e);
+            supportsHue = true;
+        }
+
+        // Bind to attribute reports, add listeners, then request the status
+        // Configure reporting - no faster than once per second - no slower than 10 minutes.
+        clusterColorControl.bind();
+        clusterColorControl.addAttributeListener(this);
+        if (supportsHue) {
+            clusterColorControl.getCurrentHue(0);
+            clusterColorControl.getCurrentSaturation(0);
+            try {
+                clusterColorControl.setCurrentHueReporting(1, 600, 1).get();
+                clusterColorControl.setCurrentSaturationReporting(1, 600, 1).get();
+            } catch (ExecutionException | InterruptedException e) {
+                logger.debug("Exception configuring color reporting", e);
+            }
+        } else if (supportsXY) {
+            clusterColorControl.getCurrentX(0);
+            clusterColorControl.getCurrentY(0);
+            try {
+                clusterColorControl.setCurrentXReporting(1, 600, 1).get();
+                clusterColorControl.setCurrentYReporting(1, 600, 1).get();
+            } catch (ExecutionException | InterruptedException e) {
+                logger.debug("Exception configuring color reporting", e);
+            }
+        }
+
+        if (clusterLevelControl != null) {
+            clusterLevelControl.bind();
+            clusterLevelControl.addAttributeListener(this);
+            clusterLevelControl.getCurrentLevel(0);
+            try {
+                clusterLevelControl.setCurrentLevelReporting(1, 600, 1).get();
+            } catch (ExecutionException | InterruptedException e) {
+                logger.debug("Exception configuring level reporting", e);
+            }
+        }
+
+        if (clusterOnOff != null) {
+            clusterOnOff.bind();
+            clusterOnOff.addAttributeListener(this);
+            clusterOnOff.getOnOff(0);
+            try {
+                clusterOnOff.setOnOffReporting(1, 600).get();
+            } catch (ExecutionException | InterruptedException e) {
+                logger.debug("Exception configuring on/off reporting", e);
+            }
         }
 
         initialised = true;
@@ -87,14 +156,105 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
     @Override
     public void disposeConverter() {
         clusterColorControl.removeAttributeListener(this);
-        clusterLevelControl.removeAttributeListener(this);
+
+        if (clusterLevelControl != null) {
+            clusterLevelControl.removeAttributeListener(this);
+        }
+
+        if (clusterOnOff != null) {
+            clusterOnOff.removeAttributeListener(this);
+        }
     }
 
     @Override
     public void handleRefresh() {
-        clusterColorControl.getCurrentHue(0);
-        clusterColorControl.getCurrentSaturation(0);
-        clusterLevelControl.getCurrentLevel(0);
+        if (supportsHue) {
+            clusterColorControl.getCurrentHue(0);
+            clusterColorControl.getCurrentSaturation(0);
+        } else if (supportsXY) {
+            clusterColorControl.getCurrentX(0);
+            clusterColorControl.getCurrentY(0);
+        }
+
+        if (clusterLevelControl != null) {
+            clusterLevelControl.getCurrentLevel(0);
+        }
+
+        if (clusterOnOff != null) {
+            clusterOnOff.getOnOff(0);
+        }
+    }
+
+    private void changeOnOff(OnOffType onoff) throws InterruptedException, ExecutionException {
+        boolean on = onoff == OnOffType.ON;
+        PercentType brightness = on ? PercentType.HUNDRED : PercentType.ZERO;
+
+        if (clusterLevelControl != null) {
+            changeBrightness(brightness);
+            return;
+        }
+
+        if (clusterOnOff == null) {
+            logger.warn("{}: ignoring on/off command", endpoint.getIeeeAddress());
+            return;
+        }
+
+        HSBType oldHSB = currentHSB;
+        currentHSB = new HSBType(oldHSB.getHue(), oldHSB.getSaturation(), brightness);
+        lastBrightness = brightness;
+
+        if (on) {
+            clusterOnOff.onCommand().get();
+        } else {
+            clusterOnOff.offCommand().get();
+        }
+    }
+
+    private void changeBrightness(PercentType brightness) throws InterruptedException, ExecutionException {
+        if (clusterLevelControl == null) {
+            if (clusterOnOff != null) {
+                changeOnOff(brightness.intValue() == 0 ? OnOffType.OFF : OnOffType.ON);
+            } else {
+                logger.warn("{}: ignoring brightness command", endpoint.getIeeeAddress());
+            }
+            return;
+        }
+
+        HSBType oldHSB = currentHSB;
+        currentHSB = new HSBType(oldHSB.getHue(), oldHSB.getSaturation(), brightness);
+        lastBrightness = brightness;
+
+        int level = (int) (brightness.floatValue() * 254.0f / 100.0f + 0.5f);
+
+        if (clusterOnOff != null) {
+            clusterLevelControl.moveToLevelWithOnOffCommand(level, 10).get();
+        } else {
+            clusterLevelControl.moveToLevelCommand(level, 10).get();
+        }
+    }
+
+    private void changeColorHueSaturation(HSBType color) throws InterruptedException, ExecutionException {
+        HSBType oldHSB = currentHSB;
+        currentHSB = new HSBType(color.getHue(), color.getSaturation(), oldHSB.getBrightness());
+        int hue = (int) (color.getHue().floatValue() * 254.0f / 360.0f + 0.5f);
+        int saturation = (int) (color.getSaturation().floatValue() * 254.0f / 100.0f + 0.5f);
+
+        clusterColorControl.moveToHueAndSaturationCommand(hue, saturation, 10).get();
+    }
+
+    private void changeColorXY(HSBType color) throws InterruptedException, ExecutionException {
+        PercentType xy[] = ColorHelper.toXY(color);
+
+        HSBType oldHSB = currentHSB;
+        currentHSB = new HSBType(color.getHue(), color.getSaturation(), oldHSB.getBrightness());
+
+        logger.debug("{}: Change Color HSV. {}, {}, {}", endpoint.getIeeeAddress(), color.getHue(),
+                color.getSaturation(), oldHSB.getBrightness());
+        logger.debug("{}: Calculated XY. {}, {}", endpoint.getIeeeAddress(), xy[0], xy[1]);
+        int x = (int) (xy[0].floatValue() / 100.0f * 65536.0f + 0.5f); // up to 65279
+        int y = (int) (xy[1].floatValue() / 100.0f * 65536.0f + 0.5f); // up to 65279
+
+        clusterColorControl.moveToColorCommand(x, y, 10).get();
     }
 
     @Override
@@ -106,28 +266,33 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                     return;
                 }
 
-                int level;
                 try {
                     if (command instanceof HSBType) {
-                        HSBType hsb = (HSBType) command;
-                        clusterColorControl
-                                .moveToHueAndSaturationCommand((int) (hsb.getHue().doubleValue() * 254.0 / 360.0 + 0.5),
-                                        (int) (hsb.getSaturation().doubleValue() * 254.0 / 100.0 + 0.5), 10)
-                                .get();
-                        level = hsb.getBrightness().intValue();
-                    } else if (command instanceof PercentType) {
-                        level = ((PercentType) command).intValue();
-                    } else if (command instanceof OnOffType) {
-                        level = (OnOffType) command == OnOffType.ON ? 100 : 0;
-                    } else {
-                        return;
-                    }
+                        HSBType color = (HSBType) command;
+                        PercentType brightness = color.getBrightness();
 
-                    clusterLevelControl.moveToLevelWithOnOffCommand((int) (level * 254.0 / 100.0 + 0.5), 10).get();
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                } catch (ExecutionException e) {
-                    e.printStackTrace();
+                        if (brightness.intValue() != currentHSB.getBrightness().intValue()) {
+                            changeBrightness(brightness);
+                            // Wait for transition to complete
+                            // Some lights do not like receiving a level/color change command
+                            // while the previous transition is in progress...
+                            Thread.sleep(1000);
+                        }
+
+                        if (supportsHue) {
+                            changeColorHueSaturation(color);
+                        } else if (supportsXY) {
+                            changeColorXY(color);
+                        }
+                    } else if (command instanceof PercentType) {
+                        PercentType brightness = (PercentType) command;
+                        changeBrightness(brightness);
+                    } else if (command instanceof OnOffType) {
+                        OnOffType onoff = (OnOffType) command;
+                        changeOnOff(onoff);
+                    }
+                } catch ( /* InterruptedException | ExecutionException | */ Exception | Error e) {
+                    logger.warn("{}: Exception processing command", endpoint.getIeeeAddress(), e);
                 }
             }
         };
@@ -135,43 +300,152 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
 
     @Override
     public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
-        if (endpoint.getInputCluster(ZclColorControlCluster.CLUSTER_ID) == null
-                || endpoint.getInputCluster(ZclLevelControlCluster.CLUSTER_ID) == null) {
+        clusterColorControl = (ZclColorControlCluster) endpoint.getInputCluster(ZclColorControlCluster.CLUSTER_ID);
+
+        if (clusterColorControl == null) {
             return null;
         }
+
+        try {
+            if (!clusterColorControl.discoverAttributes(false).get()) {
+                logger.warn(
+                        "{}: Cannot determine whether device supports RGB color. Assuming it does by now (checking again later)",
+                        endpoint.getIeeeAddress());
+            } else if (!clusterColorControl.getSupportedAttributes().contains(ZclColorControlCluster.ATTR_CURRENTHUE)
+                    && !clusterColorControl.getSupportedAttributes().contains(ZclColorControlCluster.ATTR_CURRENTX)) {
+                return null;
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.warn(
+                    "{}: Exception checking whether device supports RGB color. Assuming it does by now (checking again later)",
+                    endpoint.getIeeeAddress(), e);
+        }
+
         return createChannel(thingUID, endpoint, ZigBeeBindingConstants.CHANNEL_COLOR_COLOR,
                 ZigBeeBindingConstants.ITEM_TYPE_COLOR, "Color");
+    }
+
+    private void updateOnOff(OnOffType onoff) {
+        updateBrightness(lastBrightness);
+    }
+
+    private void updateBrightness(PercentType brightness) {
+        HSBType oldHSB = currentHSB;
+        HSBType newHSB = new HSBType(oldHSB.getHue(), oldHSB.getSaturation(), brightness);
+        currentHSB = newHSB;
+        lastBrightness = brightness;
+        updateChannelState(newHSB);
+    }
+
+    private void updateColorHSB(DecimalType hue, PercentType saturation) {
+        HSBType oldHSB = currentHSB;
+        HSBType newHSB = new HSBType(hue, saturation, oldHSB.getBrightness());
+        currentHSB = newHSB;
+        updateChannelState(newHSB);
+    }
+
+    private void updateColorXY(PercentType x, PercentType y) {
+        logger.debug("{}: Update Color XY. {}, {}", endpoint.getIeeeAddress(), x.toString(), y.toString());
+        HSBType color = ColorHelper.fromXY(x.floatValue() / 100.0f, y.floatValue() / 100.0f, 1.0f);
+        logger.debug("{}: Calculated Hue/Saturation. {}, {}", endpoint.getIeeeAddress(), color.getHue(),
+                color.getSaturation());
+        updateColorHSB(color.getHue(), color.getSaturation());
+    }
+
+    private void updateColorHSB() {
+        DecimalType hue = new DecimalType(Float.valueOf(lastHue).toString());
+        PercentType saturation = new PercentType(Float.valueOf(lastSaturation).toString());
+        updateColorHSB(hue, saturation);
+        hueChanged = false;
+        saturationChanged = false;
+    }
+
+    private void updateColorXY() {
+        PercentType x = new PercentType(Float.valueOf(lastX * 100.0f).toString());
+        PercentType y = new PercentType(Float.valueOf(lastY * 100.0f).toString());
+        updateColorXY(x, y);
+        xChanged = false;
+        yChanged = false;
     }
 
     @Override
     public void attributeUpdated(ZclAttribute attribute) {
         logger.debug("ZigBee attribute reports {} from {}", attribute, endpoint.getIeeeAddress());
-        if (attribute.getCluster() == ZclClusterType.COLOR_CONTROL) {
-            if (attribute.getId() == ZclColorControlCluster.ATTR_CURRENTHUE) {
-                Integer value = (Integer) attribute.getLastValue();
-                if (value != null) {
-                    DecimalType hue = new DecimalType(value * 100 / 254);
-                    currentHSB = new HSBType(hue, currentHSB.getSaturation(), currentHSB.getBrightness());
-                    updateChannelState(currentHSB);
+
+        synchronized (colorUpdateSync) {
+            try {
+                if (attribute.getCluster().getId() == ZclOnOffCluster.CLUSTER_ID
+                        && attribute.getId() == ZclOnOffCluster.ATTR_ONOFF) {
+                    Boolean value = (Boolean) attribute.getLastValue();
+                    OnOffType onoff = value ? OnOffType.ON : OnOffType.OFF;
+                    updateOnOff(onoff);
+                } else if (attribute.getCluster().getId() == ZclLevelControlCluster.CLUSTER_ID
+                        && attribute.getId() == ZclLevelControlCluster.ATTR_CURRENTLEVEL) {
+                    Integer value = (Integer) attribute.getLastValue();
+                    PercentType brightness = new PercentType(Float.valueOf(value * 100.0f / 254.0f).toString());
+                    updateBrightness(brightness);
+                } else if (attribute.getCluster().getId() == ZclColorControlCluster.CLUSTER_ID
+                        && attribute.getId() == ZclColorControlCluster.ATTR_CURRENTHUE) {
+                    Integer value = (Integer) attribute.getLastValue();
+                    float hue = value * 360.0f / 254.0f;
+                    if (hue != lastHue) {
+                        lastHue = hue;
+                        hueChanged = true;
+                    }
+                } else if (attribute.getCluster().getId() == ZclColorControlCluster.CLUSTER_ID
+                        && attribute.getId() == ZclColorControlCluster.ATTR_CURRENTSATURATION) {
+                    Integer value = (Integer) attribute.getLastValue();
+                    float saturation = value * 100.0f / 254.0f;
+                    if (saturation != lastSaturation) {
+                        lastSaturation = saturation;
+                        saturationChanged = true;
+                    }
+                } else if (attribute.getCluster().getId() == ZclColorControlCluster.CLUSTER_ID
+                        && attribute.getId() == ZclColorControlCluster.ATTR_CURRENTX) {
+                    Integer value = (Integer) attribute.getLastValue();
+                    float x = value / 65536.0f;
+                    if (x != lastX) {
+                        lastX = x;
+                        xChanged = true;
+                    }
+                } else if (attribute.getCluster().getId() == ZclColorControlCluster.CLUSTER_ID
+                        && attribute.getId() == ZclColorControlCluster.ATTR_CURRENTY) {
+                    Integer value = (Integer) attribute.getLastValue();
+                    float y = value / 65536.0f;
+                    if (y != lastY) {
+                        lastY = y;
+                        yChanged = true;
+                    }
                 }
-            }
-            if (attribute.getId() == ZclColorControlCluster.ATTR_CURRENTSATURATION) {
-                Integer value = (Integer) attribute.getLastValue();
-                if (value != null) {
-                    PercentType saturation = new PercentType(value * 100 / 254);
-                    currentHSB = new HSBType(currentHSB.getHue(), saturation, currentHSB.getBrightness());
-                    updateChannelState(currentHSB);
+                if (hueChanged && saturationChanged) {
+                    updateColorHSB();
+                } else if (xChanged && yChanged) {
+                    updateColorXY();
+                } else if (hueChanged || saturationChanged || xChanged || yChanged) {
+                    // Wait some time and update anyway if only one attribute in each pair is updated
+                    new Thread() {
+                        @Override
+                        public void run() {
+                            try {
+                                sleep(500);
+                                synchronized (colorUpdateSync) {
+                                    if ((hueChanged || saturationChanged) && lastHue >= 0.0f
+                                            && lastSaturation >= 0.0f) {
+                                        updateColorHSB();
+                                    } else if ((xChanged || yChanged) && lastX >= 0.0f && lastY >= 0.0f) {
+                                        updateColorXY();
+                                    }
+                                }
+                            } catch (Exception e) {
+                                logger.debug("{}: Exception in deferred attribute update", endpoint.getIeeeAddress(),
+                                        e);
+                            }
+                        }
+                    }.start();
                 }
-            }
-        } else if (attribute.getCluster() == ZclClusterType.LEVEL_CONTROL
-                && attribute.getId() == ZclLevelControlCluster.ATTR_CURRENTLEVEL) {
-            Integer value = (Integer) attribute.getLastValue();
-            if (value != null) {
-                PercentType brightness = new PercentType(value * 100 / 254);
-                currentHSB = new HSBType(currentHSB.getHue(), currentHSB.getSaturation(), brightness);
-                updateChannelState(currentHSB);
+            } catch (Exception e) {
+                logger.debug("{}: Exception in attribute update", endpoint.getIeeeAddress(), e);
             }
         }
     }
-
 }


### PR DESCRIPTION
The current color channel converter implementation only supports Hue/Saturation commands and attributes, so some lights do not work.

This pull request addresses this (closes #64)

Signed-off-by: Pedro Garcia <pg@puzzle-star.com> (github: puzzle-star)