### PR TITLE
Update firmware failure string constants

### DIFF
--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
@@ -116,7 +116,7 @@ public class EmberHandler extends ZigBeeCoordinatorHandler implements FirmwareUp
                         progressCallback.canceled();
                         break;
                     case FIRMWARE_UPDATE_FAILED:
-                        progressCallback.failed("zigbee.firmware.failed");
+                        progressCallback.failed(ZigBeeBindingConstants.FIRMWARE_FAILED);
                         break;
                     default:
                         break;

--- a/org.openhab.binding.zigbee.telegesis/src/main/java/org/openhab/binding/zigbee/telegesis/handler/TelegesisHandler.java
+++ b/org.openhab.binding.zigbee.telegesis/src/main/java/org/openhab/binding/zigbee/telegesis/handler/TelegesisHandler.java
@@ -19,6 +19,7 @@ import org.eclipse.smarthome.core.thing.binding.firmware.Firmware;
 import org.eclipse.smarthome.core.thing.binding.firmware.FirmwareUpdateHandler;
 import org.eclipse.smarthome.core.thing.binding.firmware.ProgressCallback;
 import org.eclipse.smarthome.core.thing.binding.firmware.ProgressStep;
+import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.openhab.binding.zigbee.handler.ZigBeeSerialPort;
 import org.openhab.binding.zigbee.telegesis.internal.TelegesisConfiguration;
@@ -125,7 +126,7 @@ public class TelegesisHandler extends ZigBeeCoordinatorHandler implements Firmwa
                         progressCallback.canceled();
                         break;
                     case FIRMWARE_UPDATE_FAILED:
-                        progressCallback.failed("zigbee.firmware.failed");
+                        progressCallback.failed(ZigBeeBindingConstants.FIRMWARE_FAILED);
                         break;
                     default:
                         break;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -174,6 +174,8 @@ public class ZigBeeBindingConstants {
     public final static String OFFLINE_NODE_NOT_FOUND = "@text/zigbee.status.offline_nodenotfound";
     public final static String OFFLINE_DISCOVERY_INCOMPLETE = "@text/zigbee.status.offline_discoveryincomplete";
 
+    public final static String FIRMWARE_FAILED = "@text/zigbee.firmware.failed";
+
     // List of configuration values for flow control
     public final static Integer FLOWCONTROL_CONFIG_NONE = Integer.valueOf(0);
     public final static Integer FLOWCONTROL_CONFIG_HARDWARE_CTSRTS = Integer.valueOf(1);


### PR DESCRIPTION
This tidies up some constants - don't merge right now though.

@hsudbrock I thought I saw an issue you raised on ESH about reading i18 constants from different bundles, but I can't find it now. Did I imagine that, or was it resolved (either way I can't find it).  I think it's still an issue here as this currently doesn't load (with or without the ```@text``` which I'm not sure is needed or not at the moment).

Signed-off-by: Chris Jackson <chris@cd-jackson.com>