### PR TITLE
Add version specification on zigbee bundle pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
 
 	<groupId>org.openhab.binding.zigbee</groupId>
 	<artifactId>pom</artifactId>
+	<version>2.3.0-SNAPSHOT</version>
 
 	<name>ZigBee Binding Parent POM</name>
 	<packaging>pom</packaging>


### PR DESCRIPTION
Inheriting the version in the middle of the POM hierarchy while setting it statically at more low-level components leads to weird dependency resolutions sometimes and breaks the version bump mechanisms of the maven-unleash-plugin  (e.g. here: https://openhab.ci.cloudbees.com/view/Sandbox/job/sandbox-openhab2-release/559/). For now, I would suggest to just set it statically on the top-level pom of this project as well (same approach is used for comparable components like zwave).

Signed-off-by: Patrick Fink <mail@pfink.de>