### PR TITLE
Add module to maven build that creates a p2 repository with built bundles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 		<module>org.openhab.binding.zigbee.telegesis</module>
 		<module>org.openhab.binding.zigbee.cc2531</module>
 		<module>org.openhab.binding.zigbee.xbee</module>
+		<module>releng/org.openhab.binding.zigbee.p2repo</module>
 	</modules>
 
 	<properties>

--- a/releng/org.openhab.binding.zigbee.p2repo/assembly.xml
+++ b/releng/org.openhab.binding.zigbee.p2repo/assembly.xml
@@ -1,0 +1,30 @@
+<assembly
+	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+
+  <id>bin</id>
+  
+  <formats>
+    <format>dir</format>
+  </formats>
+  
+  <includeBaseDirectory>false</includeBaseDirectory>
+  
+  <moduleSets>
+    <moduleSet>
+      
+      <!-- Enable access to all projects in the current multimodule build! -->
+      <useAllReactorProjects>true</useAllReactorProjects>
+      
+      <!-- And put all bundles into a plugins directory -->
+      <binaries>
+	<outputDirectory>plugins</outputDirectory>
+	<unpack>false</unpack>
+	<includeDependencies>false</includeDependencies>
+      </binaries>
+      
+    </moduleSet>
+  </moduleSets>
+</assembly>
+  

--- a/releng/org.openhab.binding.zigbee.p2repo/pom.xml
+++ b/releng/org.openhab.binding.zigbee.p2repo/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.openhab.binding</groupId>
+    <artifactId>org.openhab.binding.zigbee.p2repo</artifactId>
+    <packaging>pom</packaging>
+
+    <parent>
+        <groupId>org.openhab.binding</groupId>
+        <artifactId>org.openhab.binding.zigbee.pom</artifactId>
+        <version>2.4.0-SNAPSHOT</version>
+        <relativePath>../../</relativePath>
+    </parent>
+
+    <profiles>
+      <profile>
+	<!-- Profile generates p2 repo for built artifacts in releng/p2repo/target/repository -->
+	<id>p2repo</id>
+
+	<build>
+	  <plugins>
+	    
+	    <plugin>
+	      <artifactId>maven-assembly-plugin</artifactId>
+	      <version>2.6</version>
+	      <executions>
+		<execution>
+		  <id>aggregate</id>
+		  <phase>package</phase>
+		  <goals>
+		    <goal>single</goal>
+		  </goals>
+		  <configuration>
+		    <appendAssemblyId>false</appendAssemblyId>
+		    <finalName>bundles</finalName>
+		    <descriptors>
+		      <descriptor>assembly.xml</descriptor>
+		    </descriptors>
+		  </configuration>
+		</execution>
+	      </executions>
+	    </plugin>
+	    
+	    <plugin>
+	      <groupId>org.eclipse.tycho.extras</groupId>
+	      <artifactId>tycho-p2-extras-plugin</artifactId>
+	      <version>1.0.0</version>
+	      <executions>
+		<execution>
+		  <id>p2</id>
+		  <goals>
+		    <goal>publish-features-and-bundles</goal>
+		  </goals>
+		  <phase>package</phase>
+		</execution>
+	      </executions>
+	      <configuration>
+		<sourceLocation>${project.build.directory}/bundles</sourceLocation>
+	      </configuration>
+	    </plugin>
+	  </plugins>
+	</build>
+      </profile>
+    </profiles>
+
+</project>


### PR DESCRIPTION
The p2 repository will be created in folder `releng/p2repo/target/repository` if the maven profile `p2repo` is active (e.g., when running `mvn clean install -Pp2repo`).

This is, imho, useful when working locally on extensions of this binding, where one can then reference this local p2 repository.

The maven module introduced with this PR is analogous to the one introduced in this [PR for the zsmartsystems ZigBee library](https://github.com/zsmartsystems/com.zsmartsystems.zigbee/pull/330) (and of course also includes the fix from this [follow-up PR](https://github.com/zsmartsystems/com.zsmartsystems.zigbee/pull/334)).