### PR TITLE
Fix Spotbugs error in ZigBeeThingHandler

### DIFF
--- a/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
@@ -350,8 +351,8 @@ public class ZigBeeThingHandler extends BaseThingHandler
 
             // Polling starts almost immediately to get an immediate refresh
             // Add some random element to the period so that all things aren't synchronised
-            pollingJob = scheduler.scheduleAtFixedRate(pollingRunnable, (int) (Math.random() * 3000),
-                    pollingPeriod * 1000 + (int) (Math.random() * 3000), TimeUnit.MILLISECONDS);
+            pollingJob = scheduler.scheduleAtFixedRate(pollingRunnable, new Random().nextInt(3000) ,
+                    pollingPeriod * 1000 + (int) new Random().nextInt(3000) , TimeUnit.MILLISECONDS);
             logger.debug("{}: Polling initialised at {} seconds", nodeIeeeAddress, pollingPeriod);
         }
     }


### PR DESCRIPTION
Hi Chris,
this is a fix for the following [SpotBugs](https://github.com/spotbugs/spotbugs) error:

```
Dm: Use the nextInt method of Random rather than nextDouble to generate a random integer (DM_NEXTINT_VIA_NEXTDOUBLE)
If r is a java.util.Random, you can generate a random number from 0 to n-1 using r.nextInt(n), rather than using (int)(r.nextDouble() * n).

The argument to nextInt must be positive. If, for example, you want to generate a random value from -99 to 0, use -r.nextInt(100).
```

Cheers
Julian

Signed-off-by: Julian Dax <julian.dax@itemis.com>