### PR TITLE
Introduce constants for the configuration values for flow control

### DIFF
--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
@@ -19,6 +19,7 @@ import org.eclipse.smarthome.core.thing.binding.firmware.Firmware;
 import org.eclipse.smarthome.core.thing.binding.firmware.FirmwareUpdateHandler;
 import org.eclipse.smarthome.core.thing.binding.firmware.ProgressCallback;
 import org.eclipse.smarthome.core.thing.binding.firmware.ProgressStep;
+import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.ember.internal.EmberConfiguration;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.openhab.binding.zigbee.handler.ZigBeeSerialPort;
@@ -60,18 +61,14 @@ public class EmberHandler extends ZigBeeCoordinatorHandler implements FirmwareUp
         EmberConfiguration config = getConfigAs(EmberConfiguration.class);
 
         FlowControl flowControl;
-        switch (config.zigbee_flowcontrol) {
-            case 1: // Hardware
-                flowControl = FlowControl.FLOWCONTROL_OUT_RTSCTS;
-                break;
-            case 2: // Software
-                flowControl = FlowControl.FLOWCONTROL_OUT_XONOFF;
-                break;
-            default:
-                flowControl = FlowControl.FLOWCONTROL_OUT_NONE;
-                break;
+        if (ZigBeeBindingConstants.FLOWCONTROL_CONFIG_HARDWARE_CTSRTS.equals(config.zigbee_flowcontrol)) {
+        	flowControl = FlowControl.FLOWCONTROL_OUT_RTSCTS;
+        } else if (ZigBeeBindingConstants.FLOWCONTROL_CONFIG_SOFTWARE_XONXOFF.equals(config.zigbee_flowcontrol)) {
+        	flowControl = FlowControl.FLOWCONTROL_OUT_XONOFF;
+        } else {
+        	flowControl = FlowControl.FLOWCONTROL_OUT_NONE;
         }
-
+        
         ZigBeePort serialPort = new ZigBeeSerialPort(config.zigbee_port, config.zigbee_baud, flowControl);
         final ZigBeeTransportTransmit dongle = new ZigBeeDongleEzsp(serialPort);
 

--- a/org.openhab.binding.zigbee.xbee/src/main/java/org/openhab/binding/zigbee/xbee/handler/XBeeHandler.java
+++ b/org.openhab.binding.zigbee.xbee/src/main/java/org/openhab/binding/zigbee/xbee/handler/XBeeHandler.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.zigbee.xbee.handler;
 
 import org.eclipse.smarthome.core.thing.Bridge;
+import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.openhab.binding.zigbee.handler.ZigBeeSerialPort;
 import org.openhab.binding.zigbee.xbee.internal.XBeeConfiguration;
@@ -51,16 +52,12 @@ public class XBeeHandler extends ZigBeeCoordinatorHandler {
         XBeeConfiguration config = getConfigAs(XBeeConfiguration.class);
 
         FlowControl flowControl;
-        switch (config.zigbee_flowcontrol) {
-            case 1: // Hardware
-                flowControl = FlowControl.FLOWCONTROL_OUT_RTSCTS;
-                break;
-            case 2: // Software
-                flowControl = FlowControl.FLOWCONTROL_OUT_XONOFF;
-                break;
-            default:
-                flowControl = FlowControl.FLOWCONTROL_OUT_NONE;
-                break;
+        if (ZigBeeBindingConstants.FLOWCONTROL_CONFIG_HARDWARE_CTSRTS.equals(config.zigbee_flowcontrol)) {
+        	flowControl = FlowControl.FLOWCONTROL_OUT_RTSCTS;
+        } else if (ZigBeeBindingConstants.FLOWCONTROL_CONFIG_SOFTWARE_XONXOFF.equals(config.zigbee_flowcontrol)) {
+        	flowControl = FlowControl.FLOWCONTROL_OUT_XONOFF;
+        } else {
+        	flowControl = FlowControl.FLOWCONTROL_OUT_NONE;
         }
 
         ZigBeePort serialPort = new ZigBeeSerialPort(config.zigbee_port, config.zigbee_baud, flowControl);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -105,6 +105,11 @@ public class ZigBeeBindingConstants {
     public final static String OFFLINE_NO_ADDRESS = "@text/zigbee.status.offline_noaddress";
     public final static String OFFLINE_NODE_NOT_FOUND = "@text/zigbee.status.offline_nodenotfound";
     public final static String OFFLINE_DISCOVERY_INCOMPLETE = "@text/zigbee.status.offline_discoveryincomplete";
+    
+    // List of configuration values for flow control
+    public final static Integer FLOWCONTROL_CONFIG_NONE = Integer.valueOf(0);
+    public final static Integer FLOWCONTROL_CONFIG_HARDWARE_CTSRTS = Integer.valueOf(1);
+    public final static Integer FLOWCONTROL_CONFIG_SOFTWARE_XONXOFF = Integer.valueOf(2);
 
     /**
      * Return an ISO 8601 combined date and time string for current date/time


### PR DESCRIPTION
In the configuration, the different options for flow control are encoded by 0, 1, and 2. With this PR these values are available as constants in the binding. These constants are usful for PRs like, e.g., https://github.com/openhab/org.openhab.binding.zigbee/pull/179, where flow control is set in discovery results.