### PR TITLE
Fix SpotBugs Errors in ZigBeeConverterColorColor

### DIFF
--- a/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
+++ b/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
@@ -448,28 +448,28 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                     if (attribute.getId() == ZclColorControlCluster.ATTR_CURRENTHUE) {
                         Integer value = (Integer) attribute.getLastValue();
                         float hue = value * 360.0f / 254.0f;
-                        if (hue != lastHue) {
+                        if (Math.abs(hue - lastHue) < .0000001) {
                             lastHue = hue;
                             hueChanged = true;
                         }
                     } else if (attribute.getId() == ZclColorControlCluster.ATTR_CURRENTSATURATION) {
                         Integer value = (Integer) attribute.getLastValue();
                         float saturation = value * 100.0f / 254.0f;
-                        if (saturation != lastSaturation) {
+                        if (Math.abs(saturation - lastSaturation) < .0000001) {
                             lastSaturation = saturation;
                             saturationChanged = true;
                         }
                     } else if (attribute.getId() == ZclColorControlCluster.ATTR_CURRENTX) {
                         Integer value = (Integer) attribute.getLastValue();
                         float x = value / 65536.0f;
-                        if (x != lastX) {
+                        if (Math.abs(x - lastX)  < .0000001) {
                             lastX = x;
                             xChanged = true;
                         }
                     } else if (attribute.getId() == ZclColorControlCluster.ATTR_CURRENTY) {
                         Integer value = (Integer) attribute.getLastValue();
                         float y = value / 65536.0f;
-                        if (y != lastY) {
+                        if (Math.abs(y - lastY) < .0000001) {
                             lastY = y;
                             yChanged = true;
                         }


### PR DESCRIPTION
Hi Chris,
this is another SpotBugs fix, replacing equality comparison with range comparison. 

```
FE: Test for floating point equality (FE_FLOATING_POINT_EQUALITY)
This operation compares two floating point values for equality. Because floating point calculations may involve rounding, calculated float and double values may not be accurate. For values that must be precise, such as monetary values, consider using a fixed-precision type such as BigDecimal. For values that need not be precise, consider comparing for equality within some range, for example: if ( Math.abs(x - y) < .0000001 ). See the Java Language Specification, section 4.2.4.
```

Cheers
Julian


Signed-off-by: Julian Dax <julian.dax@itemis.com>