### PR TITLE
Provide option in Ember to use boost mode (and make default) and set tx power

### DIFF
--- a/org.openhab.binding.zigbee.ember/ESH-INF/thing/controller_ember.xml
+++ b/org.openhab.binding.zigbee.ember/ESH-INF/thing/controller_ember.xml
@@ -44,6 +44,26 @@
                 </options>
             </parameter>
 
+            <parameter name="zigbee_powermode" type="integer">
+                <label>Power Mode</label>
+                <description>Sets the Ember power mode. Boost mode will improve receive and transmit performance.</description>
+                <default>1</default>
+                <options>
+                    <option value="0">Normal</option>
+                    <option value="1">Boost</option>
+                </options>
+            </parameter>
+
+            <parameter name="zigbee_txpower" type="integer" min="0" max="8">
+                <label>Power Mode</label>
+                <description>Sets the Ember transmit power.</description>
+                <default>0</default>
+                <options>
+                    <option value="8">High</option>
+                    <option value="0">Normal</option>
+                </options>
+            </parameter>
+
             <parameter name="zigbee_initialise" type="boolean" groupName="network">
                 <label>Reset Controller</label>
                 <description>Resets the Controller and sets the configuration to the configured values.</description>

--- a/org.openhab.binding.zigbee.ember/META-INF/MANIFEST.MF
+++ b/org.openhab.binding.zigbee.ember/META-INF/MANIFEST.MF
@@ -12,6 +12,7 @@ Export-Package:
  org.openhab.binding.zigbee.ember.handler
 Import-Package: com.zsmartsystems.zigbee,
  com.zsmartsystems.zigbee.dongle.ember,
+ com.zsmartsystems.zigbee.dongle.ember.ezsp.structure,
  com.zsmartsystems.zigbee.serialization,
  com.zsmartsystems.zigbee.transport,
  gnu.io,

--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.dongle.ember.ZigBeeDongleEzsp;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspConfigId;
 import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
 import com.zsmartsystems.zigbee.serialization.DefaultSerializer;
 import com.zsmartsystems.zigbee.transport.TransportConfig;
@@ -31,7 +32,6 @@ import com.zsmartsystems.zigbee.transport.ZigBeePort.FlowControl;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportFirmwareCallback;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportFirmwareStatus;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportFirmwareUpdate;
-import com.zsmartsystems.zigbee.transport.ZigBeeTransportTransmit;
 
 /**
  * The {@link EmberHandler} is responsible for handling commands, which are
@@ -66,11 +66,12 @@ public class EmberHandler extends ZigBeeCoordinatorHandler implements FirmwareUp
         }
 
         ZigBeePort serialPort = new ZigBeeSerialPort(config.zigbee_port, config.zigbee_baud, flowControl);
-        final ZigBeeTransportTransmit dongle = new ZigBeeDongleEzsp(serialPort);
+        final ZigBeeDongleEzsp dongle = new ZigBeeDongleEzsp(serialPort);
 
         logger.debug("ZigBee Ember Coordinator opening Port:'{}' PAN:{}, EPAN:{}, Channel:{}", config.zigbee_port,
                 Integer.toHexString(panId), extendedPanId, Integer.toString(channelId));
 
+        dongle.updateDefaultConfiguration(EzspConfigId.EZSP_CONFIG_TX_POWER_MODE, config.zigbee_powermode);
         TransportConfig transportConfig = new TransportConfig();
 
         startZigBee(dongle, transportConfig, DefaultSerializer.class, DefaultDeserializer.class);

--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/internal/EmberConfiguration.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/internal/EmberConfiguration.java
@@ -18,4 +18,5 @@ public class EmberConfiguration {
     public String zigbee_port;
     public Integer zigbee_baud;
     public Integer zigbee_flowcontrol;
+    public Integer zigbee_powermode;
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -162,6 +162,8 @@ public class ZigBeeBindingConstants {
     public static final String CONFIGURATION_PASSWORD = "zigbee_password";
     public static final String CONFIGURATION_INITIALIZE = "zigbee_initialise";
     public static final String CONFIGURATION_TRUSTCENTREMODE = "zigbee_trustcentremode";
+    public static final String CONFIGURATION_POWERMODE = "zigbee_powermode";
+    public static final String CONFIGURATION_TXPOWER = "zigbee_txpower";
 
     public final static String CONFIGURATION_MACADDRESS = "zigbee_macaddress";
     public final static String CONFIGURATION_JOINENABLE = "zigbee_joinenable";

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -99,7 +99,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
 
     private TransportConfig transportConfig;
 
-    private final Set<ZigBeeNetworkNodeListener> listeners = new HashSet<ZigBeeNetworkNodeListener>();
+    private final Set<ZigBeeNetworkNodeListener> listeners = new HashSet<>();
 
     private boolean macAddressSet = false;
 
@@ -467,6 +467,11 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
                     transportConfig.addOption(TransportConfigOption.TRUST_CENTRE_JOIN_MODE, linkMode);
                     break;
 
+                case ZigBeeBindingConstants.CONFIGURATION_TXPOWER:
+                    transportConfig.addOption(TransportConfigOption.RADIO_TX_POWER, configurationParameter.getValue());
+                    break;
+
+                case ZigBeeBindingConstants.CONFIGURATION_POWERMODE:
                 case ZigBeeBindingConstants.CONFIGURATION_BAUD:
                 case ZigBeeBindingConstants.CONFIGURATION_FLOWCONTROL:
                 case ZigBeeBindingConstants.CONFIGURATION_PORT:


### PR DESCRIPTION
Provides two options in Ember -:

* Boost most, which improves the receive performance at the expense of power consumption. Given the coordinator will nearly always be plugged into a mains powered system, this is the default.
* TX Power - allows the transmit power to be set up to 8dBm to improve transmit performance.

Closes #243 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>