### PR TITLE
Add handleRemoval handler to send leave command to device

### DIFF
--- a/ESH-INF/thing/_controller_telegesis.xml
+++ b/ESH-INF/thing/_controller_telegesis.xml
@@ -97,7 +97,7 @@
                 <options>
                     <option value="TC_JOIN_DENY">Deny all joins</option>
                     <option value="TC_JOIN_SECURE">Allow only secure joining</option>
-                    <option value="TC_JOIN_INSECURE">All all joins</option>
+                    <option value="TC_JOIN_INSECURE">Allow all joins</option>
                 </options>
                 <default>TC_JOIN_SECURE</default>
                 <advanced>true</advanced>

--- a/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -693,7 +693,6 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
         logger.debug("{}: ZigBee leave command to {}", address, node.getNetworkAddress());
 
         networkManager.leave(node.getNetworkAddress(), node.getIeeeAddress());
-        // networkManager.leave(ZigBeeBroadcastDestination.BROADCAST_ALL_DEVICES.getKey(), node.getIeeeAddress());
         return true;
     }
 

--- a/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -226,6 +226,7 @@ public class ZigBeeThingHandler extends BaseThingHandler
                     continue;
                 }
 
+                logger.debug("{}: Initializing channel {} with {}", nodeIeeeAddress, channel.getUID(), handler);
                 handler.initializeConverter();
 
                 // TODO: Update the channel configuration from the device if method available
@@ -242,6 +243,7 @@ public class ZigBeeThingHandler extends BaseThingHandler
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR);
             return;
         }
+        logger.debug("{}: Channel initialisation complete", nodeIeeeAddress);
 
         // Update the general properties
         ZigBeeNodePropertyDiscoverer propertyDiscoverer = new ZigBeeNodePropertyDiscoverer();
@@ -365,6 +367,12 @@ public class ZigBeeThingHandler extends BaseThingHandler
 
         // We keep track of what channels are used and only poll channels that the framework is using
         thingChannelsPoll.remove(channelUID);
+    }
+
+    @Override
+    public void handleRemoval() {
+        coordinatorHandler.leave(nodeIeeeAddress);
+        updateStatus(ThingStatus.REMOVED);
     }
 
     @Override


### PR DESCRIPTION
Adds a ```handleRemoval``` method to the thing handler, and removes the device from the network when the thing is deleted.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>