### PR TITLE
Update IAS converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,22 +42,22 @@ The thing type is ```coordinator_telegesis```.
 
 The following devices have been tested with the binding
 
-| Device                     | Description                                   |
-|----------------------------|-----------------------------------------------|
-| Busch-Jaeger 6711          | Relay Insert                                  |
-| Busch-Jaeger 6735          | Control Element (1-channel)                   |
-| Busch-Jaeger 6735/01       | Control Element (1-channel, battery-operated) |
-| Busch-Jaeger 6736          | Control Element (2-channel)                   |
-| GE Bulbs                   |                                               |
-| Hue Bulbs                  | Color LED Bulb                                |
-| Hue Motion Sensor          | Motion and Luminance sensor                   |
-| Innr Bulbs                 |                                               |
-| Osram Bulbs                |                                               |
-| SmartThings Plug           | Metered Plug                                  |
-| SmartThings Motion Sensor  | Motion and Temperature sensor                 |
-| SmartThings Contact Sensor | Contact and Temperature sensor                |
-| Tradfri Bulbs              |                                               |
-| Tradfri Motion Sensor      |                                               |
+| Device                     | Description                                       |
+|----------------------------|---------------------------------------------------|
+| Busch-Jaeger 6711          | Relay Insert                                      |
+| Busch-Jaeger 6735          | Control Element (1-channel)                       |
+| Busch-Jaeger 6735/01       | Control Element (1-channel, battery-operated)     |
+| Busch-Jaeger 6736          | Control Element (2-channel)                       |
+| GE Bulbs                   |                                                   |
+| Hue Bulbs                  | Color LED Bulb                                    |
+| Hue Motion Sensor          | Motion and Luminance sensor                       |
+| Innr Bulbs                 |                                                   |
+| Osram Bulbs                |                                                   |
+| SmartThings Plug           | Metered Plug                                      |
+| SmartThings Motion Sensor  | CentraLite 3325-S Motion and Temperature sensor   |
+| SmartThings Contact Sensor | Contact and Temperature sensor                    |
+| Tradfri Bulbs              |                                                   |
+| Tradfri Motion Sensor      |                                                   |
 
 
 

--- a/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -42,32 +42,34 @@ public class ZigBeeBindingConstants {
     public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES = Sets.newHashSet(THING_TYPE_GENERIC_DEVICE);
 
     // List of Channel UIDs
-    public static final String CHANNEL_SWITCH_ONOFF = "switch_onoff";
-    public static final String CHANNEL_SWITCH_LEVEL = "switch_level";
+    public static final String CHANNEL_SWITCH_ONOFF = "zigbee:switch_onoff";
+    public static final String CHANNEL_SWITCH_LEVEL = "zigbee:switch_level";
 
-    public static final String CHANNEL_COLOR_COLOR = "color_color";
-    public static final String CHANNEL_COLOR_TEMPERATURE = "color_temperature";
+    public static final String CHANNEL_COLOR_COLOR = "zigbee:color_color";
+    public static final String CHANNEL_COLOR_TEMPERATURE = "zigbee:color_temperature";
 
-    public static final String CHANNEL_ILLUMINANCE_VALUE = "measurement_illuminance";
-    public static final String CHANNEL_TEMPERATURE_VALUE = "measurement_temperature";
-    public static final String CHANNEL_HUMIDITY_VALUE = "measurement_relativehumidity";
+    public static final String CHANNEL_ILLUMINANCE_VALUE = "zigbee:measurement_illuminance";
+    public static final String CHANNEL_TEMPERATURE_VALUE = "zigbee:measurement_temperature";
+    public static final String CHANNEL_HUMIDITY_VALUE = "zigbee:measurement_relativehumidity";
 
-    public static final String CHANNEL_OCCUPANCY_SENSOR = "sensor_occupancy";
+    public static final String CHANNEL_OCCUPANCY_SENSOR = "zigbee:sensor_occupancy";
 
-    public static final String CHANNEL_IAS_CONTACT_PORTAL1 = "ias_contactportal1";
-    public static final String CHANNEL_IAS_CONTACT_PORTAL2 = "ias_contactportal2";
-    public static final String CHANNEL_IAS_MOTION_INTRUSION = "ias_motionintrusion";
-    public static final String CHANNEL_IAS_MOTION_PRESENCE = "ias_motionpresence";
+    public static final String CHANNEL_IAS_CONTACT_PORTAL1 = "zigbee:ias_contactportal1";
+    public static final String CHANNEL_IAS_CONTACT_PORTAL2 = "zigbee:ias_contactportal2";
+    public static final String CHANNEL_IAS_MOTION_INTRUSION = "zigbee:ias_motionintrusion";
+    public static final String CHANNEL_IAS_MOTION_PRESENCE = "zigbee:ias_motionpresence";
+    public static final String CHANNEL_IAS_STANDARDCIE_SYSTEM = "zigbee:ias_standard_system";
 
-    public static final String CHANNEL_ELECTRICAL_ACTIVEPOWER = "electrical_activepower";
+    public static final String CHANNEL_ELECTRICAL_ACTIVEPOWER = "zigbee:electrical_activepower";
 
-    public static final String CHANNEL_POWER_BATTERYPERCENT = "power_batterypercent";
+    public static final String CHANNEL_POWER_BATTERYPERCENT = "system:battery-level";
 
     public static final String CHANNEL_PROPERTY_ENDPOINT = "zigbee_endpoint";
 
     public static final String ITEM_TYPE_COLOR = "Color";
-    public static final String ITEM_TYPE_NUMBER = "Number";
+    public static final String ITEM_TYPE_CONTACT = "Contact";
     public static final String ITEM_TYPE_DIMMER = "Dimmer";
+    public static final String ITEM_TYPE_NUMBER = "Number";
     public static final String ITEM_TYPE_SWITCH = "Switch";
 
     public static final String THING_PROPERTY_STKVERSION = "zigbee_stkversion";

--- a/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
+++ b/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
@@ -103,6 +103,11 @@ public abstract class ZigBeeBaseChannelConverter {
     protected List<ConfigDescriptionParameter> configOptions = null;
 
     /**
+     * The channel
+     */
+    protected Channel channel = null;
+
+    /**
      * The {@link ChannelUID} for this converter
      */
     protected ChannelUID channelUID = null;
@@ -132,20 +137,21 @@ public abstract class ZigBeeBaseChannelConverter {
      * Creates the converter handler
      *
      * @param thing the {@link ZigBeeThingHandler} the channel is part of
-     * @param channelUID the {@link channelUID} for the channel
+     * @param channel the {@link Channel} for the channel
      * @param coordinator the {@link ZigBeeCoordinatorHandler} this endpoint is part of
      * @param address the {@link IeeeAddress} of the node
      * @param endpointId the endpoint this channel is linked to
      * @return true if the handler was created successfully - false otherwise
      */
-    public void initialize(ZigBeeThingHandler thing, ChannelUID channelUID, ZigBeeCoordinatorHandler coordinator,
+    public void initialize(ZigBeeThingHandler thing, Channel channel, ZigBeeCoordinatorHandler coordinator,
             IeeeAddress address, int endpointId) {
         this.endpoint = coordinator.getEndpoint(address, endpointId);
         if (this.endpoint == null) {
             throw new IllegalArgumentException("Device was not found");
         }
         this.thing = thing;
-        this.channelUID = channelUID;
+        this.channel = channel;
+        this.channelUID = channel.getUID();
         this.coordinator = coordinator;
     }
 
@@ -266,7 +272,13 @@ public abstract class ZigBeeBaseChannelConverter {
             String label) {
         Map<String, String> properties = new HashMap<String, String>();
         properties.put(ZigBeeBindingConstants.CHANNEL_PROPERTY_ENDPOINT, Integer.toString(endpoint.getEndpointId()));
-        ChannelTypeUID channelTypeUID = new ChannelTypeUID(ZigBeeBindingConstants.BINDING_ID, channelType);
+        ChannelTypeUID channelTypeUID;
+        // if (channelType.contains(":")) {
+        channelTypeUID = new ChannelTypeUID(channelType);
+        channelType = channelType.substring(channelType.indexOf(":") + 1, channelType.length());
+        // } else {
+        // channelTypeUID = new ChannelTypeUID(ZigBeeBindingConstants.BINDING_ID, channelType);
+        // }
 
         return ChannelBuilder
                 .create(new ChannelUID(thingUID,

--- a/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeChannelConverterFactory.java
+++ b/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeChannelConverterFactory.java
@@ -15,7 +15,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.smarthome.core.thing.Channel;
-import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
@@ -101,11 +100,11 @@ public class ZigBeeChannelConverterFactory {
 
                 Channel channel = converter.getChannel(thingUID, endpoint);
                 if (channel != null) {
-                    channels.put(channel.getChannelTypeUID().getId().toString(), channel);
+                    channels.put(channel.getChannelTypeUID().toString(), channel);
                 }
             } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
                     | InvocationTargetException | NoSuchMethodException | SecurityException e) {
-                logger.debug("Exception while getting channels: ", e);
+                logger.debug("{}: Exception while getting channels: ", endpoint.getIeeeAddress(), e);
             }
         }
 
@@ -126,29 +125,28 @@ public class ZigBeeChannelConverterFactory {
      * Creates a channel converter for the requested {@link ChannelTypeUID}
      *
      * @param thingHandler the {@link ZigBeeThingHandler} for this channel
-     * @param channelTypeUid the {@link ChannelTypeUID} to create the converter for
-     * @param channelUid the {@link ChannelUID} to create the converter for
+     * @param channel the {@link Channel} to create the converter for
      * @param coordinatorHandler the {@link ZigBeeCoordinatorHandler}
      * @param ieeeAddress the {@link IeeeAddress} of the device
      * @param endpointId the endpoint ID for this channel on the device
      * @return the {@link ZigBeeBaseChannelConverter} or null if the channel is not supported
      */
-    public ZigBeeBaseChannelConverter createConverter(ZigBeeThingHandler thingHandler, ChannelTypeUID channelTypeUid,
-            ChannelUID channelUid, ZigBeeCoordinatorHandler coordinatorHandler, IeeeAddress ieeeAddress,
-            int endpointId) {
+    public ZigBeeBaseChannelConverter createConverter(ZigBeeThingHandler thingHandler, Channel channel,
+            ZigBeeCoordinatorHandler coordinatorHandler, IeeeAddress ieeeAddress, int endpointId) {
         Constructor<? extends ZigBeeBaseChannelConverter> constructor;
         try {
-            if (channelMap.get(channelTypeUid.getId()) == null) {
-                logger.debug("Channel converter for channel type {} is not implemented!", channelUid.getId());
+            if (channelMap.get(channel.getChannelTypeUID().toString()) == null) {
+                logger.debug("{}: Channel converter for channel type {} is not implemented!", ieeeAddress,
+                        channel.getUID().getId());
                 return null;
             }
-            constructor = channelMap.get(channelTypeUid.getId()).getConstructor();
+            constructor = channelMap.get(channel.getChannelTypeUID().toString()).getConstructor();
             ZigBeeBaseChannelConverter instance = constructor.newInstance();
 
-            instance.initialize(thingHandler, channelUid, coordinatorHandler, ieeeAddress, endpointId);
+            instance.initialize(thingHandler, channel, coordinatorHandler, ieeeAddress, endpointId);
             return instance;
         } catch (Exception e) {
-            logger.error("{}: Unable to create channel ", channelUid, e);
+            logger.error("{}: Unable to create channel {}", ieeeAddress, channel.getUID(), e);
         }
 
         return null;

--- a/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeConverterBatteryPercent.java
+++ b/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeConverterBatteryPercent.java
@@ -57,7 +57,10 @@ public class ZigBeeConverterBatteryPercent extends ZigBeeBaseChannelConverter im
         // Add a listener, then request the status
         cluster.addAttributeListener(this);
 
-        cluster.getBatteryPercentageRemaining(0);
+        Integer value = cluster.getBatteryPercentageRemaining(0);
+        if (value != null) {
+            updateChannelState(new PercentType(value));
+        }
 
         return true;
     }
@@ -86,6 +89,7 @@ public class ZigBeeConverterBatteryPercent extends ZigBeeBaseChannelConverter im
             if (!powerCluster.discoverAttributes(false).get()) {
                 logger.warn("{}: Failed discovering attributes in power configuration cluster",
                         endpoint.getIeeeAddress());
+                return null;
             } else if (!powerCluster
                     .isAttributeSupported(ZclPowerConfigurationCluster.ATTR_BATTERYPERCENTAGEREMAINING)) {
                 return null;
@@ -96,7 +100,7 @@ public class ZigBeeConverterBatteryPercent extends ZigBeeBaseChannelConverter im
         }
 
         return createChannel(thingUID, endpoint, ZigBeeBindingConstants.CHANNEL_POWER_BATTERYPERCENT,
-                ZigBeeBindingConstants.CHANNEL_POWER_BATTERYPERCENT, "Battery Percent");
+                ZigBeeBindingConstants.ITEM_TYPE_NUMBER, "Battery Percent");
     }
 
     @Override

--- a/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeConverterIas.java
+++ b/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeConverterIas.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zigbee.converter;
+
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.OpenClosedType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.zcl.ZclAttribute;
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+import com.zsmartsystems.zigbee.zcl.ZclCommandListener;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclIasZoneCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneStatusChangeNotificationCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
+
+/**
+ * Converter for the IAS zone sensors. This is an abstract class used as a base for different IAS sensors.
+ *
+ * @author Chris Jackson - Initial Contribution
+ *
+ */
+public abstract class ZigBeeConverterIas extends ZigBeeBaseChannelConverter implements ZclCommandListener {
+    private Logger logger = LoggerFactory.getLogger(ZigBeeConverterIas.class);
+
+    private ZclIasZoneCluster clusterIasZone;
+
+    protected int bitTest = 0;
+
+    protected static final int CIE_ALARM1 = 0x0001;
+    protected static final int CIE_ALARM2 = 0x0002;
+    protected static final int CIE_TAMPER = 0x0004;
+    protected static final int CIE_BATTERY = 0x0008;
+    protected static final int CIE_SUPERVISION = 0x0010;
+    protected static final int CIE_RESTORE = 0x0020;
+    protected static final int CIE_TROUBLE = 0x0040;
+    protected static final int CIE_ACMAINS = 0x0080;
+    protected static final int CIE_TEST = 0x0100;
+    protected static final int CIE_BATTERYDEFECT = 0x0200;
+
+    @Override
+    public boolean initializeConverter() {
+        logger.debug("{}: Initialising device IAS Zone cluster", endpoint.getIeeeAddress());
+
+        clusterIasZone = (ZclIasZoneCluster) endpoint.getInputCluster(ZclIasZoneCluster.CLUSTER_ID);
+        if (clusterIasZone == null) {
+            logger.error("{}: Error opening IAS zone cluster", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        clusterIasZone.bind();
+
+        // Add a listener, then request the status
+        clusterIasZone.addCommandListener(this);
+        clusterIasZone.getZoneStatus(0);
+
+        // Configure reporting - no faster than once per second - no slower than 10 minutes.
+        ZclAttribute attribute = clusterIasZone.getAttribute(ZclIasZoneCluster.ATTR_ZONESTATUS);
+        clusterIasZone.setReporting(attribute, 3, 600);
+        return true;
+    }
+
+    @Override
+    public void disposeConverter() {
+        logger.debug("{}: Closing device IAS zone cluster", endpoint.getIeeeAddress());
+
+        clusterIasZone.removeCommandListener(this);
+    }
+
+    @Override
+    public void handleRefresh() {
+        clusterIasZone.getZoneStatus(0);
+    }
+
+    protected boolean supportsIasChannel(ZigBeeEndpoint endpoint, ZoneTypeEnum requiredZoneType) {
+        if (endpoint.getInputCluster(ZclIasZoneCluster.CLUSTER_ID) == null) {
+            return false;
+        }
+
+        ZclIasZoneCluster cluster = (ZclIasZoneCluster) endpoint.getInputCluster(ZclIasZoneCluster.CLUSTER_ID);
+        if (cluster == null) {
+            logger.error("{}: Error opening IAS zone cluster", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        Integer zoneTypeId = null;
+        for (int retry = 0; retry < 3; retry++) {
+            zoneTypeId = cluster.getZoneType(Integer.MAX_VALUE);
+            if (zoneTypeId != null) {
+                break;
+            }
+        }
+        if (zoneTypeId == null) {
+            logger.debug("{}: Did not get IAS zone type", endpoint.getIeeeAddress());
+            return false;
+        }
+        ZoneTypeEnum zoneType = ZoneTypeEnum.getByValue(zoneTypeId);
+        logger.debug("{}: IAS zone type {}", endpoint.getIeeeAddress(), zoneType);
+        return zoneType == requiredZoneType;
+    }
+
+    @Override
+    public void commandReceived(ZclCommand command) {
+        if (command instanceof ZoneStatusChangeNotificationCommand) {
+            ZoneStatusChangeNotificationCommand zoneStatus = (ZoneStatusChangeNotificationCommand) command;
+            switch (channel.getAcceptedItemType()) {
+                case "Switch":
+                    updateChannelState(((zoneStatus.getZoneStatus() & bitTest) != 0) ? OnOffType.ON : OnOffType.OFF);
+                    break;
+                case "Contact":
+                    updateChannelState(((zoneStatus.getZoneStatus() & bitTest) != 0) ? OpenClosedType.OPEN
+                            : OpenClosedType.CLOSED);
+                    break;
+                default:
+                    logger.warn("{}: Unsupported item type {}", endpoint.getIeeeAddress(),
+                            channel.getAcceptedItemType());
+                    break;
+            }
+        }
+    }
+}

--- a/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeConverterIasCieSystem.java
+++ b/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeConverterIasCieSystem.java
@@ -16,25 +16,24 @@ import com.zsmartsystems.zigbee.zcl.ZclCommandListener;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
 
 /**
- * Converter for the IAS motion sensor.
+ * Converter for the IAS Standard CIE System sensor.
  *
  * @author Chris Jackson - Initial Contribution
  *
  */
-public class ZigBeeConverterIasMotionIntrusion extends ZigBeeConverterIas implements ZclCommandListener {
+public class ZigBeeConverterIasCieSystem extends ZigBeeConverterIas implements ZclCommandListener {
     @Override
     public boolean initializeConverter() {
-        bitTest = CIE_ALARM1;
         return super.initializeConverter();
     }
 
     @Override
     public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
-        if (!supportsIasChannel(endpoint, ZoneTypeEnum.MOTION_SENSOR)) {
+        if (!supportsIasChannel(endpoint, ZoneTypeEnum.STANDARD_CIE)) {
             return null;
         }
 
-        return createChannel(thingUID, endpoint, ZigBeeBindingConstants.CHANNEL_IAS_MOTION_INTRUSION,
-                ZigBeeBindingConstants.ITEM_TYPE_SWITCH, "Motion Intrusion");
+        return createChannel(thingUID, endpoint, ZigBeeBindingConstants.CHANNEL_IAS_STANDARDCIE_SYSTEM,
+                ZigBeeBindingConstants.ITEM_TYPE_SWITCH, "CIE Standard System Alarm");
     }
 }

--- a/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeConverterIasContactPortal1.java
+++ b/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeConverterIasContactPortal1.java
@@ -7,94 +7,34 @@
  */
 package org.openhab.binding.zigbee.converter;
 
-import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
-import com.zsmartsystems.zigbee.zcl.ZclAttribute;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclCommandListener;
-import com.zsmartsystems.zigbee.zcl.clusters.ZclIasZoneCluster;
-import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneStatusChangeNotificationCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
 
 /**
- * Converter for the IAS motion sensor.
+ * Converter for the IAS contact sensor.
  *
  * @author Chris Jackson - Initial Contribution
  *
  */
-public class ZigBeeConverterIasContactPortal1 extends ZigBeeBaseChannelConverter implements ZclCommandListener {
-    private Logger logger = LoggerFactory.getLogger(ZigBeeConverterIasContactPortal1.class);
-
-    private ZclIasZoneCluster clusterIasZone;
-
+public class ZigBeeConverterIasContactPortal1 extends ZigBeeConverterIas implements ZclCommandListener {
     @Override
     public boolean initializeConverter() {
-        logger.debug("{}: Initialising device IAS Zone cluster", endpoint.getIeeeAddress());
-
-        clusterIasZone = (ZclIasZoneCluster) endpoint.getInputCluster(ZclIasZoneCluster.CLUSTER_ID);
-        if (clusterIasZone == null) {
-            logger.error("{}: Error opening ias zone cluster", endpoint.getIeeeAddress());
-            return false;
-        }
-
-        clusterIasZone.bind();
-
-        // Add a listener, then request the status
-        clusterIasZone.addCommandListener(this);
-        clusterIasZone.getZoneStatus(0);
-
-        // Configure reporting - no faster than once per second - no slower than 10 minutes.
-        ZclAttribute attribute = clusterIasZone.getAttribute(ZclIasZoneCluster.ATTR_ZONESTATUS);
-        clusterIasZone.setReporting(attribute, 3, 600);
-        return true;
-    }
-
-    @Override
-    public void disposeConverter() {
-        logger.debug("{}: Closing device IAS cluster [contact]", endpoint.getIeeeAddress());
-
-        clusterIasZone.removeCommandListener(this);
-    }
-
-    @Override
-    public void handleRefresh() {
-        clusterIasZone.getZoneStatus(0);
+        bitTest = CIE_ALARM1;
+        return super.initializeConverter();
     }
 
     @Override
     public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
-        if (endpoint.getInputCluster(ZclIasZoneCluster.CLUSTER_ID) == null) {
-            return null;
-        }
-
-        ZclIasZoneCluster cluster = (ZclIasZoneCluster) endpoint.getInputCluster(ZclIasZoneCluster.CLUSTER_ID);
-        if (cluster == null) {
-            logger.error("{}: Error opening ias zone cluster", endpoint.getIeeeAddress());
-            return null;
-        }
-
-        Integer zoneTypeId = cluster.getZoneType(Integer.MAX_VALUE);
-        ZoneTypeEnum zoneType = ZoneTypeEnum.getByValue(zoneTypeId);
-        if (zoneType != ZoneTypeEnum.CONTACT_SWITCH) {
+        if (!supportsIasChannel(endpoint, ZoneTypeEnum.CONTACT_SWITCH)) {
             return null;
         }
 
         return createChannel(thingUID, endpoint, ZigBeeBindingConstants.CHANNEL_IAS_CONTACT_PORTAL1,
-                ZigBeeBindingConstants.ITEM_TYPE_SWITCH, "Contact Portal 1");
-    }
-
-    @Override
-    public void commandReceived(ZclCommand command) {
-        if (command instanceof ZoneStatusChangeNotificationCommand) {
-            ZoneStatusChangeNotificationCommand zoneStatus = (ZoneStatusChangeNotificationCommand) command;
-            OnOffType state = ((zoneStatus.getZoneStatus() & 0x01) != 0) ? OnOffType.ON : OnOffType.OFF;
-            updateChannelState(state);
-        }
+                ZigBeeBindingConstants.ITEM_TYPE_CONTACT, "Contact Portal 1");
     }
 }

--- a/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeConverterIasMotionPresence.java
+++ b/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeConverterIasMotionPresence.java
@@ -7,96 +7,34 @@
  */
 package org.openhab.binding.zigbee.converter;
 
-import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
-import com.zsmartsystems.zigbee.zcl.ZclAttribute;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclCommandListener;
-import com.zsmartsystems.zigbee.zcl.clusters.ZclIasZoneCluster;
-import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneStatusChangeNotificationCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
 
 /**
- * Converter for the IAS motion sensor.
+ * Converter for the IAS presence sensor.
  *
  * @author Chris Jackson - Initial Contribution
  *
  */
-public class ZigBeeConverterIasMotionPresence extends ZigBeeBaseChannelConverter implements ZclCommandListener {
-    private Logger logger = LoggerFactory.getLogger(ZigBeeConverterIasMotionPresence.class);
-
-    private ZclIasZoneCluster clusterIasZone;
-
-    private boolean initialised = false;
-
+public class ZigBeeConverterIasMotionPresence extends ZigBeeConverterIas implements ZclCommandListener {
     @Override
     public boolean initializeConverter() {
-        logger.debug("{}: Initialising device IAS Zone cluster", endpoint.getIeeeAddress());
-
-        clusterIasZone = (ZclIasZoneCluster) endpoint.getInputCluster(ZclIasZoneCluster.CLUSTER_ID);
-        if (clusterIasZone == null) {
-            logger.error("{}: Error opening ias zone cluster", endpoint.getIeeeAddress());
-            return false;
-        }
-
-        clusterIasZone.bind();
-
-        // Add a listener, then request the status
-        clusterIasZone.addCommandListener(this);
-        clusterIasZone.getZoneStatus(0);
-
-        // Configure reporting - no faster than once per second - no slower than 10 minutes.
-        ZclAttribute attribute = clusterIasZone.getAttribute(ZclIasZoneCluster.ATTR_ZONESTATUS);
-        clusterIasZone.setReporting(attribute, 3, 600);
-        return true;
-    }
-
-    @Override
-    public void disposeConverter() {
-        logger.debug("{}: Closing device IAS cluster [motion presence]", endpoint.getIeeeAddress());
-
-        clusterIasZone.removeCommandListener(this);
-    }
-
-    @Override
-    public void handleRefresh() {
-        clusterIasZone.getZoneStatus(0);
+        bitTest = CIE_ALARM2;
+        return super.initializeConverter();
     }
 
     @Override
     public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
-        if (endpoint.getInputCluster(ZclIasZoneCluster.CLUSTER_ID) == null) {
-            return null;
-        }
-
-        ZclIasZoneCluster cluster = (ZclIasZoneCluster) endpoint.getInputCluster(ZclIasZoneCluster.CLUSTER_ID);
-        if (cluster == null) {
-            logger.error("{}: Error opening ias zone cluster", endpoint.getIeeeAddress());
-            return null;
-        }
-
-        Integer zoneTypeId = cluster.getZoneType(Integer.MAX_VALUE);
-        ZoneTypeEnum zoneType = ZoneTypeEnum.getByValue(zoneTypeId);
-        if (zoneType != ZoneTypeEnum.MOTION_SENSOR) {
+        if (!supportsIasChannel(endpoint, ZoneTypeEnum.MOTION_SENSOR)) {
             return null;
         }
 
         return createChannel(thingUID, endpoint, ZigBeeBindingConstants.CHANNEL_IAS_MOTION_PRESENCE,
                 ZigBeeBindingConstants.ITEM_TYPE_SWITCH, "Motion Presence");
-    }
-
-    @Override
-    public void commandReceived(ZclCommand command) {
-        if (command instanceof ZoneStatusChangeNotificationCommand) {
-            ZoneStatusChangeNotificationCommand zoneStatus = (ZoneStatusChangeNotificationCommand) command;
-            OnOffType state = ((zoneStatus.getZoneStatus() & 0x02) != 0) ? OnOffType.ON : OnOffType.OFF;
-            updateChannelState(state);
-        }
     }
 }


### PR DESCRIPTION
Refactor IAS converters to provide a base class such that specific converters can be simply extended.

This also refactors the converters slightly to pass the Channel into the converter so more information is available. This is in support of the static type definitions (#101).

Signed-off-by: Chris Jackson <chris@cd-jackson.com>