### PR TITLE
Fix logging in temperature converter

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -59,6 +59,7 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
                 }
             } else {
                 pollingPeriod = POLLING_PERIOD_HIGH;
+                logger.debug("{}: Failed to bind level control cluster", endpoint.getIeeeAddress());
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
@@ -50,7 +50,10 @@ public class ZigBeeConverterTemperature extends ZigBeeBaseChannelConverter imple
         try {
             bindResponse = cluster.bind().get();
             if (!bindResponse.isSuccess()) {
-                logger.warn("{}: Failed to bind temperature measurement cluster");
+                logger.debug("{}: Failed to bind temperature measurement cluster", endpoint.getIeeeAddress());
+            } else {
+                // Configure reporting
+                cluster.setMeasuredValueReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 0.1);
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
@@ -59,8 +62,6 @@ public class ZigBeeConverterTemperature extends ZigBeeBaseChannelConverter imple
         // Add a listener, then request the status
         cluster.addAttributeListener(this);
 
-        // Configure reporting - no faster than once per second - no slower than 10 minutes.
-        cluster.setMeasuredValueReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 0.1);
         return true;
     }
 


### PR DESCRIPTION
This fixes an error in the logging, and also only configured reporting if the bind was successful.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>