### PR TITLE
Improve level control converter to update conditional on the on/off state

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -97,7 +97,7 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
             // really received an OFF report, thus confirming ON_OFF reporting is working
             currentState.set(true);
 
-            // Add a listener, then request the status
+            // Add a listener
             clusterOnOffServer.addAttributeListener(this);
         }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -49,6 +49,8 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
 
     private final AtomicBoolean currentState = new AtomicBoolean(true);
 
+    private PercentType lastLevel = PercentType.HUNDRED;
+
     @Override
     public boolean initializeConverter() {
         clusterLevelControl = (ZclLevelControlCluster) endpoint.getInputCluster(ZclLevelControlCluster.CLUSTER_ID);
@@ -166,10 +168,10 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.LEVEL_CONTROL
                 && attribute.getId() == ZclLevelControlCluster.ATTR_CURRENTLEVEL) {
-            Integer level = (Integer) attribute.getLastValue();
-            if (level != null && currentState.get()) {
+            lastLevel = levelToPercent((Integer) attribute.getLastValue());
+            if (currentState.get()) {
                 // Note that state is only updated if the current On/Off state is TRUE (ie ON)
-                updateChannelState(levelToPercent(level));
+                updateChannelState(lastLevel);
             }
             return;
         }
@@ -178,7 +180,7 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
                 return;
             }
             currentState.set((Boolean) attribute.getLastValue());
-            updateChannelState(currentState.get() ? OnOffType.ON : OnOffType.OFF);
+            updateChannelState(currentState.get() ? lastLevel : OnOffType.OFF);
         }
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -74,7 +74,7 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
                 logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
             }
 
-            // Add a listener, then request the status
+            // Add the listener
             clusterOnOffServer.addAttributeListener(this);
         }
 

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevelTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevelTest.java
@@ -57,34 +57,46 @@ public class ZigBeeConverterSwitchLevelTest {
                 false, false, false, false);
 
         // The following sequence checks that the level is ignored if the OnOff state is OFF
+        // Initial value of level is 100%
         onAttribute.updateValue(new Boolean(true));
         converter.attributeUpdated(onAttribute);
         Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(new ChannelUID("a:b:c:d"), channelCapture.getValue());
-        assertEquals(OnOffType.ON, stateCapture.getValue());
+        assertEquals(PercentType.HUNDRED, stateCapture.getValue());
 
-        onAttribute.updateValue(new Boolean(false));
-        converter.attributeUpdated(onAttribute);
-        Mockito.verify(thingHandler, Mockito.times(2)).setChannelState(channelCapture.capture(),
-                stateCapture.capture());
-        assertEquals(new ChannelUID("a:b:c:d"), channelCapture.getValue());
-        assertEquals(OnOffType.OFF, stateCapture.getValue());
-
-        // No update here...
+        // Set the level to ensure that level updates work before OnOff states are received
         levelAttribute.updateValue(new Integer(50));
         converter.attributeUpdated(levelAttribute);
         Mockito.verify(thingHandler, Mockito.times(2)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
+        assertEquals(new PercentType(20), stateCapture.getValue());
 
-        onAttribute.updateValue(new Boolean(true));
+        // Turn off, and we should get OFF state
+        onAttribute.updateValue(new Boolean(false));
         converter.attributeUpdated(onAttribute);
         Mockito.verify(thingHandler, Mockito.times(3)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
-        assertEquals(OnOffType.ON, stateCapture.getValue());
+        assertEquals(new ChannelUID("a:b:c:d"), channelCapture.getValue());
+        assertEquals(OnOffType.OFF, stateCapture.getValue());
 
+        // No update here, but we should remember the value for when it's turned on...
+        levelAttribute.updateValue(new Integer(101));
         converter.attributeUpdated(levelAttribute);
+        Mockito.verify(thingHandler, Mockito.times(3)).setChannelState(channelCapture.capture(),
+                stateCapture.capture());
+
+        // Turn on, and use the last level received (20%)
+        onAttribute.updateValue(new Boolean(true));
+        converter.attributeUpdated(onAttribute);
         Mockito.verify(thingHandler, Mockito.times(4)).setChannelState(channelCapture.capture(),
+                stateCapture.capture());
+        assertEquals(new PercentType(40), stateCapture.getValue());
+
+        // Set the level to 40% and make sure it's updated
+        levelAttribute.updateValue(new Integer(50));
+        converter.attributeUpdated(levelAttribute);
+        Mockito.verify(thingHandler, Mockito.times(5)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(new ChannelUID("a:b:c:d"), channelCapture.getValue());
         assertEquals(new PercentType(20), stateCapture.getValue());


### PR DESCRIPTION
This changes the level control converter to also use the on/off cluster. Level control is only updated if the onoff state is on. This should ensure that devices that report off, but with a non-zero level are correctly handled.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>