### PR TITLE
Set the default link key

### DIFF
--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -10,6 +10,23 @@ A ZigBee Coordinator is the network controller, and is therefore the heart of th
 
 Coordinators need to be installed manually and the serial port and baud rate must be set. These are set to match the configuration that the dongle is in. Should you wish to use a different baud rate than the default speed of the device, you must change the configuration of the dongle using some other, and then configure the binding to match your change. If in doubt, you should leave the settings at their default values which should work in most cases.
 
+#### Coordinator Configuration
+
+##### Link Key (zigbee_linkkey)
+
+The key is defined as 16 hexadecimal values. If not defined, this will default to the well known ZigBee HA link key.
+
+If defined with the word ```INSTALLCODE:``` before the key, this will create a link key from an install code which may be shorter than 16 bytes.
+
+eg ```5A 69 67 42 65 65 41 6C 6C 69 61 6E 63 65 30 39```
+eg ```INSTALLCODE:00 11 22 33 44 55 66 77```
+
+##### Network Key (zigbee_networkkey)
+
+The key is defined as 16 hexadecimal values. If not defined, a random key will be created.
+
+#### Supported Coordinators
+
 The following coordinators are known to be supported.
 
 | Name and Link              | Coordinator | Comment                       |

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -159,6 +159,7 @@ public class ZigBeeBindingConstants {
     public final static String CONFIGURATION_BAUD = "zigbee_baud";
     public final static String CONFIGURATION_FLOWCONTROL = "zigbee_flowcontrol";
     public static final String CONFIGURATION_NETWORKKEY = "zigbee_networkkey";
+    public static final String CONFIGURATION_LINKKEY = "zigbee_linkkey";
     public static final String CONFIGURATION_PASSWORD = "zigbee_password";
     public static final String CONFIGURATION_INITIALIZE = "zigbee_initialise";
     public static final String CONFIGURATION_TRUSTCENTREMODE = "zigbee_trustcentremode";

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -95,6 +95,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
 
     private ZigBeeNetworkStateSerializerImpl networkStateSerializer;
 
+    protected ZigBeeKey linkKey;
     protected ZigBeeKey networkKey;
 
     private TransportConfig transportConfig;
@@ -116,6 +117,12 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
 
     private volatile boolean bridgeRemoved = false;
 
+    /**
+     * Default ZigBeeAlliance09 link key
+     */
+    private final static ZigBeeKey KEY_ZIGBEE_ALLIANCE_O9 = new ZigBeeKey(new int[] { 0x5A, 0x69, 0x67, 0x42, 0x65,
+            0x65, 0x41, 0x6C, 0x6C, 0x69, 0x61, 0x6E, 0x63, 0x65, 0x30, 0x39 });
+
     public ZigBeeCoordinatorHandler(Bridge coordinator) {
         super(coordinator);
     }
@@ -126,6 +133,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
         panId = 0xffff;
         channelId = 0;
         initializeNetwork = false;
+        String linkKeyString = "";
         String networkKeyString = "";
 
         try {
@@ -145,11 +153,16 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
             }
 
             Object param = getConfig().get(CONFIGURATION_NETWORKKEY);
-            logger.debug("Key {}", getConfig().get(CONFIGURATION_NETWORKKEY));
+            logger.debug("Network Key {}", getConfig().get(CONFIGURATION_NETWORKKEY));
             if (param != null && param instanceof String) {
                 networkKeyString = (String) param;
             }
 
+            param = getConfig().get(CONFIGURATION_LINKKEY);
+            logger.debug("Link Key {}", getConfig().get(CONFIGURATION_LINKKEY));
+            if (param != null && param instanceof String) {
+                linkKeyString = (String) param;
+            }
         } catch (ClassCastException | NumberFormatException e) {
             logger.error("{}: ZigBee initialisation exception ", thing.getUID(), e);
             updateStatus(ThingStatus.OFFLINE);
@@ -225,10 +238,9 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
             }
         }
 
-        logger.debug("Key String {}", networkKeyString);
-
         // Process the network key
         try {
+            logger.debug("Network Key String {}", networkKeyString);
             networkKey = new ZigBeeKey(networkKeyString);
         } catch (IllegalArgumentException e) {
             networkKey = new ZigBeeKey();
@@ -237,10 +249,21 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
         // If no key exists, generate a random key and save it back to the configuration
         if (!networkKey.isValid()) {
             networkKey = ZigBeeKey.createRandom();
-            logger.debug("Key initialised {}", networkKey);
+            logger.debug("Network key initialised {}", networkKey);
         }
 
-        logger.debug("Key final array {}", networkKey);
+        logger.debug("Network key final array {}", networkKey);
+
+        // Process the link key
+        try {
+            logger.debug("Link Key String {}", linkKeyString);
+            linkKey = new ZigBeeKey(linkKeyString);
+        } catch (IllegalArgumentException e) {
+            linkKey = KEY_ZIGBEE_ALLIANCE_O9;
+            logger.debug("Link Key String has invalid format. Revert to default key.");
+        }
+
+        logger.debug("Link key final array {}", linkKey);
     }
 
     @Override
@@ -344,8 +367,6 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
         networkManager.addExtension(new ZigBeeIasCieExtension());
         networkManager.addExtension(new ZigBeeOtaUpgradeExtension());
 
-        logger.debug("Key initialise {}", networkKey);
-
         // Add any listeners that were registered before the manager was registered
         synchronized (listeners) {
             for (ZigBeeNetworkNodeListener listener : listeners) {
@@ -375,6 +396,9 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
         ExtendedPanId currentExtendedPanId = networkManager.getZigBeeExtendedPanId();
 
         if (initializeNetwork) {
+            logger.debug("Link key initialise {}", linkKey);
+            logger.debug("Network key initialise {}", networkKey);
+            networkManager.setZigBeeLinkKey(linkKey);
             networkManager.setZigBeeNetworkKey(networkKey);
             networkManager.setZigBeeChannel(ZigBeeChannel.create(channelId));
             networkManager.setZigBeePanId(panId);


### PR DESCRIPTION
Recent Ember dongle driver does not set the default link key, so at the moment, the link key won't be set during initialisation.  Other dongles should also be updated in future so this ensures the standard link key is set.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>