### PR TITLE
Make sure `networkStateFilePath` exists while serializing

### DIFF
--- a/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeNetworkStateSerializerImpl.java
+++ b/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeNetworkStateSerializerImpl.java
@@ -108,6 +108,7 @@ public class ZigBeeNetworkStateSerializerImpl implements ZigBeeNetworkStateSeria
         }
 
         final File file = new File(networkStateFilePath + "/" + networkStateFileName + networkId + ".xml");
+        file.getParentFile().mkdirs();
         try {
             BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"));
             stream.marshal(destinations, new PrettyPrintWriter(writer));


### PR DESCRIPTION
Hi,
In our project, the `networkStateFilePath` does not exist per default. Therefore we added a `file.getParentFile().mkdirs();` to the `serialize` method in ZigBeeNetworkStateSerializerImpl. Maybe this also helps someone else in other edge cases.

Cheers,
Julian