### PR TITLE
Protect against getNodes being called before network is up

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -707,6 +707,9 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
      * @return the set of {@link ZigBeeNode}s
      */
     public Set<ZigBeeNode> getNodes() {
+        if (networkManager == null) {
+            return Collections.emptySet();
+        }
         return networkManager.getNodes();
     }
 


### PR DESCRIPTION
Adds protection in the event that ```getNodes()``` is called before the network is initialised.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>