### PR TITLE
Remove serial event listener before closing port

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeSerialPort.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeSerialPort.java
@@ -7,13 +7,6 @@
  * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.openhab.binding.zigbee.handler;
-/**
- * Copyright (c) 2016-2017 by the respective copyright holders.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- */
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -186,10 +179,12 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
         try {
             if (serialPort != null) {
                 synchronized (this) {
+                    serialPort.removeEventListener();
                     serialPort.enableReceiveTimeout(1);
 
-                    inputStream.close();
                     outputStream.flush();
+
+                    inputStream.close();
                     outputStream.close();
 
                     serialPort.close();


### PR DESCRIPTION
This probably won't make a lot of difference, but some information I've read says it's better to remove the event listener before closing the port. I should add that I already added this to the SPI version of the serial handler and it didn't help, but it seems it shouldn't hurt.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>