### PR TITLE
Fix minor bugs in on/off converter

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -66,6 +66,8 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
                         pollingPeriod = POLLING_PERIOD_HIGH;
                     }
                 } else {
+                    logger.error("{}: Error 0x{} setting server binding", endpoint.getIeeeAddress(),
+                            Integer.toHexString(bindResponse.getStatusCode()));
                     pollingPeriod = POLLING_PERIOD_HIGH;
                 }
             } catch (InterruptedException | ExecutionException e) {
@@ -79,18 +81,12 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
         if (clusterOnOffClient != null) {
             try {
                 CommandResult bindResponse = clusterOnOffClient.bind().get();
-                if (bindResponse.isSuccess()) {
-                    // Configure reporting - no faster than once per second - no slower than 10 minutes.
-                    CommandResult reportingResponse = clusterOnOffClient
-                            .setOnOffReporting(1, REPORTING_PERIOD_DEFAULT_MAX).get();
-                    if (reportingResponse.isError()) {
-                        pollingPeriod = POLLING_PERIOD_HIGH;
-                    }
-                } else {
-                    pollingPeriod = POLLING_PERIOD_HIGH;
+                if (!bindResponse.isSuccess()) {
+                    logger.error("{}: Error 0x{} setting client binding", endpoint.getIeeeAddress(),
+                            Integer.toHexString(bindResponse.getStatusCode()));
                 }
             } catch (InterruptedException | ExecutionException e) {
-                logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+                logger.error("{}: Exception setting binding ", endpoint.getIeeeAddress(), e);
             }
 
             // Add the command listener
@@ -105,7 +101,7 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
         logger.debug("{}: Closing device on/off cluster", endpoint.getIeeeAddress());
 
         if (clusterOnOffClient != null) {
-            clusterOnOffClient.removeAttributeListener(this);
+            clusterOnOffClient.removeCommandListener(this);
         }
         if (clusterOnOffServer != null) {
             clusterOnOffServer.removeAttributeListener(this);
@@ -114,9 +110,6 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
 
     @Override
     public void handleRefresh() {
-        if (clusterOnOffClient != null) {
-            clusterOnOffClient.getOnOff(0);
-        }
         if (clusterOnOffServer != null) {
             clusterOnOffServer.getOnOff(0);
         }


### PR DESCRIPTION
This fixes two minor bugs in the on/off converter -:

1. We register a command listener for the client, but we unregister and attribute listener - updated to unregister the command listener.
2. The client doesn't support attributes so we should not request them in the refresh or configure attribute reporting.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>