### PR TITLE
changed groupId back to be in sync with all bindings

### DIFF
--- a/org.openhab.binding.zigbee.cc2531/pom.xml
+++ b/org.openhab.binding.zigbee.cc2531/pom.xml
@@ -4,13 +4,12 @@
     
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.openhab.binding.zigbee</groupId>
-        <artifactId>pom</artifactId>
+        <groupId>org.openhab.binding</groupId>
+        <artifactId>org.openhab.binding.zigbee.pom</artifactId>
         <version>2.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     
-    <groupId>org.openhab.binding.zigbee</groupId>
     <artifactId>org.openhab.binding.zigbee.cc2531</artifactId>
     
     <name>ZigBee CC2531 Bridge</name>

--- a/org.openhab.binding.zigbee.ember/pom.xml
+++ b/org.openhab.binding.zigbee.ember/pom.xml
@@ -4,13 +4,12 @@
     
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.openhab.binding.zigbee</groupId>
-        <artifactId>pom</artifactId>
+        <groupId>org.openhab.binding</groupId>
+        <artifactId>org.openhab.binding.zigbee.pom</artifactId>
         <version>2.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     
-    <groupId>org.openhab.binding.zigbee</groupId>
     <artifactId>org.openhab.binding.zigbee.ember</artifactId>
     
     <name>ZigBee Ember Bridge</name>

--- a/org.openhab.binding.zigbee.telegesis/pom.xml
+++ b/org.openhab.binding.zigbee.telegesis/pom.xml
@@ -4,13 +4,12 @@
     
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.openhab.binding.zigbee</groupId>
-        <artifactId>pom</artifactId>
+        <groupId>org.openhab.binding</groupId>
+        <artifactId>org.openhab.binding.zigbee.pom</artifactId>
         <version>2.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     
-    <groupId>org.openhab.binding.zigbee</groupId>
     <artifactId>org.openhab.binding.zigbee.telegesis</artifactId>
     
     <name>ZigBee Telegesis Bridge</name>

--- a/org.openhab.binding.zigbee.xbee/pom.xml
+++ b/org.openhab.binding.zigbee.xbee/pom.xml
@@ -4,13 +4,12 @@
     
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.openhab.binding.zigbee</groupId>
-        <artifactId>pom</artifactId>
+        <groupId>org.openhab.binding</groupId>
+        <artifactId>org.openhab.binding.zigbee.pom</artifactId>
         <version>2.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     
-    <groupId>org.openhab.binding.zigbee</groupId>
     <artifactId>org.openhab.binding.zigbee.xbee</artifactId>
     
     <name>ZigBee XBee Bridge</name>

--- a/org.openhab.binding.zigbee/pom.xml
+++ b/org.openhab.binding.zigbee/pom.xml
@@ -4,13 +4,12 @@
 
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.openhab.binding.zigbee</groupId>
-		<artifactId>pom</artifactId>
+		<groupId>org.openhab.binding</groupId>
+		<artifactId>org.openhab.binding.zigbee.pom</artifactId>
 		<version>2.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
-	<groupId>org.openhab.binding.zigbee</groupId>
 	<artifactId>org.openhab.binding.zigbee</artifactId>
 
 	<name>ZigBee Binding</name>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
 		<relativePath />
 	</parent>
 
-	<groupId>org.openhab.binding.zigbee</groupId>
-	<artifactId>pom</artifactId>
+	<groupId>org.openhab.binding</groupId>
+	<artifactId>org.openhab.binding.zigbee.pom</artifactId>
 	<version>2.3.0-SNAPSHOT</version>
 
 	<name>ZigBee Binding Parent POM</name>


### PR DESCRIPTION
The current groupIds cause an unexpected Maven repo structure (and actually made [the distro build fail](https://openhab.ci.cloudbees.com/view/Sandbox/job/sandbox-openhab2-release/562/), so I'd suggest to change it back to be in line with all other bindings, so that there are no surprises.

Signed-off-by: Kai Kreuzer <kai@openhab.org>