### PR TITLE
Fix removal of configuration parameter when configuration has been changed

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -431,7 +431,8 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
         ZigBeeDeviceConfigHandler deviceConfigHandler = new ZigBeeDeviceConfigHandler(node);
         Map<String, Object> updatedParameters = deviceConfigHandler.handleConfigurationUpdate(configurationParameters);
 
-        configuration.setProperties(updatedParameters);
+        updatedParameters.forEach((parameterKey, parameterValue) -> configuration.put(parameterKey, parameterValue));
+
         // Persist changes
         updateConfiguration(configuration);
     }


### PR DESCRIPTION
In this PR, we fixed the unintentional removal of configuration parameters that do not belong to an attribute (`ZigBeeDeviceConfigHandler#CONFIG_TYPE_ATTRIBUTE`). 

For instance, when a thing consists of two configuration parameters `zigbee_macaddress` and `attribute_02_0000_0033_18`, a configuration change will result in the removal of the `zigbee_macaddress` parameter value. Since this parameter is mandatory, the respective thing handler will remain `UNINITIALIZED` after the configuration has been changed.