### PR TITLE
Fix Spotbugs errors in ZigBeeBindingConstants

### DIFF
--- a/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -12,6 +12,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
+import  java.util.Collections;
 import java.util.TimeZone;
 
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
@@ -39,7 +40,7 @@ public class ZigBeeBindingConstants {
     // List of Thing Type UIDs
     public final static ThingTypeUID THING_TYPE_GENERIC_DEVICE = new ThingTypeUID(BINDING_ID, "device");
 
-    public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES = Sets.newHashSet(THING_TYPE_GENERIC_DEVICE);
+    public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.unmodifiableSet(Sets.newHashSet(THING_TYPE_GENERIC_DEVICE));
 
     // List of Channel UIDs
     public static final String CHANNEL_SWITCH_ONOFF = "zigbee:switch_onoff";
@@ -150,16 +151,16 @@ public class ZigBeeBindingConstants {
         StringBuilder jsonBuilder = new StringBuilder();
         jsonBuilder.append("{");
         boolean first = true;
-        for (String key : object.keySet()) {
+        for (Map.Entry<String, Object> entry : object.entrySet()) {
             if (!first) {
                 jsonBuilder.append(",");
             }
             first = false;
 
             jsonBuilder.append("\"");
-            jsonBuilder.append(key);
+            jsonBuilder.append(entry.getKey());
             jsonBuilder.append("\":\"");
-            jsonBuilder.append(object.get(key));
+            jsonBuilder.append(entry.getValue());
             jsonBuilder.append("\"");
         }
         jsonBuilder.append("}");


### PR DESCRIPTION
Hi Chris,
In our project, we run [SpotBugs](https://github.com/spotbugs/spotbugs).
This PR fixes two SpotBugs warnings in ZigBeeBindingConstants:

```
MS: Field is a mutable collection (MS_MUTABLE_COLLECTION)
A mutable collection instance is assigned to a final static field, thus can be changed by malicious code or by accident from another package. Consider wrapping this field into Collections.unmodifiableSet/List/Map/etc. to avoid this vulnerability.
```
 
```
WMI: Inefficient use of keySet iterator instead of entrySet iterator (WMI_WRONG_MAP_ITERATOR)
This method accesses the value of a Map entry, using a key that was retrieved from a keySet iterator. It is more efficient to use an iterator on the entrySet of the map, to avoid the Map.get(key) lookup.
```

Cheers
Julian

Signed-off-by: Julian Dax <julian.dax@itemis.com>