### PR TITLE
Fix SpotBugs errors in ZigBeeChannelConverterFactory

### DIFF
--- a/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactory.java
+++ b/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactory.java
@@ -111,12 +111,12 @@ public class ZigBeeChannelConverterFactory {
 
         // Perform a channel consolidation at endpoint level to remove unnecessary channels.
         // This removes channels that are covered through inheritance.
-        for (String consolidationChannel : channelConsolidation.keySet()) {
-            if (channels.containsKey(consolidationChannel)
-                    && channels.containsKey(channelConsolidation.get(consolidationChannel))) {
+        for (Map.Entry<String,String> consolidationChannel : channelConsolidation.entrySet()) {
+            if (channels.containsKey(consolidationChannel.getKey())
+                    && channels.containsKey(consolidationChannel.getValue())) {
                 logger.debug("{}: Removing channel {} in favor of {}", endpoint.getIeeeAddress(),
-                        channelConsolidation.get(consolidationChannel), consolidationChannel);
-                channels.remove(channelConsolidation.get(consolidationChannel));
+                        consolidationChannel.getValue(), consolidationChannel.getKey());
+                channels.remove(consolidationChannel.getValue());
             }
         }
         return channels.values();


### PR DESCRIPTION
Hi Chris,
this is a fix for the following [SpotBugs](https://github.com/spotbugs/spotbugs) error:

```
WMI: Inefficient use of keySet iterator instead of entrySet iterator (WMI_WRONG_MAP_ITERATOR)
This method accesses the value of a Map entry, using a key that was retrieved from a keySet iterator. It is more efficient to use an iterator on the entrySet of the map, to avoid the Map.get(key) lookup.
```

Cheers
Julian

Signed-off-by: Julian Dax <julian.dax@itemis.com>