### PR TITLE
Improve network performance during discovery

### DIFF
--- a/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeDiscoveryService.java
+++ b/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeDiscoveryService.java
@@ -113,16 +113,21 @@ public class ZigBeeDiscoveryService extends AbstractDiscoveryService
             return;
         }
 
+        ThingTypeUID thingTypeUID = ZigBeeBindingConstants.THING_TYPE_GENERIC_DEVICE;
+        ThingUID bridgeUID = coordinatorHandler.getThing().getUID();
+
+        String thingId = node.getIeeeAddress().toString().toLowerCase().replaceAll("[^a-z0-9_/]", "");
+        ThingUID thingUID = new ThingUID(thingTypeUID, bridgeUID, thingId);
+
+        // If this already exists as a thing, then no need to rediscover
+        if (discoveryServiceCallback != null && discoveryServiceCallback.getExistingThing(thingUID) != null) {
+            return;
+        }
+
         Runnable pollingRunnable = new Runnable() {
             @Override
             public void run() {
                 logger.info("{}: Starting ZigBee device discovery", node.getIeeeAddress());
-
-                ThingTypeUID thingTypeUID = ZigBeeBindingConstants.THING_TYPE_GENERIC_DEVICE;
-                ThingUID bridgeUID = coordinatorHandler.getThing().getUID();
-
-                String thingId = node.getIeeeAddress().toString().toLowerCase().replaceAll("[^a-z0-9_/]", "");
-                ThingUID thingUID = new ThingUID(thingTypeUID, bridgeUID, thingId);
 
                 // Set the default label
                 String label = "Unknown ZigBee Device " + node.getIeeeAddress();


### PR DESCRIPTION
This adds a check in the discovery service so that we don't perform any discovery if a node already exists as a thing which should reduce network congestion during discovery.
#95 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>