### PR TITLE
Add water sensor channel

### DIFF
--- a/org.openhab.binding.zigbee/ESH-INF/thing/channels.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/channels.xml
@@ -112,6 +112,15 @@
         <state readOnly="true" />
     </channel-type>
 
+    <!-- IAS Water Sensor Channel -->
+    <channel-type id="ias_water">
+        <item-type>Switch</item-type>
+        <label>Water Sensor</label>
+        <description>Water Sensor Alarm</description>
+        <category>Sensor</category>
+        <state readOnly="true" />
+    </channel-type>
+
     <!-- Illuminance Channel -->
     <channel-type id="measurement_illuminance">
         <item-type>Number</item-type>

--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -123,6 +123,7 @@ The following channels are supported -:
 | ias_motionintrusion | ```IAS_ZONE``` (0x0500) | Switch |  |
 | ias_motionpresence | ```IAS_ZONE``` (0x0500) | Switch |  |
 | ias_standard_system | ```IAS_ZONE``` (0x0500) | Switch |  |
+| ias_water | ```IAS_ZONE``` (0x0500) | Switch |  |
 | measurement_illuminance | ```ILLUMINANCE_MEASUREMENT``` (0x0400) | Number |   |
 | measurement_pressure | ```PRESSURE_MEASUREMENT``` (0x0403) | Number |   |
 | measurement_relativehumidity | ```RELATIVE_HUMIDITY_MEASUREMENT``` (0x0405) | Number |   |

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -100,6 +100,10 @@ public class ZigBeeBindingConstants {
     public static final String CHANNEL_LABEL_IAS_FIREINDICATION = "Fire Alarm";
     public static final ChannelTypeUID CHANNEL_IAS_FIREINDICATION = new ChannelTypeUID("zigbee:ias_fire");
 
+    public static final String CHANNEL_NAME_IAS_WATERSENSOR = "water";
+    public static final String CHANNEL_LABEL_IAS_WATERSENSOR = "Water Alarm";
+    public static final ChannelTypeUID CHANNEL_IAS_WATERSENSOR = new ChannelTypeUID("zigbee:ias_water");
+
     public static final String CHANNEL_NAME_ELECTRICAL_ACTIVEPOWER = "activepower";
     public static final String CHANNEL_LABEL_ELECTRICAL_ACTIVEPOWER = "Total Active Power";
     public static final ChannelTypeUID CHANNEL_ELECTRICAL_ACTIVEPOWER = new ChannelTypeUID(

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactory.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactory.java
@@ -65,6 +65,7 @@ public class ZigBeeChannelConverterFactory {
         channelMap.put(ZigBeeBindingConstants.CHANNEL_IAS_MOTIONINTRUSION, ZigBeeConverterIasMotionIntrusion.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_IAS_MOTIONPRESENCE, ZigBeeConverterIasMotionPresence.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_IAS_STANDARDCIESYSTEM, ZigBeeConverterIasCieSystem.class);
+        channelMap.put(ZigBeeBindingConstants.CHANNEL_IAS_WATERSENSOR, ZigBeeConverterIasWaterSensor.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_ILLUMINANCE_VALUE, ZigBeeConverterIlluminance.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_OCCUPANCY_SENSOR, ZigBeeConverterOccupancy.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_POWER_BATTERYPERCENT, ZigBeeConverterBatteryPercent.class);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasWaterSensor.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasWaterSensor.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zigbee.internal.converter;
+
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
+import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
+
+/**
+ * Converter for the IAS water sensor.
+ *
+ * @author Chris Jackson - Initial Contribution
+ *
+ */
+public class ZigBeeConverterIasWaterSensor extends ZigBeeConverterIas {
+    @Override
+    public boolean initializeConverter() {
+        bitTest = CIE_ALARM1;
+        return super.initializeConverter();
+    }
+
+    @Override
+    public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
+        if (!supportsIasChannel(endpoint, ZoneTypeEnum.WATER_SENSOR)) {
+            return null;
+        }
+
+        return ChannelBuilder
+                .create(createChannelUID(thingUID, endpoint, ZigBeeBindingConstants.CHANNEL_NAME_IAS_WATERSENSOR),
+                        ZigBeeBindingConstants.ITEM_TYPE_SWITCH)
+                .withType(ZigBeeBindingConstants.CHANNEL_IAS_WATERSENSOR)
+                .withLabel(ZigBeeBindingConstants.CHANNEL_LABEL_IAS_WATERSENSOR)
+                .withProperties(createProperties(endpoint)).build();
+    }
+}


### PR DESCRIPTION
This is untested, but changes are minimal so it should be ok, and once merged another user can test this. It seems that the latest Samsung door sensor is reporting itself as a water sensor! (#236).

Signed-off-by: Chris Jackson <chris@cd-jackson.com>