### PR TITLE
Do not synchronize on 'this' when closing the serial port

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeSerialPort.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeSerialPort.java
@@ -178,20 +178,21 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
     public void close() {
         try {
             if (serialPort != null) {
+                serialPort.removeEventListener();
+                serialPort.enableReceiveTimeout(1);
+
+                outputStream.flush();
+
+                inputStream.close();
+                outputStream.close();
+
+                serialPort.close();
+
+                serialPort = null;
+                inputStream = null;
+                outputStream = null;
+
                 synchronized (this) {
-                    serialPort.removeEventListener();
-                    serialPort.enableReceiveTimeout(1);
-
-                    outputStream.flush();
-
-                    inputStream.close();
-                    outputStream.close();
-
-                    serialPort.close();
-
-                    serialPort = null;
-                    inputStream = null;
-                    outputStream = null;
                     this.notify();
                 }
 


### PR DESCRIPTION
Fixes #276 

The deadlock described in #276 happens because the call to `removeEventListener` is within a `synchronized(this)` block. This PR pushes all statements for closing the port out of this synchronized block, except the final call to `notify` (as one must own the object's monitor to notify).

@cdjackson I am wondering whether I break something by moving more than the call to `removeEventListener` out of the `synchronized` block. Do you recall the reason that the other commands for closing the port were inside the `synchronized` block?