### PR TITLE
Dispose of the scheduler used for color updates when the converter is disposed

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
@@ -38,6 +38,8 @@ import com.zsmartsystems.zigbee.zcl.clusters.ZclOnOffCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.ColorCapabilitiesEnum;
 
 /**
+ * Converter for color control. Uses the {@link ZclColorControlCluster}, and may also use the
+ * {@link ZclLevelControlCluster} and {@link ZclOnOffCluster} if available.
  *
  * @author Chris Jackson - Initial Contribution. Improvements in detection of device functionality.
  * @author Pedro Garcia - Added CIE XY color support
@@ -186,6 +188,13 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
 
     @Override
     public void disposeConverter() {
+        // Stop the timer and shutdown the scheduler
+        if (colorUpdateTimer != null) {
+            colorUpdateTimer.cancel(true);
+            colorUpdateTimer = null;
+        }
+        colorUpdateScheduler.shutdownNow();
+
         clusterColorControl.removeAttributeListener(this);
 
         if (clusterLevelControl != null) {


### PR DESCRIPTION
Scheduler is not currently stopped when the converter is closed.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>