### PR TITLE
Minor updates for Ember config and Bridge config updates

### DIFF
--- a/org.openhab.binding.zigbee.ember/ESH-INF/thing/controller_ember.xml
+++ b/org.openhab.binding.zigbee.ember/ESH-INF/thing/controller_ember.xml
@@ -15,14 +15,26 @@
 				<description></description>
 			</parameter-group>
 
-			<parameter name="zigbee_port" type="text" required="true">
+			<parameter-group name="port">
+				<context></context>
+				<label>Serial Port Configuration</label>
+				<description></description>
+			</parameter-group>
+
+			<parameter-group name="ember">
+				<context></context>
+				<label>Ember NCP Configuration</label>
+				<description></description>
+			</parameter-group>
+
+			<parameter name="zigbee_port" type="text" required="true" groupName="port">
 				<label>Port</label>
 				<context>serial-port</context>
 				<default></default>
 				<description>Serial Port</description>
 			</parameter>
 
-			<parameter name="zigbee_flowcontrol" type="integer" required="true">
+			<parameter name="zigbee_flowcontrol" type="integer" required="true" groupName="port">
 				<label>Flow Control</label>
 				<description>Serial Port Flow Control</description>
 				<default>1</default>
@@ -33,7 +45,7 @@
 				</options>
 			</parameter>
 
-			<parameter name="zigbee_baud" type="integer" required="true">
+			<parameter name="zigbee_baud" type="integer" required="true" groupName="port">
 				<label>Baud Rate</label>
 				<description>Serial Port Baud Rate</description>
 				<default>115200</default>
@@ -44,15 +56,9 @@
 				</options>
 			</parameter>
 
-			<parameter name="zigbee_installcode" type="text">
-				<label>Install Code</label>
-				<description>Add a temporary install key for device</description>
-				<advanced>true</advanced>
-			</parameter>
-
-			<parameter name="zigbee_powermode" type="integer">
+			<parameter name="zigbee_powermode" type="integer" groupName="ember">
 				<label>Power Mode</label>
-				<description>Sets the Ember power mode. Boost mode will improve receive and transmit performance.</description>
+				<description>Sets the Ember power mode. Boost mode will improve receive and transmit performance</description>
 				<default>1</default>
 				<options>
 					<option value="0">Normal</option>
@@ -60,9 +66,9 @@
 				</options>
 			</parameter>
 
-			<parameter name="zigbee_txpower" type="integer" min="0" max="8">
-				<label>Power Mode</label>
-				<description>Sets the Ember transmit power.</description>
+			<parameter name="zigbee_txpower" type="integer" min="0" max="8" groupName="ember">
+				<label>Transmit Power</label>
+				<description>Sets the Ember transmit power</description>
 				<default>0</default>
 				<options>
 					<option value="8">High</option>
@@ -72,8 +78,9 @@
 
 			<parameter name="zigbee_initialise" type="boolean" groupName="network">
 				<label>Reset Controller</label>
-				<description>Resets the Controller and sets the configuration to the configured values.</description>
+				<description>Resets the Controller and sets the configuration to the configured values</description>
 				<default>false</default>
+				<verify>true</verify>
 				<advanced>true</advanced>
 			</parameter>
 
@@ -115,8 +122,12 @@
 
 			<parameter name="zigbee_extendedpanid" type="text" groupName="network" required="false">
 				<label>Extended PAN ID</label>
-				<description>Extended PAN Network ID: 16 byte hexadecimal value</description>
+				<description>Extended PAN Network ID: 8 byte hexadecimal value</description>
 				<default>0000000000000000</default>
+				<options>
+					<option value="0000000000000000">Auto</option>
+				</options>
+				<limitToOptions>false</limitToOptions>
 				<advanced>true</advanced>
 			</parameter>
 
@@ -124,6 +135,27 @@
 				<label>Network Security Key</label>
 				<description>Set the network security key</description>
 				<default>00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00</default>
+				<options>
+					<option value="00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00">Auto</option>
+				</options>
+				<limitToOptions>false</limitToOptions>
+				<advanced>true</advanced>
+			</parameter>
+
+			<parameter name="zigbee_linkkey" type="text" groupName="network">
+				<label>Link Security Key</label>
+				<description>Set the link security key</description>
+				<default>5A 69 67 42 65 65 41 6C 6C 69 61 6E 63 65 30 39</default>
+				<options>
+					<option value="5A 69 67 42 65 65 41 6C 6C 69 61 6E 63 65 30 39">ZigBee Alliance 09</option>
+				</options>
+				<limitToOptions>false</limitToOptions>
+				<advanced>true</advanced>
+			</parameter>
+
+			<parameter name="zigbee_installcode" type="text" groupName="network">
+				<label>Install Code</label>
+				<description>Add a temporary install key for device installation</description>
 				<advanced>true</advanced>
 			</parameter>
 

--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -14,7 +14,7 @@ Coordinators need to be installed manually and the serial port and baud rate mus
 
 ##### Link Key (zigbee_linkkey)
 
-The key is defined as 16 hexadecimal values. If not defined, this will default to the well known ZigBee HA link key.
+The key is defined as 16 hexadecimal values. If not defined, this will default to the well known ZigBee HA link key which is required for ZigBee HA 1.2 devices. Do not alter this key if using with a ZigBee HA 1.2 network unless you fully understand the impact.
 
 If defined with the word ```INSTALLCODE:``` before the key, this will create a link key from an install code which may be shorter than 16 bytes.
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -82,8 +83,8 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
         implements Identifiable<ThingUID>, ZigBeeNetworkStateListener, ZigBeeNetworkNodeListener {
     private final Logger logger = LoggerFactory.getLogger(ZigBeeCoordinatorHandler.class);
 
-    protected int panId;
-    protected int channelId;
+    protected Integer panId;
+    protected Integer channelId;
     protected ExtendedPanId extendedPanId;
 
     private IeeeAddress nodeIeeeAddress = null;
@@ -180,6 +181,32 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
             initializeNetwork = true;
         }
 
+        // Process the network key
+        try {
+            logger.debug("Network Key String {}", networkKeyString);
+            networkKey = new ZigBeeKey(networkKeyString);
+        } catch (IllegalArgumentException e) {
+            networkKey = new ZigBeeKey();
+            logger.debug("Network Key String has invalid format. Revert to default key.");
+        }
+
+        // If no key exists, generate a random key and save it back to the configuration
+        if (!networkKey.isValid()) {
+            networkKey = ZigBeeKey.createRandom();
+            logger.debug("Network key initialised {}", networkKey);
+        }
+
+        logger.debug("Network key final array {}", networkKey);
+
+        // Process the link key
+        try {
+            logger.debug("Link Key String {}", linkKeyString);
+            linkKey = new ZigBeeKey(linkKeyString);
+        } catch (IllegalArgumentException e) {
+            linkKey = KEY_ZIGBEE_ALLIANCE_O9;
+            logger.debug("Link Key String has invalid format. Revert to default key.");
+        }
+
         if (initializeNetwork) {
             logger.debug("Initialising network");
 
@@ -230,38 +257,15 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
             }
 
             try {
-                // Reset the initialization flag
+                // Reset the initialization flag and save the keys
                 Configuration configuration = editConfiguration();
+                configuration.put(CONFIGURATION_LINKKEY, linkKey.toString());
+                configuration.put(CONFIGURATION_NETWORKKEY, networkKey.toString());
                 configuration.put(CONFIGURATION_INITIALIZE, false);
                 updateConfiguration(configuration);
             } catch (IllegalStateException e) {
-                logger.error("Error updating configuration: Unable to reset initialize flag. ", e);
+                logger.error("Error updating configuration: Unable to reset initialize flag and save keys. ", e);
             }
-        }
-
-        // Process the network key
-        try {
-            logger.debug("Network Key String {}", networkKeyString);
-            networkKey = new ZigBeeKey(networkKeyString);
-        } catch (IllegalArgumentException e) {
-            networkKey = new ZigBeeKey();
-        }
-
-        // If no key exists, generate a random key and save it back to the configuration
-        if (!networkKey.isValid()) {
-            networkKey = ZigBeeKey.createRandom();
-            logger.debug("Network key initialised {}", networkKey);
-        }
-
-        logger.debug("Network key final array {}", networkKey);
-
-        // Process the link key
-        try {
-            logger.debug("Link Key String {}", linkKeyString);
-            linkKey = new ZigBeeKey(linkKeyString);
-        } catch (IllegalArgumentException e) {
-            linkKey = KEY_ZIGBEE_ALLIANCE_O9;
-            logger.debug("Link Key String has invalid format. Revert to default key.");
         }
 
         logger.debug("Link key final array {}", linkKey);
@@ -479,6 +483,17 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
         boolean reinitialise = false;
         Configuration configuration = editConfiguration();
         for (Entry<String, Object> configurationParameter : configurationParameters.entrySet()) {
+            // Ignore any configuration parameters that have not changed
+            if (Objects.equals(configurationParameter.getValue(), configuration.get(configurationParameter.getKey()))) {
+                logger.debug("{}: Configuration update: Ignored {} as no change", nodeIeeeAddress,
+                        configurationParameter.getKey());
+                continue;
+            }
+
+            logger.debug("{}: Configuration update: Processing {} -> {}", nodeIeeeAddress,
+                    configurationParameter.getKey(), configurationParameter.getValue());
+
+            boolean saveConfig = true;
             switch (configurationParameter.getKey()) {
                 case ZigBeeBindingConstants.CONFIGURATION_JOINENABLE:
                     if ((Boolean) configurationParameter.getValue()) {
@@ -496,17 +511,22 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
                     transportConfig.addOption(TransportConfigOption.RADIO_TX_POWER, configurationParameter.getValue());
                     break;
 
+                case ZigBeeBindingConstants.CONFIGURATION_LINKKEY:
+                case ZigBeeBindingConstants.CONFIGURATION_NETWORKKEY:
                 case ZigBeeBindingConstants.CONFIGURATION_POWERMODE:
                 case ZigBeeBindingConstants.CONFIGURATION_BAUD:
                 case ZigBeeBindingConstants.CONFIGURATION_FLOWCONTROL:
                 case ZigBeeBindingConstants.CONFIGURATION_PORT:
+                case ZigBeeBindingConstants.CONFIGURATION_CHANNEL:
+                case ZigBeeBindingConstants.CONFIGURATION_EXTENDEDPANID:
+                case ZigBeeBindingConstants.CONFIGURATION_INITIALIZE:
                     reinitialise = true;
                     break;
 
                 case ZigBeeBindingConstants.THING_PROPERTY_INSTALLCODE:
                     addInstallCode((String) configurationParameter.getValue());
                     // Don't save this - it's a transient key
-                    configurationParameter.setValue("");
+                    saveConfig = false;
                     break;
 
                 default:
@@ -516,7 +536,9 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
                     continue;
             }
 
-            configuration.put(configurationParameter.getKey(), configurationParameter.getValue());
+            if (saveConfig) {
+                configuration.put(configurationParameter.getKey(), configurationParameter.getValue());
+            }
         }
 
         // Persist changes
@@ -541,6 +563,10 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
      * @param transportConfig the {@link TransportConfig} to populate with the configuration
      */
     private void addInstallCode(String installCode) {
+        if (installCode == null || installCode.isEmpty()) {
+            return;
+        }
+
         // Split the install code and the address
         String[] codeParts = installCode.split(":");
         if (codeParts.length != 2) {


### PR DESCRIPTION
This tidies up a few minor issues in the Ember dongle and coordinator handler -:

* Regroups the configuration parameters, and moves them into a more logical order so they appear more meaningfully in the UI.
* Moves the processing of the keys before the initialisation code so that keys can be updated if they are modified by the init code. This ensures the UI is consistent with the configuration.
* Fixes a bug in the install code processing as Paper UI is passing NULL if it is not set.
* Ignores configuration parameters that have not changed. This prevents the bridge being reinitialised if there are really no changes to the config since PaperUI passes all configuration even if there are no changes.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>