### PR TITLE
Improve logging when commands received by the binding

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/internal/ZigBeeDefaultDiscoveryParticipant.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/internal/ZigBeeDefaultDiscoveryParticipant.java
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.openhab.binding.zigbee.discovery.internal;
 
 import java.util.Map;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -423,7 +423,8 @@ public class ZigBeeThingHandler extends BaseThingHandler
 
     @Override
     public void handleCommand(final ChannelUID channelUID, final Command command) {
-        logger.debug("{}: Command for channel {} --> {}", nodeIeeeAddress, channelUID, command);
+        logger.debug("{}: Command for channel {} --> {} [{}]", nodeIeeeAddress, channelUID, command,
+                command.getClass().getSimpleName());
 
         // Check that we have a coordinator to work through
         if (coordinatorHandler == null) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeBaseChannelConverter.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeBaseChannelConverter.java
@@ -43,7 +43,8 @@ import com.zsmartsystems.zigbee.zcl.ZclCluster;
  * required features are available. If so, it should return the channel. This method allows dynamic channel detection
  * for unknown devices and may not be called if a device is defined through another mechanism.
  * <li>The thing handler will call the
- * {@link ZigBeeBaseChannelConverter#initialize(ZigBeeThingHandler, Channel, ZigBeeCoordinatorHandler, IeeeAddress, int)} to initialise the
+ * {@link ZigBeeBaseChannelConverter#initialize(ZigBeeThingHandler, Channel, ZigBeeCoordinatorHandler, IeeeAddress, int)}
+ * to initialise the
  * channel converter. The converter should get any clusters via the
  * {@link ZigBeeCoordinatorHandler#getEndpoint(IeeeAddress, int)} and {@link ZigBeeEndpoint#getInputCluster(int)} or
  * {@link ZigBeeEndpoint#getOutputCluster(int)}. It should configure the binding by calling {@link ZclCluster#bind()}
@@ -75,6 +76,11 @@ public abstract class ZigBeeBaseChannelConverter {
      * Our logger
      */
     private Logger logger = LoggerFactory.getLogger(ZigBeeBaseChannelConverter.class);
+
+    /**
+     * Default minimum reporting period. Should be short to ensure we get dynamic state changes in a reasonable time
+     */
+    protected final int REPORTING_PERIOD_DEFAULT_MIN = 1;
 
     /**
      * Default maximum reporting period
@@ -124,8 +130,10 @@ public abstract class ZigBeeBaseChannelConverter {
 
     /**
      * The polling period used for this channel in seconds. Normally this should be left at the default
-     * ({@link ZigBeeBaseChannelConverter#POLLING_PERIOD_DEFAULT}), however if the channel does not support reporting, it can be set to a higher
-     * period such as {@link ZigBeeBaseChannelConverter#POLLING_PERIOD_HIGH}. Any period may be used, however it is recommended to use these
+     * ({@link ZigBeeBaseChannelConverter#POLLING_PERIOD_DEFAULT}), however if the channel does not support reporting,
+     * it can be set to a higher
+     * period such as {@link ZigBeeBaseChannelConverter#POLLING_PERIOD_HIGH}. Any period may be used, however it is
+     * recommended to use these
      * standard settings.
      */
     protected int pollingPeriod = POLLING_PERIOD_DEFAULT;
@@ -236,7 +244,8 @@ public abstract class ZigBeeBaseChannelConverter {
      * Gets the configuration descriptions required to configure this channel.
      * <p>
      * Ideally, implementations should use the {@link ZclCluster#discoverAttributes(boolean)} method and the
-     * {@link ZclCluster#isAttributeSupported(int)} method to understand exactly what the device supports and only provide
+     * {@link ZclCluster#isAttributeSupported(int)} method to understand exactly what the device supports and only
+     * provide
      * configuration as necessary.
      * <p>
      * This method should not be overridden - the {@link #configOptions} list should be populated during converter
@@ -250,8 +259,10 @@ public abstract class ZigBeeBaseChannelConverter {
 
     /**
      * Gets the polling period for this channel in seconds. Normally this should be left at the default
-     * ({@link ZigBeeBaseChannelConverter#POLLING_PERIOD_DEFAULT}), however if the channel does not support reporting, it can be set to a higher
-     * period such as {@link ZigBeeBaseChannelConverter#POLLING_PERIOD_HIGH} during the converter initialisation. Any period may be used, however
+     * ({@link ZigBeeBaseChannelConverter#POLLING_PERIOD_DEFAULT}), however if the channel does not support reporting,
+     * it can be set to a higher
+     * period such as {@link ZigBeeBaseChannelConverter#POLLING_PERIOD_HIGH} during the converter initialisation. Any
+     * period may be used, however
      * it is recommended to use these standard settings.
      *
      * @return the polling period for this channel in seconds
@@ -262,7 +273,7 @@ public abstract class ZigBeeBaseChannelConverter {
 
     /**
      * Creates a standard channel UID given the {@link ZigBeeEndpoint}
-     * 
+     *
      * @param thingUID the {@link ThingUID}
      * @param endpoint the {@link ZigBeeEndpoint}
      * @param channelName the name of the channel
@@ -275,7 +286,7 @@ public abstract class ZigBeeBaseChannelConverter {
     /**
      * Creates a set of properties, adding the standard properties required by the system.
      * Channel converters may add additional properties prior to creating the channel.
-     * 
+     *
      * @param endpoint the {@link ZigBeeEndpoint}
      * @return an initial properties map
      */

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -59,9 +59,9 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
             try {
                 CommandResult bindResponse = clusterOnOffServer.bind().get();
                 if (bindResponse.isSuccess()) {
-                    // Configure reporting - no faster than once per second - no slower than 10 minutes.
+                    // Configure reporting
                     CommandResult reportingResponse = clusterOnOffServer
-                            .setOnOffReporting(1, REPORTING_PERIOD_DEFAULT_MAX).get();
+                            .setOnOffReporting(REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX).get();
                     if (reportingResponse.isError()) {
                         pollingPeriod = POLLING_PERIOD_HIGH;
                     }
@@ -117,6 +117,12 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
 
     @Override
     public void handleCommand(final Command command) {
+        if (clusterOnOffServer == null) {
+            logger.warn("{}: OnOff converter is not linked to a server and cannot accept commands",
+                    endpoint.getIeeeAddress());
+            return;
+        }
+
         OnOffType cmdOnOff = null;
         if (command instanceof PercentType) {
             if (((PercentType) command).intValue() == 0) {
@@ -126,6 +132,10 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
             }
         } else if (command instanceof OnOffType) {
             cmdOnOff = (OnOffType) command;
+        } else {
+            logger.warn("{}: OnOff converter only accepts PercentType and OnOffType - not {}",
+                    endpoint.getIeeeAddress(), command.getClass().getSimpleName());
+            return;
         }
 
         if (cmdOnOff == OnOffType.ON) {

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/discovery/internal/ZigBeeDefaultDiscoveryParticipantTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/discovery/internal/ZigBeeDefaultDiscoveryParticipantTest.java
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.openhab.binding.zigbee.discovery.internal;
 
 import static org.junit.Assert.assertEquals;

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandlerTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandlerTest.java
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.openhab.binding.zigbee.handler;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
Improves logging when commands received by adding the command class to the log entry. Also added a log in the OnOff converter if the command type is not supported (log entry is the same as used in the LevelControl converter).
I also ran the license formatter, so there are a few other changes to some files as a result.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>