### PR TITLE
Fix JavaDoc warnings

### DIFF
--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/internal/EmberHandlerFactory.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/internal/EmberHandlerFactory.java
@@ -32,7 +32,7 @@ import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
 
 /**
- * The {@link org.openhab.binding.zigbee.emberHandlerFactory} is responsible for creating things and thing
+ * The {@link EmberHandlerFactory} is responsible for creating things and thing
  * handlers.
  *
  * @author Chris Jackson - Initial contribution

--- a/org.openhab.binding.zigbee.telegesis/src/main/java/org/openhab/binding/zigbee/telegesis/internal/TelegesisHandlerFactory.java
+++ b/org.openhab.binding.zigbee.telegesis/src/main/java/org/openhab/binding/zigbee/telegesis/internal/TelegesisHandlerFactory.java
@@ -32,7 +32,7 @@ import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
 
 /**
- * The {@link org.openhab.binding.zigbee.emberHandlerFactory} is responsible for creating things and thing
+ * The {@link TelegesisHandlerFactory} is responsible for creating things and thing
  * handlers.
  *
  * @author Chris Jackson - Initial contribution

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -141,12 +141,15 @@ public class ZigBeeBindingConstants {
 
     /**
      * Convert a map into a json encoded string.
+     * 
+     * @param properties a map with the to-be-converted properties.
+     * @return a String with a JSON representation of the properties.
      */
-    public static String propertiesToJson(Map<String, Object> object) {
+    public static String propertiesToJson(Map<String, Object> properties) {
         StringBuilder jsonBuilder = new StringBuilder();
         jsonBuilder.append("{");
         boolean first = true;
-        for (Map.Entry<String, Object> entry : object.entrySet()) {
+        for (Map.Entry<String, Object> entry : properties.entrySet()) {
             if (!first) {
                 jsonBuilder.append(",");
             }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -19,7 +19,7 @@ import java.util.TimeZone;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
- * The {@link ZigBeeBinding} class defines common constants, which are
+ * The {@link ZigBeeBindingConstants} class defines common constants, which are
  * used across the whole binding.
  *
  * @author Chris Jackson - Initial contribution
@@ -140,10 +140,7 @@ public class ZigBeeBindingConstants {
     }
 
     /**
-     * Convert a map into a json encoded string
-     *
-     * @param object
-     * @return
+     * Convert a map into a json encoded string.
      */
     public static String propertiesToJson(Map<String, Object> object) {
         StringBuilder jsonBuilder = new StringBuilder();

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeNetworkStateSerializerImpl.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeNetworkStateSerializerImpl.java
@@ -104,7 +104,6 @@ public class ZigBeeNetworkStateSerializerImpl implements ZigBeeNetworkStateSeria
      * Note that this method needs to be synchronised as serialisation may be called from different threads.
      *
      * @param networkManager the network state
-     * @return the serialized network state as json {@link String}.
      */
     @Override
     public synchronized void serialize(final ZigBeeNetworkManager networkManager) {
@@ -137,7 +136,6 @@ public class ZigBeeNetworkStateSerializerImpl implements ZigBeeNetworkStateSeria
      * Deserializes the network state.
      *
      * @param networkState the network state
-     * @param networkStateString the network state as {@link String}
      */
     @Override
     public void deserialize(final ZigBeeNetworkManager networkState) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeBaseChannelConverter.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeBaseChannelConverter.java
@@ -45,7 +45,7 @@ import com.zsmartsystems.zigbee.zcl.ZclCluster;
  * required features are available. If so, it should return the channel. This method allows dynamic channel detection
  * for unknown devices and may not be called if a device is defined through another mechanism.
  * <li>The thing handler will call the
- * {@link #initialize(ZigBeeThingHandler, ChannelUID, ZigBeeCoordinatorHandler, IeeeAddress, int)} to initialise the
+ * {@link ZigBeeBaseChannelConverter#initialize(ZigBeeThingHandler, Channel, ZigBeeCoordinatorHandler, IeeeAddress, int)} to initialise the
  * channel converter. The converter should get any clusters via the
  * {@link ZigBeeCoordinatorHandler#getEndpoint(IeeeAddress, int)} and {@link ZigBeeEndpoint#getInputCluster(int)} or
  * {@link ZigBeeEndpoint#getOutputCluster(int)}. It should configure the binding by calling {@link ZclCluster#bind()}
@@ -54,7 +54,7 @@ import com.zsmartsystems.zigbee.zcl.ZclCluster;
  * {@link #configOptions} with any configuration options that the device supports that may need to be adjusted by the
  * user.
  * <li>If the converter receives information from the ZigBee library that updates the channel state, it should update
- * the state by calling {@link #updateChannelState(State).
+ * the state by calling {@link #updateChannelState(State)}.
  * <li>The thing handler may call {@link #updateConfiguration(Configuration)} with an updated channel configuration from
  * the user. The handler should update the configuration in the device, read back the updated configuration if
  * necessary, and return an updated channel configuration to the thing handler.
@@ -126,8 +126,8 @@ public abstract class ZigBeeBaseChannelConverter {
 
     /**
      * The polling period used for this channel in seconds. Normally this should be left at the default
-     * ({@link POLLING_PERIOD_DEFAULT}), however if the channel does not support reporting, it can be set to a higher
-     * period such as {@link POLLING_PERIOD_HIGH}. Any period may be used, however it is recommended to use these
+     * ({@link ZigBeeBaseChannelConverter#POLLING_PERIOD_DEFAULT}), however if the channel does not support reporting, it can be set to a higher
+     * period such as {@link ZigBeeBaseChannelConverter#POLLING_PERIOD_HIGH}. Any period may be used, however it is recommended to use these
      * standard settings.
      */
     protected int pollingPeriod = POLLING_PERIOD_DEFAULT;
@@ -148,7 +148,6 @@ public abstract class ZigBeeBaseChannelConverter {
      * @param coordinator the {@link ZigBeeCoordinatorHandler} this endpoint is part of
      * @param address the {@link IeeeAddress} of the node
      * @param endpointId the endpoint this channel is linked to
-     * @return true if the handler was created successfully - false otherwise
      */
     public void initialize(ZigBeeThingHandler thing, Channel channel, ZigBeeCoordinatorHandler coordinator,
             IeeeAddress address, int endpointId) {
@@ -190,8 +189,6 @@ public abstract class ZigBeeBaseChannelConverter {
      * <p>
      * This is run in a separate thread by the Thing Handler so the converter doesn't need to worry about returning
      * quickly.
-     *
-     * @param channel the {@link ZigBeeThingChannel}
      */
     public void handleRefresh() {
         // Overridable if a channel can be refreshed
@@ -240,8 +237,8 @@ public abstract class ZigBeeBaseChannelConverter {
     /**
      * Gets the configuration descriptions required to configure this channel.
      * <p>
-     * Ideally, implementations should use the {@link ZclCluster#discoverAttributes()} method and the
-     * {@link ZclCluster#isAttributeSupported()} method to understand exactly what the device supports and only provide
+     * Ideally, implementations should use the {@link ZclCluster#discoverAttributes(boolean)} method and the
+     * {@link ZclCluster#isAttributeSupported(int)} method to understand exactly what the device supports and only provide
      * configuration as necessary.
      * <p>
      * This method should not be overridden - the {@link #configOptions} list should be populated during converter
@@ -255,8 +252,8 @@ public abstract class ZigBeeBaseChannelConverter {
 
     /**
      * Gets the polling period for this channel in seconds. Normally this should be left at the default
-     * ({@link POLLING_PERIOD_DEFAULT}), however if the channel does not support reporting, it can be set to a higher
-     * period such as {@link POLLING_PERIOD_HIGH} during the converter initialisation. Any period may be used, however
+     * ({@link ZigBeeBaseChannelConverter#POLLING_PERIOD_DEFAULT}), however if the channel does not support reporting, it can be set to a higher
+     * period such as {@link ZigBeeBaseChannelConverter#POLLING_PERIOD_HIGH} during the converter initialisation. Any period may be used, however
      * it is recommended to use these standard settings.
      *
      * @return the polling period for this channel in seconds

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactory.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactory.java
@@ -92,7 +92,6 @@ public class ZigBeeChannelConverterFactory {
      *
      * @param thingUID the {@link ThingUID} of the thing
      * @param endpoint the {@link ZigBeeEndpoint} to generate the channels for
-     * @return
      */
     @SuppressWarnings("unchecked")
     public Collection<Channel> getChannels(ThingUID thingUID, ZigBeeEndpoint endpoint) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactory.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactory.java
@@ -17,7 +17,6 @@ import java.util.Map;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
-import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
@@ -92,6 +91,8 @@ public class ZigBeeChannelConverterFactory {
      *
      * @param thingUID the {@link ThingUID} of the thing
      * @param endpoint the {@link ZigBeeEndpoint} to generate the channels for
+     * 
+     * @return a collection of all channels supported by the {@link ZigBeeEndpoint}
      */
     @SuppressWarnings("unchecked")
     public Collection<Channel> getChannels(ThingUID thingUID, ZigBeeEndpoint endpoint) {


### PR DESCRIPTION
Fixes "more severe" JavaDoc warnings (in the sense of "those JavaDoc warnings that are still visible when setting doclint=none").

Signed-off-by: Henning Sudbrock <henning.sudbrock@telekom.de>