### PR TITLE
removed dependency on Guava

### DIFF
--- a/org.openhab.binding.zigbee/META-INF/MANIFEST.MF
+++ b/org.openhab.binding.zigbee/META-INF/MANIFEST.MF
@@ -5,8 +5,7 @@ Bundle-SymbolicName: org.openhab.binding.zigbee;singleton:=true
 Bundle-Vendor: openHAB
 Bundle-Version: 2.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.google.common.collect,
- com.thoughtworks.xstream,
+Import-Package: com.thoughtworks.xstream,
  com.thoughtworks.xstream.converters,
  com.thoughtworks.xstream.io,
  com.thoughtworks.xstream.io.xml,

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -18,8 +18,6 @@ import java.util.TimeZone;
 
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
-import com.google.common.collect.Sets;
-
 /**
  * The {@link ZigBeeBinding} class defines common constants, which are
  * used across the whole binding.
@@ -34,8 +32,7 @@ public class ZigBeeBindingConstants {
     // List of Thing Type UIDs
     public final static ThingTypeUID THING_TYPE_GENERIC_DEVICE = new ThingTypeUID(BINDING_ID, "device");
 
-    public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections
-            .unmodifiableSet(Sets.newHashSet(THING_TYPE_GENERIC_DEVICE));
+    public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_GENERIC_DEVICE);
 
     // List of Channel UIDs
     public static final String CHANNEL_SWITCH_ONOFF = "zigbee:switch_onoff";


### PR DESCRIPTION
The current release build (https://openhab.ci.cloudbees.com/view/Sandbox/job/sandbox-openhab2-release/525/) fails due to dependency on Guava. I am not completely sure why, but in the light of https://www.eclipse.org/smarthome/documentation/development/guidelines.html#c-language-levels-and-libraries, we should anyhow remove this dependency.

Signed-off-by: Kai Kreuzer <kai@openhab.org>