### PR TITLE
Add thing level cluster configuration

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
@@ -337,15 +337,16 @@ public abstract class ZigBeeBaseChannelConverter {
     }
 
     /**
-     * Update the channel configuration. This is called by the Thing Handler if the user updates the channel
-     * configuration.
+     * Processes the updated configuration. As required, the method shall process each known configuration parameter and
+     * set a local variable for local parameters, and update the remote device for remote parameters.
+     * The currentConfiguration shall be updated.
      *
-     * @param configuration the channel {@link Configuration}
-     * @return the updated {@link Configuration} to persist to handler configuration
+     * @param currentConfiguration the current {@link Configuration}
+     * @param updatedParameters a map containing the updated configuration parameters to be set
      */
-    public Configuration updateConfiguration(@NonNull Configuration configuration) {
-        // Nothing required as default implementation
-        return new Configuration();
+    public void updateConfiguration(@NonNull Configuration currentConfiguration,
+            Map<String, Object> updatedParameters) {
+        // Nothing required in default implementation
     }
 
     /**

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -135,11 +135,17 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
     /**
      * The factory to create the converters for the different channels.
      */
-    private final ZigBeeChannelConverterFactory factory;
+    private final ZigBeeChannelConverterFactory channelFactory;
 
-    public ZigBeeThingHandler(Thing zigbeeDevice, ZigBeeChannelConverterFactory factory) {
+    /**
+     * Creates a ZigBee thing.
+     *
+     * @param zigbeeDevice the {@link Thing}
+     * @param channelFactory the {@link ZigBeeChannelConverterFactory} to be used to create the channels
+     */
+    public ZigBeeThingHandler(Thing zigbeeDevice, ZigBeeChannelConverterFactory channelFactory) {
         super(zigbeeDevice);
-        this.factory = factory;
+        this.channelFactory = channelFactory;
     }
 
     @Override
@@ -235,8 +241,6 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
             configHandlers.addAll(handlers);
         }
 
-        // Create the channel factory
-        ZigBeeChannelConverterFactory channelFactory = new ZigBeeChannelConverterFactory();
         List<Channel> nodeChannels;
 
         if (getThing().getThingTypeUID().equals(ZigBeeBindingConstants.THING_TYPE_GENERIC_DEVICE)) {
@@ -250,7 +254,6 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
             logger.debug("{}: Dynamically created {} channels", nodeIeeeAddress, nodeChannels.size());
 
             try {
-                // List<ConfigDescriptionParameterGroup> groups = new ArrayList<ConfigDescriptionParameterGroup>();
                 List<ConfigDescriptionParameter> parameters = new ArrayList<ConfigDescriptionParameter>();
 
                 for (ZclClusterConfigHandler handler : configHandlers) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -9,6 +9,7 @@
 package org.openhab.binding.zigbee.handler;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -30,6 +32,7 @@ import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.ConfigDescription;
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 import org.eclipse.smarthome.config.core.ConfigDescriptionProvider;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -54,6 +57,8 @@ import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
 import org.openhab.binding.zigbee.discovery.ZigBeeNodePropertyDiscoverer;
 import org.openhab.binding.zigbee.internal.ZigBeeDeviceConfigHandler;
 import org.openhab.binding.zigbee.internal.converter.ZigBeeChannelConverterFactory;
+import org.openhab.binding.zigbee.internal.converter.config.ZclClusterConfigFactory;
+import org.openhab.binding.zigbee.internal.converter.config.ZclClusterConfigHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,6 +97,16 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
      * The map of all the channels defined for this thing
      */
     private final Map<ChannelUID, ZigBeeBaseChannelConverter> channels = new HashMap<>();
+
+    /**
+     * A list of all the configuration handlers at node level.
+     */
+    private final List<ZclClusterConfigHandler> configHandlers = new ArrayList<>();
+
+    /**
+     * The configuration description if dynamically generated
+     */
+    private ConfigDescription configDescription;
 
     /**
      * The {@link IeeeAddress} for this device
@@ -213,6 +228,15 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
         // Clear the channels in case we are reinitialising
         channels.clear();
 
+        // Get the configuration handlers applicable for the thing
+        ZclClusterConfigFactory configFactory = new ZclClusterConfigFactory();
+        for (ZigBeeEndpoint endpoint : coordinatorHandler.getNodeEndpoints(nodeIeeeAddress)) {
+            List<ZclClusterConfigHandler> handlers = configFactory.getConfigHandlers(endpoint);
+            configHandlers.addAll(handlers);
+        }
+
+        // Create the channel factory
+        ZigBeeChannelConverterFactory channelFactory = new ZigBeeChannelConverterFactory();
         List<Channel> nodeChannels;
 
         if (getThing().getThingTypeUID().equals(ZigBeeBindingConstants.THING_TYPE_GENERIC_DEVICE)) {
@@ -221,9 +245,22 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
             nodeChannels = new ArrayList<>();
             for (ZigBeeEndpoint endpoint : coordinatorHandler.getNodeEndpoints(nodeIeeeAddress)) {
                 logger.debug("{}: Checking endpoint {} channels", nodeIeeeAddress, endpoint.getEndpointId());
-                nodeChannels.addAll(factory.getChannels(getThing().getUID(), endpoint));
+                nodeChannels.addAll(channelFactory.getChannels(getThing().getUID(), endpoint));
             }
             logger.debug("{}: Dynamically created {} channels", nodeIeeeAddress, nodeChannels.size());
+
+            try {
+                // List<ConfigDescriptionParameterGroup> groups = new ArrayList<ConfigDescriptionParameterGroup>();
+                List<ConfigDescriptionParameter> parameters = new ArrayList<ConfigDescriptionParameter>();
+
+                for (ZclClusterConfigHandler handler : configHandlers) {
+                    parameters.addAll(handler.getConfiguration());
+                }
+
+                configDescription = new ConfigDescription(new URI("thing:" + getThing().getUID()), parameters);
+            } catch (IllegalArgumentException | URISyntaxException e) {
+                logger.debug("Error creating URI for thing description:", e);
+            }
         } else {
             // We already have the correct thing type so just use the channels
             nodeChannels = getThing().getChannels();
@@ -307,7 +344,7 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
                 // Process the channel properties
                 Map<String, String> properties = channel.getProperties();
 
-                ZigBeeBaseChannelConverter handler = factory.createConverter(this, channel, coordinatorHandler,
+                ZigBeeBaseChannelConverter handler = channelFactory.createConverter(this, channel, coordinatorHandler,
                         node.getIeeeAddress(),
                         Integer.parseInt(properties.get(ZigBeeBindingConstants.CHANNEL_PROPERTY_ENDPOINT)));
                 if (handler == null) {
@@ -324,7 +361,7 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
                 handler.handleRefresh();
 
                 // TODO: Update the channel configuration from the device if method available
-                handler.updateConfiguration(channel.getConfiguration());
+                handler.updateConfiguration(new Configuration(), channel.getConfiguration().getProperties());
 
                 channels.put(channel.getUID(), handler);
 
@@ -500,6 +537,13 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
 
         Configuration configuration = editConfiguration();
         for (Entry<String, Object> configurationParameter : configurationParameters.entrySet()) {
+            // Ignore any configuration parameters that have not changed
+            if (Objects.equals(configurationParameter.getValue(), configuration.get(configurationParameter.getKey()))) {
+                logger.debug("{}: Configuration update: Ignored {} as no change", nodeIeeeAddress,
+                        configurationParameter.getKey());
+                continue;
+            }
+
             switch (configurationParameter.getKey()) {
                 case ZigBeeBindingConstants.CONFIGURATION_JOINENABLE:
                     coordinatorHandler.permitJoin(nodeIeeeAddress, 60);
@@ -507,14 +551,19 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
                 case ZigBeeBindingConstants.CONFIGURATION_LEAVE:
                     coordinatorHandler.leave(nodeIeeeAddress);
                     break;
+                default:
+                    break;
             }
+        }
+
+        for (ZclClusterConfigHandler handler : configHandlers) {
+            handler.updateConfiguration(configuration, configurationParameters);
         }
 
         ZigBeeNode node = coordinatorHandler.getNode(nodeIeeeAddress);
         ZigBeeDeviceConfigHandler deviceConfigHandler = new ZigBeeDeviceConfigHandler(node);
-        Map<String, Object> updatedParameters = deviceConfigHandler.handleConfigurationUpdate(configurationParameters);
+        deviceConfigHandler.updateConfiguration(configuration, configurationParameters);
 
-        configuration.setProperties(updatedParameters);
         // Persist changes
         updateConfiguration(configuration);
     }
@@ -696,6 +745,10 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
 
     @Override
     public ConfigDescription getConfigDescription(URI uri, Locale locale) {
+        if (configDescription != null && configDescription.getUID().equals(uri)) {
+            return configDescription;
+        }
+
         if ("channel".equals(uri.getScheme()) == false) {
             return null;
         }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -184,7 +185,8 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
         }
 
         // Create a configuration handler and get the available options
-        configLevelControl = new ZclLevelControlConfig(clusterLevelControl);
+        configLevelControl = new ZclLevelControlConfig();
+        configLevelControl.initialize(clusterLevelControl);
         configOptions = configLevelControl.getConfiguration();
 
         return true;
@@ -459,8 +461,9 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
     }
 
     @Override
-    public Configuration updateConfiguration(@NonNull Configuration configuration) {
-        return configLevelControl.updateConfiguration(configuration);
+    public void updateConfiguration(@NonNull Configuration currentConfiguration,
+            Map<String, Object> updatedParameters) {
+        configLevelControl.updateConfiguration(currentConfiguration, updatedParameters);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -107,7 +108,8 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
         clusterLevelControl.addAttributeListener(this);
 
         // Create a configuration handler and get the available options
-        configLevelControl = new ZclLevelControlConfig(clusterLevelControl);
+        configLevelControl = new ZclLevelControlConfig();
+        configLevelControl.initialize(clusterLevelControl);
         configOptions = configLevelControl.getConfiguration();
 
         return true;
@@ -195,8 +197,9 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
     }
 
     @Override
-    public Configuration updateConfiguration(@NonNull Configuration configuration) {
-        return configLevelControl.updateConfiguration(configuration);
+    public void updateConfiguration(@NonNull Configuration currentConfiguration,
+            Map<String, Object> updatedParameters) {
+        configLevelControl.updateConfiguration(currentConfiguration, updatedParameters);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclClusterConfigFactory.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclClusterConfigFactory.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zigbee.internal.converter.config;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.zcl.ZclCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclDoorLockCluster;
+
+/**
+ * A factory that provides configuration handlers for device level clusters.
+ * This is only applicable for clusters that are not specific to a channel. For example, the
+ * {@link ZclLevelControlConfig} class is directly relevant to a specific dimmer channel. For a lock however, lock
+ * configuration data such as keypad volume is more directly applicable to the device itself.
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZclClusterConfigFactory {
+    private Logger logger = LoggerFactory.getLogger(ZclClusterConfigFactory.class);
+
+    /**
+     * Map of all channels supported by the binding
+     */
+    private final Map<Integer, Class<? extends ZclClusterConfigHandler>> configMap;
+
+    public ZclClusterConfigFactory() {
+        configMap = new HashMap<>();
+
+        configMap.put(ZclDoorLockCluster.CLUSTER_ID, ZclDoorLockConfig.class);
+    }
+
+    public List<ZclClusterConfigHandler> getConfigHandlers(ZigBeeEndpoint endpoint) {
+        List<ZclClusterConfigHandler> handlers = new ArrayList<>();
+
+        for (int clusterId : endpoint.getInputClusterIds()) {
+            try {
+                ZclClusterConfigHandler handler = getClusterConfigHandler(endpoint.getInputCluster(clusterId));
+                if (handler != null) {
+                    handlers.add(handler);
+                }
+            } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
+                    | InvocationTargetException | NoSuchMethodException | SecurityException e) {
+                logger.debug("{}: Exception while getting config for input cluster {}: ", endpoint.getIeeeAddress(),
+                        clusterId, e);
+            }
+        }
+
+        for (int clusterId : endpoint.getOutputClusterIds()) {
+            try {
+                ZclClusterConfigHandler handler = getClusterConfigHandler(endpoint.getOutputCluster(clusterId));
+                if (handler != null) {
+                    handlers.add(handler);
+                }
+            } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
+                    | InvocationTargetException | NoSuchMethodException | SecurityException e) {
+                logger.debug("{}: Exception while getting config for output cluster {}: ", endpoint.getIeeeAddress(),
+                        clusterId, e);
+            }
+        }
+
+        return handlers;
+    }
+
+    @SuppressWarnings("unchecked")
+    private ZclClusterConfigHandler getClusterConfigHandler(ZclCluster cluster)
+            throws NoSuchMethodException, SecurityException, InstantiationException, IllegalAccessException,
+            IllegalArgumentException, InvocationTargetException {
+        Constructor<? extends ZclClusterConfigHandler> constructor;
+        Class<?> converterClass = configMap.get(cluster.getClusterId());
+        if (converterClass == null) {
+            return null;
+        }
+
+        constructor = (Constructor<? extends ZclClusterConfigHandler>) converterClass.getConstructor();
+        ZclClusterConfigHandler converter = constructor.newInstance();
+
+        if (converter.initialize(cluster)) {
+            return converter;
+        }
+
+        return null;
+    }
+
+}

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclClusterConfigHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclClusterConfigHandler.java
@@ -9,6 +9,7 @@
 package org.openhab.binding.zigbee.internal.converter.config;
 
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
@@ -32,16 +33,25 @@ public interface ZclClusterConfigHandler {
      * Creates the list of {@link ConfigDescriptionParameter}. This method shall check the available attributes on the
      * remote device and create configuration parameters for each supported attribute that needs to be configurable.
      *
+     * @param cluster the {@link ZclCluster} to get the configuration
+     * @return true if this cluster has configuration descriptions
+     */
+    boolean initialize(ZclCluster cluster);
+
+    /**
+     * Gets the configuration description that was generated dynamically
+     *
      * @return the list of {@link ConfigDescriptionParameter}
      */
-    public List<ConfigDescriptionParameter> getConfiguration();
+    List<ConfigDescriptionParameter> getConfiguration();
 
     /**
      * Processes the updated configuration. As required, the method shall process each known configuration parameter and
      * set a local variable for local parameters, and update the remote device for remote parameters.
+     * The currentConfiguration shall be updated.
      *
-     * @param configuration the {@link Configuration} to be processed
-     * @return the {@link Configuration} to be persisted within the thing
+     * @param currentConfiguration the current {@link Configuration}
+     * @param updatedParameters a map containing the updated configuration parameters to be set
      */
-    public Configuration updateConfiguration(@NonNull Configuration configuration);
+    void updateConfiguration(@NonNull Configuration currentConfiguration, Map<String, Object> updatedParameters);
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclDoorLockConfig.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclDoorLockConfig.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zigbee.internal.converter.config;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type;
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameterBuilder;
+import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.config.core.ParameterOption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.zsmartsystems.zigbee.zcl.ZclCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclDoorLockCluster;
+
+/**
+ * Configuration handler for the {@link ZclDoorLockCluster}
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZclDoorLockConfig implements ZclClusterConfigHandler {
+    private Logger logger = LoggerFactory.getLogger(ZclDoorLockConfig.class);
+
+    private static final String CONFIG_ID = "zigbee_doorlock_";
+    private static final String CONFIG_SOUNDVOLUME = CONFIG_ID + "soundvolume";
+    private static final String CONFIG_ENABLEONETOUCHLOCKING = CONFIG_ID + "onetouchlocking";
+    private static final String CONFIG_ENABLELOCALPROGRAMMING = CONFIG_ID + "localprogramming";
+    private static final String CONFIG_AUTORELOCKTIME = CONFIG_ID + "autorelocktime";
+
+    private final List<ConfigDescriptionParameter> parameters = new ArrayList<>();
+
+    private ZclDoorLockCluster doorLockCluster;
+
+    @Override
+    public boolean initialize(ZclCluster cluster) {
+        doorLockCluster = (ZclDoorLockCluster) cluster;
+        try {
+            Boolean result = doorLockCluster.discoverAttributes(false).get();
+            if (!result) {
+                logger.debug("{}: Unable to get supported attributes for {}.", doorLockCluster.getZigBeeAddress(),
+                        doorLockCluster.getClusterName());
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error("{}: Error getting supported attributes for {}. ", doorLockCluster.getZigBeeAddress(),
+                    doorLockCluster.getClusterName(), e);
+        }
+
+        // Build a list of configuration supported by this channel based on the attributes the cluster supports
+        List<ParameterOption> options = new ArrayList<>();
+
+        if (doorLockCluster.isAttributeSupported(ZclDoorLockCluster.ATTR_SOUNDVOLUME)) {
+            options = new ArrayList<>();
+            options.add(new ParameterOption("0", "Silent"));
+            options.add(new ParameterOption("1", "Low"));
+            options.add(new ParameterOption("2", "High"));
+            parameters.add(ConfigDescriptionParameterBuilder.create(CONFIG_SOUNDVOLUME, Type.INTEGER)
+                    .withLabel("The sound volume of the door lock").withDescription("").withDefault("0")
+                    .withOptions(options).build());
+        }
+        if (doorLockCluster.isAttributeSupported(ZclDoorLockCluster.ATTR_AUTORELOCKTIME)) {
+            options = new ArrayList<>();
+            options.add(new ParameterOption("0", "Disabled"));
+            parameters.add(ConfigDescriptionParameterBuilder.create(CONFIG_AUTORELOCKTIME, Type.INTEGER)
+                    .withLabel("Enable one touch locking").withDescription("").withMinimum(BigDecimal.ZERO)
+                    .withMaximum(new BigDecimal(3600)).withDefault("0").withOptions(options).build());
+        }
+        if (doorLockCluster.isAttributeSupported(ZclDoorLockCluster.ATTR_ENABLEONETOUCHLOCKING)) {
+            parameters.add(ConfigDescriptionParameterBuilder.create(CONFIG_ENABLEONETOUCHLOCKING, Type.BOOLEAN)
+                    .withLabel("Set auto relock time").withDescription("").withDefault("false").build());
+        }
+        if (doorLockCluster.isAttributeSupported(ZclDoorLockCluster.ATTR_ENABLELOCALPROGRAMMING)) {
+            parameters.add(ConfigDescriptionParameterBuilder.create(CONFIG_ENABLELOCALPROGRAMMING, Type.BOOLEAN)
+                    .withLabel("Enable local programming").withDescription("").withDefault("false").build());
+        }
+
+        return !parameters.isEmpty();
+    }
+
+    @Override
+    public List<ConfigDescriptionParameter> getConfiguration() {
+        return parameters;
+    }
+
+    @Override
+    public void updateConfiguration(@NonNull Configuration currentConfiguration,
+            Map<String, Object> updatedParameters) {
+        for (Entry<String, Object> configurationParameter : updatedParameters.entrySet()) {
+            if (!configurationParameter.getKey().startsWith(CONFIG_ID)) {
+                continue;
+            }
+
+            // Ignore any configuration parameters that have not changed
+            if (Objects.equals(configurationParameter.getValue(),
+                    currentConfiguration.get(configurationParameter.getKey()))) {
+                logger.debug("Configuration update: Ignored {} as no change", configurationParameter.getKey());
+                continue;
+            }
+
+            logger.debug("{}: Update DoorLock configuration property {}->{} ({})", doorLockCluster.getZigBeeAddress(),
+                    configurationParameter.getKey(), configurationParameter.getValue(),
+                    configurationParameter.getValue().getClass().getSimpleName());
+            Object response = null;
+            switch (configurationParameter.getKey()) {
+                case CONFIG_ENABLEONETOUCHLOCKING:
+                    doorLockCluster
+                            .setEnableOneTouchLocking(((Boolean) (configurationParameter.getValue())).booleanValue());
+                    response = Boolean.valueOf(doorLockCluster.getEnableOneTouchLocking(0));
+                    break;
+                case CONFIG_ENABLELOCALPROGRAMMING:
+                    doorLockCluster
+                            .setEnableLocalProgramming(((Boolean) configurationParameter.getValue()).booleanValue());
+                    response = Boolean.valueOf(doorLockCluster.getEnableLocalProgramming(0));
+                    break;
+                case CONFIG_SOUNDVOLUME:
+                    doorLockCluster.setSoundVolume(((BigDecimal) (configurationParameter.getValue())).intValue());
+                    response = BigInteger.valueOf(doorLockCluster.getSoundVolume(0));
+                    break;
+                case CONFIG_AUTORELOCKTIME:
+                    doorLockCluster.setAutoRelockTime(((BigDecimal) (configurationParameter.getValue())).intValue());
+                    response = BigInteger.valueOf(doorLockCluster.getAutoRelockTime(0));
+                    break;
+                default:
+                    logger.warn("{}: Unhandled configuration property {}", doorLockCluster.getZigBeeAddress(),
+                            configurationParameter.getKey());
+                    break;
+            }
+
+            if (response != null) {
+                currentConfiguration.put(configurationParameter.getKey(), response);
+            }
+        }
+    }
+}

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/ZigBeeDeviceConfigHandlerTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/ZigBeeDeviceConfigHandlerTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.eclipse.smarthome.config.core.Configuration;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
@@ -37,9 +38,9 @@ public class ZigBeeDeviceConfigHandlerTest {
         ZclCluster clusterIn = Mockito.mock(ZclCluster.class);
         ZclCluster clusterOut = Mockito.mock(ZclCluster.class);
 
-        Mockito.when(node.getEndpoint(Mockito.anyInt())).thenReturn(endpoint);
-        Mockito.when(endpoint.getInputCluster(Mockito.anyInt())).thenReturn(clusterIn);
-        Mockito.when(endpoint.getOutputCluster(Mockito.anyInt())).thenReturn(clusterOut);
+        Mockito.when(node.getEndpoint(ArgumentMatchers.anyInt())).thenReturn(endpoint);
+        Mockito.when(endpoint.getInputCluster(ArgumentMatchers.anyInt())).thenReturn(clusterIn);
+        Mockito.when(endpoint.getOutputCluster(ArgumentMatchers.anyInt())).thenReturn(clusterOut);
 
         ArgumentCaptor<Integer> attributeCapture = ArgumentCaptor.forClass(Integer.class);
         ArgumentCaptor<ZclDataType> dataTypeCapture = ArgumentCaptor.forClass(ZclDataType.class);
@@ -55,9 +56,10 @@ public class ZigBeeDeviceConfigHandlerTest {
         Map<String, Object> configuration = new TreeMap<>();
         configuration.put("attribute_02_in_0404_0030_18", Integer.valueOf(1));
         configuration.put("attribute_02_out_0406_0032_29", Integer.valueOf(2));
-        Map<String, Object> updatedConfig = configHandler.handleConfigurationUpdate(configuration);
+        Configuration updatedConfig = new Configuration();
+        configHandler.updateConfiguration(updatedConfig, configuration);
 
-        assertEquals(2, updatedConfig.size());
+        assertEquals(2, updatedConfig.getProperties().size());
 
         assertEquals(2, attributeCapture.getAllValues().size());
 

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/config/ZclDoorLockConfigTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/config/ZclDoorLockConfigTest.java
@@ -10,64 +10,36 @@ package org.openhab.binding.zigbee.internal.converter.config;
 
 import static org.junit.Assert.assertEquals;
 
-import java.math.BigDecimal;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
-import org.eclipse.smarthome.config.core.Configuration;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
-import com.zsmartsystems.zigbee.zcl.clusters.ZclLevelControlCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclDoorLockCluster;
 
 /**
  *
  * @author Chris Jackson - Initial Contribution
  *
  */
-public class ZclLevelControlConfigTest {
-    private final String CONFIG_DEFAULTTRANSITIONTIME = "zigbee_levelcontrol_transitiontimedefault";
-
+public class ZclDoorLockConfigTest {
     @Test
     public void getConfiguration() {
-        ZclLevelControlCluster cluster = Mockito.mock(ZclLevelControlCluster.class);
+        ZclDoorLockCluster cluster = Mockito.mock(ZclDoorLockCluster.class);
         Mockito.when(cluster.discoverAttributes(ArgumentMatchers.anyBoolean())).thenReturn(new MockedBooleanFuture());
         Mockito.when(cluster.isAttributeSupported(ArgumentMatchers.anyInt())).thenReturn(true);
 
-        ZclLevelControlConfig config = new ZclLevelControlConfig();
+        ZclDoorLockConfig config = new ZclDoorLockConfig();
         config.initialize(cluster);
         List<ConfigDescriptionParameter> configuration = config.getConfiguration();
 
-        assertEquals(6, configuration.size());
-        ConfigDescriptionParameter cfg = configuration.get(0);
-        assertEquals(CONFIG_DEFAULTTRANSITIONTIME, cfg.getName());
-    }
-
-    @Test
-    public void getDefaultTransitionTime() {
-        ZclLevelControlCluster cluster = Mockito.mock(ZclLevelControlCluster.class);
-        Mockito.when(cluster.discoverAttributes(ArgumentMatchers.anyBoolean())).thenReturn(new MockedBooleanFuture());
-        Mockito.when(cluster.isAttributeSupported(ArgumentMatchers.anyInt())).thenReturn(true);
-
-        ZclLevelControlConfig config = new ZclLevelControlConfig();
-        config.initialize(cluster);
-        config.getConfiguration();
-
-        Configuration configuration = new Configuration();
-
-        Map<String, Object> parameters = new HashMap<>();
-        parameters.put(CONFIG_DEFAULTTRANSITIONTIME, new BigDecimal(45));
-
-        config.updateConfiguration(configuration, parameters);
-
-        assertEquals(45, config.getDefaultTransitionTime());
+        assertEquals(4, configuration.size());
     }
 
     class MockedBooleanFuture implements Future<Boolean> {


### PR DESCRIPTION
This PR adds a factory for thing level configuration. It allows specific ```ZclClusterConfigHandler```s to provide configuration parameters at thing level.

Some refactoring of the current interface was required to make this fit better with the thing configuration interfaces, otherwise it's the same interface already existed for the channel configuration.

The initialisation of the thing will create the handlers, but will only add the parameters to the things configuration if it is using dynamically defined channels - thus allowing the static things to define the parameter configuration.

This also provides a DoorLock config handler with some of the basic lock configuration options as an example.

@hsudbrock let me know what you think.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>