### PR TITLE
Remove the node from the ZigBeeNetworkManager when the thing is removed

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -682,6 +682,23 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
     }
 
     /**
+     * Removes a node from the network manager. This does not cause the network manager to tell the node to leave the
+     * network, but will only remove the node from the network manager lists. Thus, if the node is still alive, it may
+     * be able to rejoin the network.
+     * <p>
+     * To force the node to leave the network, use the {@link #leave(IeeeAddress)} method
+     *
+     * @param nodeIeeeAddress the {@link IeeeAddress} of the node to remove
+     */
+    public void removeNode(IeeeAddress nodeIeeeAddress) {
+        ZigBeeNode node = networkManager.getNode(nodeIeeeAddress);
+        if (node == null) {
+            return;
+        }
+        networkManager.removeNode(node);
+    }
+
+    /**
      * Permit joining only for the specified node
      *
      * @param address the 16 bit network address of the node to enable joining

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -392,6 +392,7 @@ public class ZigBeeThingHandler extends BaseThingHandler
     @Override
     public void handleRemoval() {
         coordinatorHandler.leave(nodeIeeeAddress);
+        coordinatorHandler.removeNode(nodeIeeeAddress);
         updateStatus(ThingStatus.REMOVED);
     }
 


### PR DESCRIPTION
If a thing is removed from the network, then the node is deleted from the network manager. The ```handleRemoval``` method already sends the ```leave``` command, so if the device is listening, it will already leave the network, so this addition covers the case where the thing is no longer alive - it will simply be removed. If however it is still alive, it may rejoin the network later (as per normal ZigBee rejoins).

Signed-off-by: Chris Jackson <chris@cd-jackson.com>