### PR TITLE
Add CC2531 baud rate option

### DIFF
--- a/org.openhab.binding.zigbee.cc2531/ESH-INF/thing/controller_ti2351.xml
+++ b/org.openhab.binding.zigbee.cc2531/ESH-INF/thing/controller_ti2351.xml
@@ -21,6 +21,17 @@
                 <default></default>
                 <description>Serial Port</description>
             </parameter>
+            
+            <parameter name="zigbee_baud" type="integer" required="true">
+                <label>Baud Rate</label>
+                <description>Serial Port Baud Rate</description>
+                <default>115200</default>
+                <options>
+                    <option value="38400">38400</option>
+                    <option value="57600">57600</option>
+                    <option value="115200">115200</option>
+                </options>
+            </parameter>
 
             <parameter name="zigbee_initialise" type="boolean" groupName="network">
                 <label>Reset Controller</label>


### PR DESCRIPTION
Adds the configuration option for CC2531 serial port baud rate.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>