### PR TITLE
Add trace level logging into channel detection

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
@@ -95,6 +95,7 @@ public class ZigBeeConverterAtmosphericPressure extends ZigBeeBaseChannelConvert
     @Override
     public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
         if (endpoint.getInputCluster(ZclPressureMeasurementCluster.CLUSTER_ID) == null) {
+            logger.trace("{}: Pressure measurement cluster not found", endpoint.getIeeeAddress());
             return null;
         }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
@@ -352,6 +352,7 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
         ZclColorControlCluster clusterColorControl = (ZclColorControlCluster) endpoint
                 .getInputCluster(ZclColorControlCluster.CLUSTER_ID);
         if (clusterColorControl == null) {
+            logger.trace("{}: Color control cluster not found", endpoint.getIeeeAddress());
             return null;
         }
 
@@ -361,26 +362,29 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                 Integer capabilities = clusterColorControl.getColorCapabilities(Long.MAX_VALUE);
                 if (capabilities == null && clusterColorControl.getCurrentX(Long.MAX_VALUE) == null
                         && clusterColorControl.getCurrentHue(Long.MAX_VALUE) == null) {
+                    logger.trace("{}: Color control XY and Hue returned null", endpoint.getIeeeAddress());
                     return null;
                 }
                 if (capabilities != null && ((capabilities & (ColorCapabilitiesEnum.HUE_AND_SATURATION.getKey()
                         | ColorCapabilitiesEnum.XY_ATTRIBUTE.getKey())) == 0)) {
                     // No support for hue or XY
+                    logger.trace("{}: Color control XY and Hue capabilities not supported", endpoint.getIeeeAddress());
                     return null;
                 }
-
             } else if (clusterColorControl.isAttributeSupported(ZclColorControlCluster.ATTR_COLORCAPABILITIES)) {
-                // If the device is reporting is capabilities, then use this over attribute detection
+                // If the device is reporting its capabilities, then use this over attribute detection
                 // The color control cluster is required to always support XY attributes, so a non-color bulb is still
                 // detected as a color bulb in this case.
                 Integer capabilities = clusterColorControl.getColorCapabilities(Long.MAX_VALUE);
                 if ((capabilities != null) && (capabilities & (ColorCapabilitiesEnum.HUE_AND_SATURATION.getKey()
                         | ColorCapabilitiesEnum.XY_ATTRIBUTE.getKey())) == 0) {
                     // No support for hue or XY
+                    logger.trace("{}: Color control XY and Hue capabilities not supported", endpoint.getIeeeAddress());
                     return null;
                 }
             } else if (!clusterColorControl.isAttributeSupported(ZclColorControlCluster.ATTR_CURRENTHUE)
                     && !clusterColorControl.isAttributeSupported(ZclColorControlCluster.ATTR_CURRENTX)) {
+                logger.trace("{}: Color control XY and Hue attributes not supported", endpoint.getIeeeAddress());
                 return null;
             }
         } catch (InterruptedException | ExecutionException e) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
@@ -123,6 +123,7 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
         ZclColorControlCluster clusterColorControl = (ZclColorControlCluster) endpoint
                 .getInputCluster(ZclColorControlCluster.CLUSTER_ID);
         if (clusterColorControl == null) {
+            logger.trace("{}: Color control cluster not found", endpoint.getIeeeAddress());
             return null;
         }
 
@@ -131,10 +132,14 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
                 // Device is not supporting attribute reporting - instead, just read the attributes
                 Integer capabilities = clusterColorControl.getColorCapabilities(Long.MAX_VALUE);
                 if (capabilities == null && clusterColorControl.getColorTemperature(Long.MAX_VALUE) == null) {
+                    logger.trace("{}: Color control color temperature attribute returned null",
+                            endpoint.getIeeeAddress());
                     return null;
                 }
                 if (capabilities != null && (capabilities & ColorCapabilitiesEnum.COLOR_TEMPERATURE.getKey()) == 0) {
                     // No support for color temperature
+                    logger.trace("{}: Color control color temperature capability not supported",
+                            endpoint.getIeeeAddress());
                     return null;
                 }
             } else if (clusterColorControl.isAttributeSupported(ZclColorControlCluster.ATTR_COLORCAPABILITIES)) {
@@ -142,9 +147,12 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
                 Integer capabilities = clusterColorControl.getColorCapabilities(Long.MAX_VALUE);
                 if (capabilities != null && (capabilities & ColorCapabilitiesEnum.COLOR_TEMPERATURE.getKey()) == 0) {
                     // No support for color temperature
+                    logger.trace("{}: Color control color temperature capability not supported",
+                            endpoint.getIeeeAddress());
                     return null;
                 }
             } else if (!clusterColorControl.isAttributeSupported(ZclColorControlCluster.ATTR_COLORTEMPERATURE)) {
+                logger.trace("{}: Color control color temperature attribute not supported", endpoint.getIeeeAddress());
                 return null;
             }
         } catch (InterruptedException | ExecutionException e) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
@@ -83,6 +83,7 @@ public abstract class ZigBeeConverterIas extends ZigBeeBaseChannelConverter impl
 
     protected boolean supportsIasChannel(ZigBeeEndpoint endpoint, ZoneTypeEnum requiredZoneType) {
         if (endpoint.getInputCluster(ZclIasZoneCluster.CLUSTER_ID) == null) {
+            logger.trace("{}: IAS zone cluster not found", endpoint.getIeeeAddress());
             return false;
         }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
@@ -67,6 +67,7 @@ public class ZigBeeConverterIlluminance extends ZigBeeBaseChannelConverter imple
     @Override
     public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
         if (endpoint.getInputCluster(ZclIlluminanceMeasurementCluster.CLUSTER_ID) == null) {
+            logger.trace("{}: Illuminance measurement cluster not found", endpoint.getIeeeAddress());
             return null;
         }
         return ChannelBuilder

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
@@ -97,22 +97,25 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
         ZclElectricalMeasurementCluster cluster = (ZclElectricalMeasurementCluster) endpoint
                 .getInputCluster(ZclElectricalMeasurementCluster.CLUSTER_ID);
         if (cluster == null) {
+            logger.trace("{}: Electrical measurement cluster not found", endpoint.getIeeeAddress());
             return null;
         }
 
         try {
-            if (!cluster.discoverAttributes(false).get()) {
-                logger.warn("{}: Failed discovering attributes in electrical measurement cluster",
+            if (!cluster.discoverAttributes(false).get()
+                    && !cluster.isAttributeSupported(ZclElectricalMeasurementCluster.ATTR_ACTIVEPOWER)) {
+                logger.trace("{}: Electrical measurement cluster active power not supported",
+                        endpoint.getIeeeAddress());
+
+                return null;
+            } else if (cluster.getActivePower(Long.MAX_VALUE) == null) {
+                logger.trace("{}: Electrical measurement cluster active power returned null",
                         endpoint.getIeeeAddress());
                 return null;
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.warn("{}: Exception discovering attributes in electrical measurement cluster",
                     endpoint.getIeeeAddress(), e);
-            return null;
-        }
-
-        if (!cluster.isAttributeSupported(ZclElectricalMeasurementCluster.ATTR_ACTIVEPOWER)) {
             return null;
         }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
@@ -97,15 +97,18 @@ public class ZigBeeConverterMeasurementRmsCurrent extends ZigBeeBaseChannelConve
         ZclElectricalMeasurementCluster cluster = (ZclElectricalMeasurementCluster) endpoint
                 .getInputCluster(ZclElectricalMeasurementCluster.CLUSTER_ID);
         if (cluster == null) {
+            logger.trace("{}: Electrical measurement cluster not found", endpoint.getIeeeAddress());
             return null;
         }
 
         try {
             if (!cluster.discoverAttributes(false).get()
                     && !cluster.isAttributeSupported(ZclElectricalMeasurementCluster.ATTR_RMSCURRENT)) {
+                logger.trace("{}: Electrical measurement cluster RMS current not supported", endpoint.getIeeeAddress());
 
                 return null;
-            } else if (cluster.getRmsCurrent(0) == null) {
+            } else if (cluster.getRmsCurrent(Long.MAX_VALUE) == null) {
+                logger.trace("{}: Electrical measurement cluster RMS current returned null", endpoint.getIeeeAddress());
                 return null;
             }
         } catch (InterruptedException | ExecutionException e) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
@@ -97,15 +97,18 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
         ZclElectricalMeasurementCluster cluster = (ZclElectricalMeasurementCluster) endpoint
                 .getInputCluster(ZclElectricalMeasurementCluster.CLUSTER_ID);
         if (cluster == null) {
+            logger.trace("{}: Electrical measurement cluster not found", endpoint.getIeeeAddress());
             return null;
         }
 
         try {
             if (!cluster.discoverAttributes(false).get()
                     && !cluster.isAttributeSupported(ZclElectricalMeasurementCluster.ATTR_RMSVOLTAGE)) {
+                logger.trace("{}: Electrical measurement cluster RMS voltage not supported", endpoint.getIeeeAddress());
 
                 return null;
-            } else if (cluster.getRmsVoltage(0) == null) {
+            } else if (cluster.getRmsVoltage(Long.MAX_VALUE) == null) {
+                logger.trace("{}: Electrical measurement cluster RMS voltage returned null", endpoint.getIeeeAddress());
                 return null;
             }
         } catch (InterruptedException | ExecutionException e) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
@@ -68,6 +68,7 @@ public class ZigBeeConverterOccupancy extends ZigBeeBaseChannelConverter impleme
     @Override
     public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
         if (endpoint.getInputCluster(ZclOccupancySensingCluster.CLUSTER_ID) == null) {
+            logger.trace("{}: Occupancy sensing cluster not found", endpoint.getIeeeAddress());
             return null;
         }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
@@ -67,6 +67,7 @@ public class ZigBeeConverterRelativeHumidity extends ZigBeeBaseChannelConverter 
     @Override
     public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
         if (endpoint.getInputCluster(ZclRelativeHumidityMeasurementCluster.CLUSTER_ID) == null) {
+            logger.trace("{}: Relative humidity cluster not found", endpoint.getIeeeAddress());
             return null;
         }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -154,6 +154,7 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
     @Override
     public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
         if (endpoint.getInputCluster(ZclLevelControlCluster.CLUSTER_ID) == null) {
+            logger.trace("{}: Level control cluster not found", endpoint.getIeeeAddress());
             return null;
         }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -149,6 +149,7 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
     public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
         if (endpoint.getInputCluster(ZclOnOffCluster.CLUSTER_ID) == null
                 && endpoint.getOutputCluster(ZclOnOffCluster.CLUSTER_ID) == null) {
+            logger.trace("{}: OnOff cluster not found", endpoint.getIeeeAddress());
             return null;
         }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
@@ -79,6 +79,7 @@ public class ZigBeeConverterTemperature extends ZigBeeBaseChannelConverter imple
     @Override
     public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
         if (endpoint.getInputCluster(ZclTemperatureMeasurementCluster.CLUSTER_ID) == null) {
+            logger.trace("{}: Temperature measurement cluster not found", endpoint.getIeeeAddress());
             return null;
         }
 


### PR DESCRIPTION
This adds a standard set of trace level logging into the channel detection method in all converters. This should allow the channel detection to be debugged in the event that a device doesn't provide a channel.
Also fixes #245 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>