### PR TITLE
Don't refresh value in initializeConverter method - only in handleRefesh

### DIFF
--- a/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -348,9 +348,10 @@ public class ZigBeeThingHandler extends BaseThingHandler
                 pollingPeriod = POLLING_PERIOD_MAX;
             }
 
-            pollingJob = scheduler.scheduleAtFixedRate(pollingRunnable,
-                    pollingPeriod * 1000 + (int) (Math.random() * 3000),
-                    pollingPeriod * 1000 + (int) (Math.random() * 1000), TimeUnit.MILLISECONDS);
+            // Polling starts almost immediately to get an immediate refresh
+            // Add some random element to the period so that all things aren't synchronised
+            pollingJob = scheduler.scheduleAtFixedRate(pollingRunnable, (int) (Math.random() * 3000),
+                    pollingPeriod * 1000 + (int) (Math.random() * 3000), TimeUnit.MILLISECONDS);
             logger.debug("{}: Polling initialised at {} seconds", nodeIeeeAddress, pollingPeriod);
         }
     }

--- a/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
+++ b/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
@@ -57,11 +57,6 @@ public class ZigBeeConverterBatteryPercent extends ZigBeeBaseChannelConverter im
         // Add a listener, then request the status
         cluster.addAttributeListener(this);
 
-        Integer value = cluster.getBatteryPercentageRemaining(0);
-        if (value != null) {
-            updateChannelState(new DecimalType(value));
-        }
-
         return true;
     }
 

--- a/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
+++ b/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
@@ -125,8 +125,6 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                 pollingPeriod = POLLING_PERIOD_HIGH;
             }
             if (supportsHue) {
-                clusterColorControl.getCurrentHue(0);
-                clusterColorControl.getCurrentSaturation(0);
                 CommandResult reportResponse = clusterColorControl.setCurrentHueReporting(1, 600, 1).get();
                 if (!reportResponse.isSuccess()) {
                     pollingPeriod = POLLING_PERIOD_HIGH;
@@ -136,8 +134,6 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                     pollingPeriod = POLLING_PERIOD_HIGH;
                 }
             } else {
-                clusterColorControl.getCurrentX(0);
-                clusterColorControl.getCurrentY(0);
                 clusterColorControl.setCurrentXReporting(1, 600, 1).get();
                 clusterColorControl.setCurrentYReporting(1, 600, 1).get();
             }
@@ -169,7 +165,6 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                 if (!bindResponse.isSuccess()) {
                     pollingPeriod = POLLING_PERIOD_HIGH;
                 }
-                clusterOnOff.getOnOff(0);
                 CommandResult reportResponse = clusterOnOff.setOnOffReporting(1, 600).get();
                 if (!reportResponse.isSuccess()) {
                     pollingPeriod = POLLING_PERIOD_HIGH;

--- a/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
+++ b/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
@@ -70,7 +70,6 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
         clusterColorControl.bind();
 
         clusterColorControl.addAttributeListener(this);
-        clusterColorControl.getColorTemperature(0);
 
         // Configure reporting - no faster than once per second - no slower than 10 minutes.
         clusterColorControl.setColorTemperatureReporting(1, 600, 1);

--- a/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
+++ b/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
@@ -58,7 +58,6 @@ public abstract class ZigBeeConverterIas extends ZigBeeBaseChannelConverter impl
 
         // Add a listener, then request the status
         clusterIasZone.addCommandListener(this);
-        clusterIasZone.getZoneStatus(0);
 
         // Configure reporting - no faster than once per second - no slower than 10 minutes.
         ZclAttribute attribute = clusterIasZone.getAttribute(ZclIasZoneCluster.ATTR_ZONESTATUS);

--- a/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
+++ b/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
@@ -46,7 +46,6 @@ public class ZigBeeConverterIlluminance extends ZigBeeBaseChannelConverter imple
 
         // Add a listener, then request the status
         cluster.addAttributeListener(this);
-        cluster.getMeasuredValue(60);
 
         // Configure reporting - no faster than once per second - no slower than 10 minutes.
         cluster.setMeasuredValueReporting(1, 600, 1);

--- a/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
+++ b/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
@@ -74,7 +74,6 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
 
         // Add a listener, then request the status
         clusterMeasurement.addAttributeListener(this);
-        clusterMeasurement.getActivePower(0);
 
         return true;
     }

--- a/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
+++ b/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
@@ -45,7 +45,6 @@ public class ZigBeeConverterOccupancy extends ZigBeeBaseChannelConverter impleme
 
         // Add a listener, then request the status
         clusterOccupancy.addAttributeListener(this);
-        clusterOccupancy.getOccupancy(0);
 
         // Configure reporting - no faster than once per second - no slower than 10 minutes.
         clusterOccupancy.setOccupancyReporting(1, 600);

--- a/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -64,7 +64,6 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
 
         // Add a listener, then request the status
         clusterLevelControl.addAttributeListener(this);
-        clusterLevelControl.getCurrentLevel(0);
 
         // Create a configuration handler and get the available options
         configLevelControl = new ZclLevelControlConfig(clusterLevelControl);

--- a/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -73,7 +73,6 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
 
             // Add a listener, then request the status
             clusterOnOffServer.addAttributeListener(this);
-            clusterOnOffServer.getOnOff(0);
         }
 
         if (clusterOnOffClient != null) {

--- a/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
+++ b/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
@@ -46,7 +46,6 @@ public class ZigBeeConverterTemperature extends ZigBeeBaseChannelConverter imple
 
         // Add a listener, then request the status
         cluster.addAttributeListener(this);
-        cluster.getMeasuredValue(60);
 
         // Configure reporting - no faster than once per second - no slower than 10 minutes.
         cluster.setMeasuredValueReporting(1, 600, 0.1);


### PR DESCRIPTION
Converters should not read the value during initialisation. Instead, all updates are handled in the ```handleRefresh()``` method. This avoids duplication, reduces startup congestion, and only updates channels that are linked to items.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>