### PR TITLE
Remove generic type parameter from ServiceRegistration, for compatibility with OSGi version 4.2

### DIFF
--- a/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -92,7 +92,7 @@ public class ZigBeeThingHandler extends BaseThingHandler
 
     private final TranslationProvider translationProvider;
 
-    private ServiceRegistration<FirmwareUpdateHandler> firmwareRegistration;
+    private ServiceRegistration firmwareRegistration;
 
     private final Object pollingSync = new Object();
     private ScheduledFuture<?> pollingJob = null;

--- a/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeHandlerFactory.java
+++ b/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeHandlerFactory.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 public class ZigBeeHandlerFactory extends BaseThingHandlerFactory {
     private final Logger logger = LoggerFactory.getLogger(ZigBeeHandlerFactory.class);
 
-    private Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+    private Map<ThingUID, ServiceRegistration> discoveryServiceRegs = new HashMap<>();
 
     private TranslationProvider translationProvider;
 
@@ -108,7 +108,7 @@ public class ZigBeeHandlerFactory extends BaseThingHandlerFactory {
     @Override
     protected synchronized void removeHandler(ThingHandler thingHandler) {
         if (thingHandler instanceof ZigBeeCoordinatorHandler) {
-            ServiceRegistration<?> serviceReg = this.discoveryServiceRegs.get(thingHandler.getThing().getUID());
+            ServiceRegistration serviceReg = this.discoveryServiceRegs.get(thingHandler.getThing().getUID());
             if (serviceReg != null) {
                 // remove discovery service, if bridge handler is removed
                 ZigBeeDiscoveryService service = (ZigBeeDiscoveryService) bundleContext


### PR DESCRIPTION
This PR removes all three occurrences of the generic type parameter for the `ServiceRegistration` interface, thereby fixing #139 and making the binding compile-time compatible with OSGi version 4.2 (the minimal OSGi version supported by Eclipse SmartHome).

