### PR TITLE
Fix initialisation error in CIE System Alarm

### DIFF
--- a/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
+++ b/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
@@ -31,8 +31,11 @@ public abstract class ZigBeeConverterIas extends ZigBeeBaseChannelConverter impl
 
     private ZclIasZoneCluster clusterIasZone;
 
-    protected int bitTest = 0;
+    protected int bitTest = CIE_ALARM1;
 
+    /**
+     * CIE Zone Status Attribute flags
+     */
     protected static final int CIE_ALARM1 = 0x0001;
     protected static final int CIE_ALARM2 = 0x0002;
     protected static final int CIE_TAMPER = 0x0004;

--- a/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasCieSystem.java
+++ b/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasCieSystem.java
@@ -24,6 +24,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
 public class ZigBeeConverterIasCieSystem extends ZigBeeConverterIas implements ZclCommandListener {
     @Override
     public boolean initializeConverter() {
+        bitTest = CIE_ALARM1;
         return super.initializeConverter();
     }
 


### PR DESCRIPTION
Initialises the Zone Status bit required to detect the system alarm.
#110 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>