### PR TITLE
Reinitialise the thing and all converters if the bridge goes offline/online

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -134,6 +134,12 @@ public class ZigBeeThingHandler extends BaseThingHandler
 
         if (bridgeStatusInfo.getStatus() != ThingStatus.ONLINE || getBridge() == null) {
             logger.debug("{}: Coordinator is unknown or not online.", nodeIeeeAddress);
+
+            // The bridge has gone offline. In order to avoid any issues with data that is cached in the converters
+            // we will reinitialise the node, and all converters, when the bridge comes back online.
+            nodeInitialised = false;
+
+            stopPolling();
             return;
         }
 
@@ -183,6 +189,9 @@ public class ZigBeeThingHandler extends BaseThingHandler
         propertyDiscoverer.setProperties(getThing().getProperties());
         Map<String, String> newProperties = propertyDiscoverer.getProperties(node);
         updateProperties(newProperties);
+
+        // Clear the channels in case we are reinitialising
+        channels.clear();
 
         // Create the channel factory
         ZigBeeChannelConverterFactory factory = new ZigBeeChannelConverterFactory();


### PR DESCRIPTION
This is a proposed fix for #233 to ensure that the node is always initialised with the current instant of the ```ZigBeeNetworkManager```.

If the bridge goes offline, then we reset the ```nodeInitialised``` flag and stop polling (this is not really related, but I wanted to ensure it is stopped when we reinitialise). When the bridge comes back online, the ```doNodeInitialisation()``` method will be called, and the node will be initialised again.

@hsudbrock I've not really tested this - if you have the opportunity to test this it would be good. I don't see any downside of this, but happy to discuss...

Signed-off-by: Chris Jackson <chris@cd-jackson.com>