### PR TITLE
Add support for serial port flow control in the Ember dongle

### DIFF
--- a/org.openhab.binding.zigbee.ember/ESH-INF/thing/controller_ember.xml
+++ b/org.openhab.binding.zigbee.ember/ESH-INF/thing/controller_ember.xml
@@ -22,6 +22,17 @@
                 <description>Serial Port</description>
             </parameter>
 
+            <parameter name="zigbee_flowcontrol" type="integer" required="true">
+                <label>Flow Control</label>
+                <description>Serial Port Flow Control</description>
+                <default>1</default>
+                <options>
+                    <option value="0">None</option>
+                    <option value="1">Hardware (CTS/RTS)</option>
+                    <option value="2">Software (XOn/XOff)</option>
+                </options>
+            </parameter>
+
             <parameter name="zigbee_baud" type="integer" required="true">
                 <label>Baud Rate</label>
                 <description>Serial Port Baud Rate</description>

--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
@@ -59,8 +59,20 @@ public class EmberHandler extends ZigBeeCoordinatorHandler implements FirmwareUp
 
         EmberConfiguration config = getConfigAs(EmberConfiguration.class);
 
-        ZigBeePort serialPort = new ZigBeeSerialPort(config.zigbee_port, config.zigbee_baud,
-                FlowControl.FLOWCONTROL_OUT_RTSCTS);
+        FlowControl flowControl;
+        switch (config.zigbee_flowcontrol) {
+            case 1: // Hardware
+                flowControl = FlowControl.FLOWCONTROL_OUT_RTSCTS;
+                break;
+            case 2: // Software
+                flowControl = FlowControl.FLOWCONTROL_OUT_XONOFF;
+                break;
+            default:
+                flowControl = FlowControl.FLOWCONTROL_OUT_NONE;
+                break;
+        }
+
+        ZigBeePort serialPort = new ZigBeeSerialPort(config.zigbee_port, config.zigbee_baud, flowControl);
         final ZigBeeTransportTransmit dongle = new ZigBeeDongleEzsp(serialPort);
 
         logger.debug("ZigBee Ember Coordinator opening Port:'{}' PAN:{}, EPAN:{}, Channel:{}", config.zigbee_port,

--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/internal/EmberConfiguration.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/internal/EmberConfiguration.java
@@ -21,4 +21,5 @@ package org.openhab.binding.zigbee.ember.internal;
 public class EmberConfiguration {
     public String zigbee_port;
     public Integer zigbee_baud;
+    public Integer zigbee_flowcontrol;
 }


### PR DESCRIPTION
This PR provides access to the new flow control feature in the ember driver.
Lower speed (57k6) NCP firmware probably should use XON/XOFF (software flow control) while high speed (115k2) should use CTS/RTS (hardware flow control).

Signed-off-by: Chris Jackson <chris@cd-jackson.com>