### PR TITLE
Catch exception when starting coordinator

### DIFF
--- a/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -396,7 +396,11 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
         restartJob = scheduler.schedule(() -> {
             logger.debug("ZigBee network starting");
             restartJob = null;
-            initialiseZigBee();
+            try {
+                initialiseZigBee();
+            } catch (Exception e) {
+                logger.error("Error initialising ZigBee coordinator", e);
+            }
         }, 1, TimeUnit.SECONDS);
     }
 


### PR DESCRIPTION
Ensures any exceptions in the initialisation thread are logged rather than silently lost.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>