### PR TITLE
Add IAS Fire Indicator alarm

### DIFF
--- a/org.openhab.binding.zigbee/ESH-INF/thing/_channels.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/_channels.xml
@@ -85,6 +85,15 @@
         <state readOnly="true" />
     </channel-type>
 
+    <!-- IAS Fire Channel -->
+    <channel-type id="ias_fire">
+        <item-type>Switch</item-type>
+        <label>Fire Detector</label>
+        <description>Fire Indication Alarm</description>
+        <category>SmokeDetector</category>
+        <state readOnly="true" />
+    </channel-type>
+
     <!-- IAS Motion Presence Channel -->
     <channel-type id="ias_motionpresence">
         <item-type>Switch</item-type>

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -54,6 +54,7 @@ public class ZigBeeBindingConstants {
     public static final String CHANNEL_IAS_MOTION_PRESENCE = "zigbee:ias_motionpresence";
     public static final String CHANNEL_IAS_STANDARDCIE_SYSTEM = "zigbee:ias_standard_system";
     public static final String CHANNEL_IAS_CO_DETECTOR = "zigbee:ias_codetector";
+    public static final String CHANNEL_IAS_FIRE_INDICATION = "zigbee:ias_fire";
 
     public static final String CHANNEL_ELECTRICAL_ACTIVEPOWER = "zigbee:electrical_activepower";
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactory.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactory.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
@@ -60,6 +61,7 @@ public class ZigBeeChannelConverterFactory {
         channelMap.put(ZigBeeBindingConstants.CHANNEL_HUMIDITY_VALUE, ZigBeeConverterRelativeHumidity.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_IAS_CONTACT_PORTAL1, ZigBeeConverterIasContactPortal1.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_IAS_CO_DETECTOR, ZigBeeConverterIasCoDetector.class);
+        channelMap.put(ZigBeeBindingConstants.CHANNEL_IAS_FIRE_INDICATION, ZigBeeConverterIasFireIndicator.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_IAS_MOTION_INTRUSION, ZigBeeConverterIasMotionIntrusion.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_IAS_MOTION_PRESENCE, ZigBeeConverterIasMotionPresence.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_IAS_STANDARDCIE_SYSTEM, ZigBeeConverterIasCieSystem.class);
@@ -95,7 +97,7 @@ public class ZigBeeChannelConverterFactory {
      *
      * @param thingUID the {@link ThingUID} of the thing
      * @param endpoint the {@link ZigBeeEndpoint} to generate the channels for
-     * 
+     *
      * @return a collection of all channels supported by the {@link ZigBeeEndpoint}
      */
     @SuppressWarnings("unchecked")

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasCoDetector.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasCoDetector.java
@@ -13,16 +13,15 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
-import com.zsmartsystems.zigbee.zcl.ZclCommandListener;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
 
 /**
- * Converter for the IAS motion sensor.
+ * Converter for the IAS CO sensor.
  *
  * @author Chris Jackson - Initial Contribution
  *
  */
-public class ZigBeeConverterIasCoDetector extends ZigBeeConverterIas implements ZclCommandListener {
+public class ZigBeeConverterIasCoDetector extends ZigBeeConverterIas {
     @Override
     public boolean initializeConverter() {
         bitTest = CIE_ALARM1;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasContactPortal1.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasContactPortal1.java
@@ -13,7 +13,6 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
-import com.zsmartsystems.zigbee.zcl.ZclCommandListener;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
 
 /**
@@ -22,7 +21,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
  * @author Chris Jackson - Initial Contribution
  *
  */
-public class ZigBeeConverterIasContactPortal1 extends ZigBeeConverterIas implements ZclCommandListener {
+public class ZigBeeConverterIasContactPortal1 extends ZigBeeConverterIas {
     @Override
     public boolean initializeConverter() {
         bitTest = CIE_ALARM1;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasFireIndicator.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasFireIndicator.java
@@ -16,12 +16,12 @@ import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
 
 /**
- * Converter for the IAS Standard CIE System sensor.
+ * Converter for the IAS fire indicator.
  *
  * @author Chris Jackson - Initial Contribution
  *
  */
-public class ZigBeeConverterIasCieSystem extends ZigBeeConverterIas {
+public class ZigBeeConverterIasFireIndicator extends ZigBeeConverterIas {
     @Override
     public boolean initializeConverter() {
         bitTest = CIE_ALARM1;
@@ -30,11 +30,11 @@ public class ZigBeeConverterIasCieSystem extends ZigBeeConverterIas {
 
     @Override
     public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
-        if (!supportsIasChannel(endpoint, ZoneTypeEnum.STANDARD_CIE)) {
+        if (!supportsIasChannel(endpoint, ZoneTypeEnum.FIRE_SENSOR)) {
             return null;
         }
 
-        return createChannel(thingUID, endpoint, ZigBeeBindingConstants.CHANNEL_IAS_STANDARDCIE_SYSTEM,
-                ZigBeeBindingConstants.ITEM_TYPE_SWITCH, "CIE Standard System Alarm");
+        return createChannel(thingUID, endpoint, ZigBeeBindingConstants.CHANNEL_IAS_FIRE_INDICATION,
+                ZigBeeBindingConstants.ITEM_TYPE_SWITCH, "Fire Detector");
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasMotionIntrusion.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasMotionIntrusion.java
@@ -13,7 +13,6 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
-import com.zsmartsystems.zigbee.zcl.ZclCommandListener;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
 
 /**
@@ -22,7 +21,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
  * @author Chris Jackson - Initial Contribution
  *
  */
-public class ZigBeeConverterIasMotionIntrusion extends ZigBeeConverterIas implements ZclCommandListener {
+public class ZigBeeConverterIasMotionIntrusion extends ZigBeeConverterIas {
     @Override
     public boolean initializeConverter() {
         bitTest = CIE_ALARM1;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasMotionPresence.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasMotionPresence.java
@@ -13,7 +13,6 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
-import com.zsmartsystems.zigbee.zcl.ZclCommandListener;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
 
 /**
@@ -22,7 +21,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
  * @author Chris Jackson - Initial Contribution
  *
  */
-public class ZigBeeConverterIasMotionPresence extends ZigBeeConverterIas implements ZclCommandListener {
+public class ZigBeeConverterIasMotionPresence extends ZigBeeConverterIas {
     @Override
     public boolean initializeConverter() {
         bitTest = CIE_ALARM2;


### PR DESCRIPTION
This adds the FIRE IAS alarm. Note that it requires 1.0.11 of the zigbee libs (now available in the OH TP).
Signed-off-by: Chris Jackson <chris@cd-jackson.com>