### PR TITLE
ZigBeeDiscovery: Add RepresentationProperty

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeDiscoveryService.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeDiscoveryService.java
@@ -165,6 +165,7 @@ public class ZigBeeDiscoveryService extends AbstractDiscoveryService
                             node.getIeeeAddress().toString());
                     DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID)
                             .withThingType(thingTypeUID).withProperties(objProperties).withBridge(bridgeUID)
+                            .withRepresentationProperty(ZigBeeBindingConstants.CONFIGURATION_MACADDRESS)
                             .withLabel(label).build();
 
                     thingDiscovered(discoveryResult);
@@ -192,7 +193,9 @@ public class ZigBeeDiscoveryService extends AbstractDiscoveryService
                 Map<String, Object> objProperties = new HashMap<String, Object>(properties);
                 objProperties.put(ZigBeeBindingConstants.CONFIGURATION_MACADDRESS, node.getIeeeAddress().toString());
                 DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
-                        .withProperties(objProperties).withBridge(bridgeUID).withLabel(label).build();
+                        .withProperties(objProperties).withBridge(bridgeUID)
+                        .withRepresentationProperty(ZigBeeBindingConstants.CONFIGURATION_MACADDRESS)
+                        .withLabel(label).build();
 
                 thingDiscovered(discoveryResult);
 


### PR DESCRIPTION
RepresentationProperty enables ESH to uniquely identify a device and it is used in the inbox auto ignore service

Details:
* https://www.eclipse.org/smarthome/documentation/development/bindings/thing-definition.html#representation-property
* https://github.com/eclipse/smarthome/pull/3899

Signed-off-by: Michael Reitler <github@madpage.de>