### PR TITLE
A channel converter for buttons (e.g., on remote controls or wall switches)

### DIFF
--- a/org.openhab.binding.zigbee/ESH-INF/thing/bitron/bitron-video-902010-23.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/bitron/bitron-video-902010-23.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                          xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+                          bindingId="zigbee"
+                          xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+   <thing-type id="bitron-video-902010-23">
+      <supported-bridge-type-refs>
+         <bridge-type-ref id="coordinator_telegesis"/>
+         <bridge-type-ref id="coordinator_ember"/>
+      </supported-bridge-type-refs>
+      <label>BitronVideo 4-button Remote Control</label>
+      <channels>
+         <channel id="key1" typeId="system.button">
+            <label>Button 1</label>
+            <description>Button marked with one dot</description>
+            <properties>
+               <property name="zigbee_endpoint">1</property>
+               <property name="zigbee_shortpress_cluster_id">0x0008</property>
+               <property name="zigbee_shortpress_command_id">0x06</property>
+               <property name="zigbee_shortpress_parameter_name">stepMode</property>
+               <property name="zigbee_shortpress_parameter_value">0</property>
+            </properties>
+         </channel>
+         <channel id="key2" typeId="system.button">
+            <label>Button 2</label>
+            <description>Button marked with two dots</description>
+            <properties>
+               <property name="zigbee_endpoint">1</property>
+               <property name="zigbee_shortpress_cluster_id">0x0006</property>
+               <property name="zigbee_shortpress_command_id">0x01</property>
+            </properties>
+         </channel>
+         <channel id="key3" typeId="system.button">
+            <label>Button 3</label>
+            <description>Button marked with three dots</description>
+            <properties>
+               <property name="zigbee_endpoint">1</property>
+               <property name="zigbee_shortpress_cluster_id">0x0006</property>
+               <property name="zigbee_shortpress_command_id">0x00</property>
+            </properties>
+         </channel>
+         <channel id="key4" typeId="system.button">
+            <label>Button 4</label>
+            <description>Button marked with four dots</description>
+            <properties>
+               <property name="zigbee_endpoint">1</property>
+               <property name="zigbee_shortpress_cluster_id">0x0008</property>
+               <property name="zigbee_shortpress_command_id">0x06</property>
+               <property name="zigbee_shortpress_parameter_name">stepMode</property>
+               <property name="zigbee_shortpress_parameter_value">1</property>
+            </properties>
+         </channel>
+      </channels>
+      <config-description>
+         <parameter name="zigbee_macaddress"
+                    type="text"
+                    readOnly="true"
+                    required="true">
+            <label>MAC Address</label>
+         </parameter>
+      </config-description>
+   </thing-type>
+</thing:thing-descriptions>

--- a/org.openhab.binding.zigbee/ESH-INF/thing/bitron/bitron-video-av2010-34.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/bitron/bitron-video-av2010-34.xml
@@ -3,47 +3,51 @@
                           xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
                           bindingId="zigbee"
                           xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
-   <thing-type id="bitron-video-902010-23">
-      <label>BitronVideo 4-button Remote Control</label>
+   <thing-type id="bitron-video-av2010-34">
+      <label>Bitron Video Wall Switch AV2010/34</label>
       <channels>
-         <channel id="key1" typeId="system.button">
+         <channel id="button1" typeId="system.button">
             <label>Button 1</label>
             <description>Button marked with one dot</description>
             <properties>
                <property name="zigbee_endpoint">1</property>
-               <property name="zigbee_shortpress_cluster_id">0x0008</property>
-               <property name="zigbee_shortpress_command_id">0x06</property>
-               <property name="zigbee_shortpress_parameter_name">stepMode</property>
-               <property name="zigbee_shortpress_parameter_value">0</property>
+               <property name="zigbee_shortpress_cluster_id">0x0005</property>
+               <property name="zigbee_shortpress_command_id">0x05</property>
+               <property name="zigbee_shortpress_parameter_name">sceneId</property>
+               <property name="zigbee_shortpress_parameter_value">1</property>
             </properties>
          </channel>
-         <channel id="key2" typeId="system.button">
+         <channel id="button2" typeId="system.button">
             <label>Button 2</label>
             <description>Button marked with two dots</description>
             <properties>
                <property name="zigbee_endpoint">1</property>
-               <property name="zigbee_shortpress_cluster_id">0x0006</property>
-               <property name="zigbee_shortpress_command_id">0x01</property>
+               <property name="zigbee_shortpress_cluster_id">0x0005</property>
+               <property name="zigbee_shortpress_command_id">0x05</property>
+               <property name="zigbee_shortpress_parameter_name">sceneId</property>
+               <property name="zigbee_shortpress_parameter_value">2</property>
             </properties>
          </channel>
-         <channel id="key3" typeId="system.button">
+         <channel id="button3" typeId="system.button">
             <label>Button 3</label>
             <description>Button marked with three dots</description>
             <properties>
                <property name="zigbee_endpoint">1</property>
-               <property name="zigbee_shortpress_cluster_id">0x0006</property>
-               <property name="zigbee_shortpress_command_id">0x00</property>
+               <property name="zigbee_shortpress_cluster_id">0x0005</property>
+               <property name="zigbee_shortpress_command_id">0x05</property>
+               <property name="zigbee_shortpress_parameter_name">sceneId</property>
+               <property name="zigbee_shortpress_parameter_value">3</property>
             </properties>
          </channel>
-         <channel id="key4" typeId="system.button">
+         <channel id="button4" typeId="system.button">
             <label>Button 4</label>
             <description>Button marked with four dots</description>
             <properties>
                <property name="zigbee_endpoint">1</property>
-               <property name="zigbee_shortpress_cluster_id">0x0008</property>
-               <property name="zigbee_shortpress_command_id">0x06</property>
-               <property name="zigbee_shortpress_parameter_name">stepMode</property>
-               <property name="zigbee_shortpress_parameter_value">1</property>
+               <property name="zigbee_shortpress_cluster_id">0x0005</property>
+               <property name="zigbee_shortpress_command_id">0x05</property>
+               <property name="zigbee_shortpress_parameter_name">sceneId</property>
+               <property name="zigbee_shortpress_parameter_value">4</property>
             </properties>
          </channel>
       </channels>

--- a/org.openhab.binding.zigbee/ESH-INF/thing/innr/rc-110.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/innr/rc-110.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                          xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+                          bindingId="zigbee"
+                          xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+   <thing-type id="innr-rc-110">
+      <label>Innr RC 110 Remote Control</label>
+      <channels>
+         <channel id="scenesOn" typeId="system.button">
+            <label>Button On</label>
+            <description>Button 'On/Off' turning On (with Scenes selected)</description>
+            <properties>
+               <property name="zigbee_endpoint">1</property>
+               <property name="zigbee_shortpress_cluster_id">0x0006</property>
+               <property name="zigbee_shortpress_command_id">0x01</property>
+            </properties>
+         </channel>
+         
+         <channel id="scenesOff" typeId="system.button">
+            <label>Button On</label>
+            <description>Button 'On/Off' turning Off (with Scenes selected)</description>
+            <properties>
+               <property name="zigbee_endpoint">1</property>
+               <property name="zigbee_shortpress_cluster_id">0x0006</property>
+               <property name="zigbee_shortpress_command_id">0x00</property>
+            </properties>
+         </channel>
+         
+         <channel id="scenesMinus" typeId="system.button">
+            <label>Button -</label>
+            <description>Button '-' (with Scenes selected)</description>
+            <properties>
+               <property name="zigbee_endpoint">1</property>
+               <property name="zigbee_shortpress_cluster_id">0x0008</property>
+               <property name="zigbee_shortpress_command_id">0x02</property>
+               <property name="zigbee_shortpress_parameter_name">stepMode</property>
+               <property name="zigbee_shortpress_parameter_value">1</property>
+               <property name="zigbee_longpress_cluster_id">0x0008</property>
+               <property name="zigbee_longpress_command_id">0x01</property>
+               <property name="zigbee_longpress_parameter_name">moveMode</property>
+               <property name="zigbee_longpress_parameter_value">1</property>
+            </properties>
+         </channel>
+         
+         <channel id="scenesPlus" typeId="system.button">
+            <label>Button +</label>
+            <description>Button '+' (with Scenes selected)</description>
+            <properties>
+               <property name="zigbee_endpoint">1</property>
+               <property name="zigbee_shortpress_cluster_id">0x0008</property>
+               <property name="zigbee_shortpress_command_id">0x02</property>
+               <property name="zigbee_shortpress_parameter_name">stepMode</property>
+               <property name="zigbee_shortpress_parameter_value">0</property>
+               <property name="zigbee_longpress_cluster_id">0x0008</property>
+               <property name="zigbee_longpress_command_id">0x01</property>
+               <property name="zigbee_longpress_parameter_name">moveMode</property>
+               <property name="zigbee_longpress_parameter_value">0</property>
+            </properties>
+         </channel>
+         
+         <channel id="scenesMinusPlusRelease" typeId="system.button">
+            <label>Button +/- released</label>
+            <description>Button '+' or '-' when being released (with Scenes selected)</description>
+            <properties>
+               <property name="zigbee_endpoint">1</property>
+               <property name="zigbee_shortpress_cluster_id">0x0008</property>
+               <property name="zigbee_shortpress_command_id">0x03</property>
+            </properties>
+         </channel>
+      
+         <channel id="scenes1" typeId="system.button">
+            <label>Button 1</label>
+            <description>Button 1 (with Scenes selected)</description>
+            <properties>
+               <property name="zigbee_endpoint">1</property>
+               <property name="zigbee_shortpress_cluster_id">0x0008</property>
+               <property name="zigbee_shortpress_command_id">0x04</property>
+               <property name="zigbee_shortpress_parameter_name">level</property>
+               <property name="zigbee_shortpress_parameter_value">2</property>
+            </properties>
+         </channel>
+         
+         <channel id="scenes2" typeId="system.button">
+            <label>Button 2</label>
+            <description>Button 2 (with Scenes selected)</description>
+            <properties>
+               <property name="zigbee_endpoint">1</property>
+               <property name="zigbee_shortpress_cluster_id">0x0008</property>
+               <property name="zigbee_shortpress_command_id">0x04</property>
+               <property name="zigbee_shortpress_parameter_name">level</property>
+               <property name="zigbee_shortpress_parameter_value">52</property>
+            </properties>
+         </channel>
+         
+         <channel id="scenes3" typeId="system.button">
+            <label>Button 3</label>
+            <description>Button 3 (with Scenes selected)</description>
+            <properties>
+               <property name="zigbee_endpoint">1</property>
+               <property name="zigbee_shortpress_cluster_id">0x0008</property>
+               <property name="zigbee_shortpress_command_id">0x04</property>
+               <property name="zigbee_shortpress_parameter_name">level</property>
+               <property name="zigbee_shortpress_parameter_value">102</property>
+            </properties>
+         </channel>
+         
+         <channel id="scenes4" typeId="system.button">
+            <label>Button 4</label>
+            <description>Button 4 (with Scenes selected)</description>
+            <properties>
+               <property name="zigbee_endpoint">1</property>
+               <property name="zigbee_shortpress_cluster_id">0x0008</property>
+               <property name="zigbee_shortpress_command_id">0x04</property>
+               <property name="zigbee_shortpress_parameter_name">level</property>
+               <property name="zigbee_shortpress_parameter_value">153</property>
+            </properties>
+         </channel>
+         
+         <channel id="scenes5" typeId="system.button">
+            <label>Button 5</label>
+            <description>Button 5 (with Scenes selected)</description>
+            <properties>
+               <property name="zigbee_endpoint">1</property>
+               <property name="zigbee_shortpress_cluster_id">0x0008</property>
+               <property name="zigbee_shortpress_command_id">0x04</property>
+               <property name="zigbee_shortpress_parameter_name">level</property>
+               <property name="zigbee_shortpress_parameter_value">194</property>
+            </properties>
+         </channel>
+         
+         <channel id="scenes6" typeId="system.button">
+            <label>Button 6</label>
+            <description>Button 6 (with Scenes selected)</description>
+            <properties>
+               <property name="zigbee_endpoint">1</property>
+               <property name="zigbee_shortpress_cluster_id">0x0008</property>
+               <property name="zigbee_shortpress_command_id">0x04</property>
+               <property name="zigbee_shortpress_parameter_name">level</property>
+               <property name="zigbee_shortpress_parameter_value">254</property>
+            </properties>
+         </channel>
+         
+      </channels>
+      <config-description>
+         <parameter name="zigbee_macaddress"
+                    type="text"
+                    readOnly="true"
+                    required="true">
+            <label>MAC Address</label>
+         </parameter>
+      </config-description>
+   </thing-type>
+</thing:thing-descriptions>

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -501,11 +501,32 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
      * @param state the new {link State}
      */
     public void setChannelState(ChannelUID channel, State state) {
-        logger.debug("{}: Updating ZigBee channel state {} to {}", nodeIeeeAddress, channel, state);
         if (firmwareUpdateInProgress) {
+            logger.debug("Omitting updating ZigBee channel state {} to {} due to firmware update in progress", channel,
+                    state);
             return;
         }
+        logger.debug("{}: Updating ZigBee channel state {} to {}", nodeIeeeAddress, channel, state);
         updateState(channel, state);
+        updateStatus(ThingStatus.ONLINE);
+    }
+
+    /**
+     * Callback from handlers to trigger a channel. This is called from the channel converter when a trigger is
+     * received.
+     *
+     * @param channel the {@link ChannelUID} to be triggered
+     * @param event   the event to be emitted
+     */
+    @Override
+    public void triggerChannel(ChannelUID channel, String event) {
+        if (firmwareUpdateInProgress) {
+            logger.debug("Omitting triggering ZigBee channel {} with event {} due to firmware update in progress",
+                    channel, event);
+            return;
+        }
+        logger.debug("{}: Triggering ZigBee channel {} with event {}", nodeIeeeAddress, channel, event);
+        super.triggerChannel(channel, event);
         updateStatus(ThingStatus.ONLINE);
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactory.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactory.java
@@ -16,6 +16,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.DefaultSystemChannelTypeProvider;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
@@ -81,6 +82,7 @@ public class ZigBeeChannelConverterFactory {
                 ZigBeeConverterMeasurementRmsVoltage.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_ELECTRICAL_RMSCURRENT,
                 ZigBeeConverterMeasurementRmsCurrent.class);
+        channelMap.put(DefaultSystemChannelTypeProvider.SYSTEM_BUTTON.getUID(), ZigBeeConverterGenericButton.class);
 
         // Add the hierarchical list of channels that are to be removed due to inheritance
         // Note that order is important in the event that there are multiple removals...

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButton.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButton.java
@@ -1,0 +1,264 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zigbee.internal.converter;
+
+import static java.lang.Integer.*;
+import static java.lang.String.format;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.zsmartsystems.zigbee.CommandResult;
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.zcl.ZclCluster;
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+import com.zsmartsystems.zigbee.zcl.ZclCommandListener;
+
+/**
+ * Generic converter for buttons (e.g., from remote controls).
+ * <p>
+ * This converter needs to be configured with the ZigBee commands that are triggered by the button presses. This is done
+ * by channel properties that specify the endpoint, the cluster, the command ID, and (optionally) a command parameter.
+ * <p>
+ * As the configuration is done via channel properties, this converter is usable via static thing types only.
+ *
+ * @author Henning Sudbrock - initial contribution
+ */
+public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter implements ZclCommandListener {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private static final String CLUSTER = "cluster_id";
+    private static final String COMMAND = "command_id";
+    private static final String PARAM_NAME = "parameter_name";
+    private static final String PARAM_VALUE = "parameter_value";
+
+    private Map<ButtonPressType, CommandSpec> handledCommands = new HashMap<>();
+    private Set<ZclCluster> clientClusters = new HashSet<>();
+
+    @Override
+    public synchronized boolean initializeConverter() {
+        for (ButtonPressType buttonPressType : ButtonPressType.values()) {
+            CommandSpec commandSpec = parseCommandSpec(buttonPressType);
+            if (commandSpec != null) {
+                handledCommands.put(buttonPressType, commandSpec);
+            }
+        }
+
+        if (handledCommands.isEmpty()) {
+            logger.error("{}: No command is specified for any of the possible button press types in channel {}",
+                    endpoint.getIeeeAddress(), channel.getUID());
+            return false;
+        }
+
+        for (CommandSpec commandSpec : handledCommands.values()) {
+            int clusterId = commandSpec.getClusterId();
+
+            if (clientClusters.stream().anyMatch(cluster -> cluster.getClusterId().intValue() == clusterId)) {
+                // bind to each output cluster only once
+                continue;
+            }
+
+            ZclCluster clientCluster = endpoint.getOutputCluster(clusterId);
+            if (clientCluster == null) {
+                logger.error("{}: Error opening client cluster {} on endpoint {}", endpoint.getIeeeAddress(), clusterId,
+                        endpoint.getEndpointId());
+                return false;
+            }
+
+            try {
+                CommandResult bindResponse = clientCluster.bind().get();
+                if (!bindResponse.isSuccess()) {
+                    logger.error("{}: Error 0x{} setting client binding for cluster {}", endpoint.getIeeeAddress(),
+                            toHexString(bindResponse.getStatusCode()), clusterId);
+                }
+            } catch (InterruptedException | ExecutionException e) {
+                logger.error(endpoint.getIeeeAddress() + ": Exception setting binding to cluster " + clusterId, e);
+            }
+
+            clientCluster.addCommandListener(this);
+            clientClusters.add(clientCluster);
+        }
+
+        return true;
+    }
+
+    @Override
+    public void disposeConverter() {
+        for (ZclCluster clientCluster : clientClusters) {
+            logger.debug("{}: Closing cluster {}", endpoint.getIeeeAddress(), clientCluster.getClusterId());
+            clientCluster.removeCommandListener(this);
+        }
+    }
+
+    @Override
+    public void handleRefresh() {
+        // nothing to do, as we only listen to commands
+    }
+
+    @Override
+    public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
+        // This converter is used only for channels specified in static thing types, and cannot be used to construct
+        // channels based on an endpoint alone.
+        return null;
+    }
+
+    @Override
+    public void commandReceived(ZclCommand command) {
+        ButtonPressType buttonPressType = getButtonPressType(command);
+        if (buttonPressType != null) {
+            logger.debug("{}: Matching ZigBee command for press type {} received: {}", endpoint.getIeeeAddress(),
+                    buttonPressType, command);
+            thing.triggerChannel(channel.getUID(), getEvent(buttonPressType));
+        }
+    }
+
+    private String getEvent(ButtonPressType pressType) {
+        switch (pressType) {
+            case DOUBLE_PRESS:
+                return CommonTriggerEvents.DOUBLE_PRESSED;
+            case LONG_PRESS:
+                return CommonTriggerEvents.LONG_PRESSED;
+            case SHORT_PRESS:
+                return CommonTriggerEvents.SHORT_PRESSED;
+            default:
+                logger.warn("Stumbled upon invalid presstype: {}", pressType);
+                return null;
+        }
+    }
+
+    private ButtonPressType getButtonPressType(ZclCommand command) {
+        for (Entry<ButtonPressType, CommandSpec> entry : handledCommands.entrySet()) {
+            if (entry.getValue().matchesCommand(command)) {
+                return entry.getKey();
+            }
+        }
+        return null;
+    }
+
+    private CommandSpec parseCommandSpec(ButtonPressType pressType) {
+        String clusterProperty = channel.getProperties().get(getParameterName(CLUSTER, pressType));
+        String commandProperty = channel.getProperties().get(getParameterName(COMMAND, pressType));
+        String commandParameterName = channel.getProperties().get(getParameterName(PARAM_NAME, pressType));
+        String commandParameterValue = channel.getProperties().get(getParameterName(PARAM_VALUE, pressType));
+
+        if (clusterProperty == null || commandProperty == null) {
+            return null;
+        }
+
+        int clusterId;
+        int commandId;
+
+        try {
+            clusterId = parseId(clusterProperty);
+        } catch (NumberFormatException e) {
+            logger.warn("{}: Could not parse cluster property {}", endpoint.getIeeeAddress(), clusterProperty);
+            return null;
+        }
+
+        try {
+            commandId = parseId(commandProperty);
+        } catch (NumberFormatException e) {
+            logger.warn("{}: Could not parse command property {}", endpoint.getIeeeAddress(), commandProperty);
+            return null;
+        }
+
+        if ((commandParameterName != null && commandParameterValue == null)
+                || (commandParameterName == null && commandParameterValue != null)) {
+            logger.warn("{}: When specifiying a command parameter, both name and value must be specified",
+                    endpoint.getIeeeAddress());
+            return null;
+        }
+
+        return new CommandSpec(clusterId, commandId, commandParameterName, commandParameterValue);
+    }
+
+    private String getParameterName(String parameterType, ButtonPressType buttonPressType) {
+        return String.format("zigbee_%s_%s", buttonPressType, parameterType);
+    }
+
+    private int parseId(String id) throws NumberFormatException {
+        if (id.startsWith("0x")) {
+            return parseInt(id.substring(2, id.length()), 16);
+        } else {
+            return parseInt(id);
+        }
+    }
+
+    private enum ButtonPressType {
+        SHORT_PRESS("shortpress"),
+        DOUBLE_PRESS("doublepress"),
+        LONG_PRESS("longpress");
+
+        private String parameterValue;
+
+        private ButtonPressType(String parameterValue) {
+            this.parameterValue = parameterValue;
+        }
+
+        @Override
+        public String toString() {
+            return parameterValue;
+        }
+    }
+
+    private class CommandSpec {
+        private final int clusterId;
+        private final int commandId;
+        private final String commandParameterName;
+        private final String commandParameterValue;
+
+        public CommandSpec(int clusterId, int commandId, String commandParameterName, String commandParameterValue) {
+            this.clusterId = clusterId;
+            this.commandId = commandId;
+            this.commandParameterName = commandParameterName;
+            this.commandParameterValue = commandParameterValue;
+        }
+
+        public boolean matchesCommand(ZclCommand command) {
+            boolean commandIdMatches = command.getCommandId().intValue() == commandId;
+            boolean commandParameterMatches = commandParameterName == null || commandParameterValue == null
+                    || matchesParameter(command);
+
+            return commandIdMatches && commandParameterMatches;
+        }
+
+        private boolean matchesParameter(ZclCommand command) {
+            String capitalizedParameterName = commandParameterName.substring(0, 1).toUpperCase()
+                    + commandParameterName.substring(1);
+            try {
+                Method propertyGetter = command.getClass().getMethod("get" + capitalizedParameterName);
+                Object result = propertyGetter.invoke(command);
+                return Objects.equals(result.toString(), commandParameterValue);
+            } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException
+                    | InvocationTargetException e) {
+                logger.warn(format("%s: Could not read parameter %s for command %s", endpoint.getIeeeAddress(),
+                        commandParameterName, command), e);
+                return false;
+            }
+        }
+
+        public int getClusterId() {
+            return clusterId;
+        }
+    }
+}

--- a/org.openhab.binding.zigbee/src/main/resources/discovery.txt
+++ b/org.openhab.binding.zigbee/src/main/resources/discovery.txt
@@ -1,2 +1,3 @@
 philips_sml001,vendor=Philips,modelId=SML001
 smartthings_motionv4,vendor=SmartThings,modelId=motionv4
+bitron-video-902010-23,vendor=Bitron Home,modelId=902010/23

--- a/org.openhab.binding.zigbee/src/main/resources/discovery.txt
+++ b/org.openhab.binding.zigbee/src/main/resources/discovery.txt
@@ -1,3 +1,4 @@
 philips_sml001,vendor=Philips,modelId=SML001
 smartthings_motionv4,vendor=SmartThings,modelId=motionv4
 bitron-video-902010-23,vendor=Bitron Home,modelId=902010/23
+bitron-video-av2010-34,vendor=Bitron Video,modelId=AV2010/34

--- a/org.openhab.binding.zigbee/src/main/resources/discovery.txt
+++ b/org.openhab.binding.zigbee/src/main/resources/discovery.txt
@@ -2,3 +2,4 @@ philips_sml001,vendor=Philips,modelId=SML001
 smartthings_motionv4,vendor=SmartThings,modelId=motionv4
 bitron-video-902010-23,vendor=Bitron Home,modelId=902010/23
 bitron-video-av2010-34,vendor=Bitron Video,modelId=AV2010/34
+innr-rc-110,vendor=innr,modelId=RC 110

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButtonTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButtonTest.java
@@ -1,0 +1,260 @@
+package org.openhab.binding.zigbee.internal.converter;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
+
+import com.zsmartsystems.zigbee.CommandResult;
+import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.ZigBeeCommand;
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.zcl.ZclCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.MoveHueCommand;
+
+/**
+ * Unit tests for the {@link ZigBeeConverterGenericButton}.
+ *
+ * @author Henning Sudbrock - initial contribution
+ */
+public class ZigBeeConverterGenericButtonTest {
+
+    private ZigBeeConverterGenericButton converter;
+
+    private ZigBeeThingHandler thingHandler;
+    private Channel channel;
+    private ZigBeeCoordinatorHandler coordinatorHandler;
+    private ZigBeeEndpoint endpoint;
+
+    private Map<String, String> channelProperties;
+
+    @Before
+    public void setup() {
+        IeeeAddress ieeeAddress = new IeeeAddress();
+        int endpointId = 1;
+
+        endpoint = mock(ZigBeeEndpoint.class);
+        thingHandler = mock(ZigBeeThingHandler.class);
+
+        channel = mock(Channel.class);
+        channelProperties = new HashMap<>();
+        when(channel.getProperties()).thenReturn(channelProperties);
+
+        coordinatorHandler = mock(ZigBeeCoordinatorHandler.class);
+        when(coordinatorHandler.getEndpoint(ieeeAddress, endpointId)).thenReturn(endpoint);
+
+        converter = new ZigBeeConverterGenericButton();
+        converter.initialize(thingHandler, channel, coordinatorHandler, ieeeAddress, endpointId);
+    }
+
+    @Test
+    public void converterInitializationBindsToCorrectCluster() {
+        channelProperties.put("zigbee_shortpress_cluster_id", "0x0008");
+        channelProperties.put("zigbee_shortpress_command_id", "0x0017");
+
+        ZclCluster cluster = mockCluster(8);
+
+        boolean initResult = converter.initializeConverter();
+
+        assertTrue(initResult);
+        verify(cluster, times(1)).addCommandListener(converter);
+    }
+
+    @Test
+    public void converterInitializationBindsToClusterOnlyOnce() {
+        channelProperties.put("zigbee_shortpress_cluster_id", "0x0008");
+        channelProperties.put("zigbee_shortpress_command_id", "0x0017");
+
+        channelProperties.put("zigbee_longpress_cluster_id", "0x0008");
+        channelProperties.put("zigbee_longpress_command_id", "0x0018");
+
+        channelProperties.put("zigbee_doublepress_cluster_id", "0x0009");
+        channelProperties.put("zigbee_doublepress_command_id", "0x0017");
+
+        ZclCluster cluster8 = mockCluster(8);
+        ZclCluster cluster9 = mockCluster(9);
+
+        boolean initResult = converter.initializeConverter();
+
+        assertTrue(initResult);
+        verify(cluster8, times(1)).addCommandListener(converter);
+        verify(cluster9, times(1)).addCommandListener(converter);
+    }
+
+    @Test
+    public void converterInitializationClusterIdIsMandatory() {
+        channelProperties.put("zigbee_shortpress_command_id", "0x0017");
+        boolean initResult = converter.initializeConverter();
+        assertFalse(initResult);
+    }
+
+    @Test
+    public void converterInitializationCommandIdIsMandatory() {
+        channelProperties.put("zigbee_shortpress_cluster_id", "0x008");
+        mockCluster(8);
+        boolean initResult = converter.initializeConverter();
+        assertFalse(initResult);
+    }
+
+    @Test
+    public void converterCannotInitializeWithUnparseableClusterId() {
+        channelProperties.put("zigbee_shortpress_cluster_id", "0xEFGH");
+        channelProperties.put("zigbee_shortpress_command_id", "123");
+        boolean initResult = converter.initializeConverter();
+        assertFalse(initResult);
+    }
+
+    @Test
+    public void converterCannotInitializeWithUnparseableCommandId() {
+        channelProperties.put("zigbee_shortpress_cluster_id", "0x8");
+        channelProperties.put("zigbee_shortpress_command_id", "abc");
+        mockCluster(8);
+        boolean initResult = converter.initializeConverter();
+        assertFalse(initResult);
+    }
+
+    @Test
+    public void converterCannotInitializeWithIncompleteParamSpecWithoutValue() {
+        channelProperties.put("zigbee_shortpress_cluster_id", "0x8");
+        channelProperties.put("zigbee_shortpress_command_id", "0xabc");
+        channelProperties.put("zigbee_shortpress_parameter_name", "mode");
+        mockCluster(8);
+        boolean initResult = converter.initializeConverter();
+        assertFalse(initResult);
+    }
+
+    @Test
+    public void converterCannotInitializeWithIncompleteParamSpecWithoutName() {
+        channelProperties.put("zigbee_shortpress_cluster_id", "0x8");
+        channelProperties.put("zigbee_shortpress_command_id", "0xabc");
+        channelProperties.put("zigbee_shortpress_parameter_value", "1");
+        mockCluster(8);
+        boolean initResult = converter.initializeConverter();
+        assertFalse(initResult);
+    }
+
+    @Test
+    public void cannotInitializeConverterWithoutChannel() {
+        assertNull(converter.getChannel(mock(ThingUID.class), endpoint));
+    }
+
+    @Test
+    public void commandListenersAreRemovedOnDispose() {
+        channelProperties.put("zigbee_shortpress_cluster_id", "0x0008");
+        channelProperties.put("zigbee_shortpress_command_id", "0x0017");
+        ZclCluster cluster = mockCluster(8);
+
+        converter.initializeConverter();
+        converter.disposeConverter();
+
+        verify(cluster).removeCommandListener(converter);
+    }
+
+    @Test
+    public void commandWithoutSpecifiedParamIsHandled() {
+        channelProperties.put("zigbee_shortpress_cluster_id", "768");
+        channelProperties.put("zigbee_shortpress_command_id", "0x01");
+        mockCluster(768);
+        converter.initializeConverter();
+
+        converter.commandReceived(new MoveHueCommand());
+
+        verify(thingHandler, times(1)).triggerChannel(channel.getUID(), CommonTriggerEvents.SHORT_PRESSED);
+        verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.LONG_PRESSED);
+        verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.DOUBLE_PRESSED);
+    }
+
+    @Test
+    public void commandWithMatchingSpecifiedParamIsHandled() {
+        channelProperties.put("zigbee_shortpress_cluster_id", "768");
+        channelProperties.put("zigbee_shortpress_command_id", "0x01");
+        channelProperties.put("zigbee_shortpress_parameter_name", "moveMode");
+        channelProperties.put("zigbee_shortpress_parameter_value", "1");
+        mockCluster(768);
+        converter.initializeConverter();
+
+        MoveHueCommand moveHueCommand = new MoveHueCommand();
+        moveHueCommand.setMoveMode(1);
+        converter.commandReceived(moveHueCommand);
+
+        verify(thingHandler, times(1)).triggerChannel(channel.getUID(), CommonTriggerEvents.SHORT_PRESSED);
+        verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.LONG_PRESSED);
+        verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.DOUBLE_PRESSED);
+    }
+
+    @Test
+    public void commandWithNonMatchingSpecifiedParamNameIsNotHandled() {
+        channelProperties.put("zigbee_shortpress_cluster_id", "768");
+        channelProperties.put("zigbee_shortpress_command_id", "0x01");
+        channelProperties.put("zigbee_shortpress_parameter_name", "blueMode");
+        channelProperties.put("zigbee_shortpress_parameter_value", "1");
+        mockCluster(768);
+        converter.initializeConverter();
+
+        MoveHueCommand moveHueCommand = new MoveHueCommand();
+        moveHueCommand.setMoveMode(1);
+        converter.commandReceived(moveHueCommand);
+
+        verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.SHORT_PRESSED);
+        verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.LONG_PRESSED);
+        verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.DOUBLE_PRESSED);
+    }
+
+    @Test
+    public void commandWithNonMatchingSpecifiedParamValueIsNotHandled() {
+        channelProperties.put("zigbee_shortpress_cluster_id", "768");
+        channelProperties.put("zigbee_shortpress_command_id", "0x01");
+        channelProperties.put("zigbee_shortpress_parameter_name", "moveMode");
+        channelProperties.put("zigbee_shortpress_parameter_value", "1");
+        mockCluster(768);
+        converter.initializeConverter();
+
+        MoveHueCommand moveHueCommand = new MoveHueCommand();
+        moveHueCommand.setMoveMode(0);
+        converter.commandReceived(moveHueCommand);
+
+        verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.SHORT_PRESSED);
+        verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.LONG_PRESSED);
+        verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.DOUBLE_PRESSED);
+    }
+
+    @Test
+    public void commandTypeIsCorrectlyDetected() {
+        channelProperties.put("zigbee_shortpress_cluster_id", "0x0008");
+        channelProperties.put("zigbee_shortpress_command_id", "0x0017");
+
+        channelProperties.put("zigbee_longpress_cluster_id", "768");
+        channelProperties.put("zigbee_longpress_command_id", "0x01");
+
+        channelProperties.put("zigbee_doublepress_cluster_id", "0x0009");
+        channelProperties.put("zigbee_doublepress_command_id", "0x0017");
+
+        mockCluster(768);
+        converter.initializeConverter();
+
+        converter.commandReceived(new MoveHueCommand());
+
+        verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.SHORT_PRESSED);
+        verify(thingHandler, times(1)).triggerChannel(channel.getUID(), CommonTriggerEvents.LONG_PRESSED);
+        verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.DOUBLE_PRESSED);
+    }
+
+    private ZclCluster mockCluster(int clusterId) {
+        ZclCluster cluster = mock(ZclCluster.class);
+        when(cluster.getClusterId()).thenReturn(clusterId);
+        when(cluster.bind()).thenReturn(CompletableFuture.completedFuture(new CommandResult(new ZigBeeCommand())));
+        when(endpoint.getOutputCluster(clusterId)).thenReturn(cluster);
+        return cluster;
+    }
+
+}


### PR DESCRIPTION
This PR contains a converter for trigger channels of type 'system.button'. The converter binds to the client cluster implemented by the device with the button, and emits trigger events when a particular command is received from the device.

The converter is configured via channel properties that specify on which commands the converter shall react. A different command can be specified for short, long, and double button presses (the three button press types of the button system channel). Since the converter needs to be configured via channel properties, devices with such buttons need to be specified via a static thing type.

I have tested the implementation so far with a remote control from bitronhome, the model 902010/23 (see, e.g., https://www.qivicon.com/assets/Products/Bitron-Home/4-Tasten-Fernbedienung/LBT90353-DS902010-003-902010-23.pdf). This remote has four buttons; two of the buttons generate an On and Off command of the OnOff cluster, respectively; the other two buttons generate a Step-with-on-off command of the LevelControl cluster, with a different stepMode parameter for each button. The device does not support other press modes (e.g., long or double press).

With the proposed solution, the channels (one for each button) are defined as indicated in the XML snipped below. For each channel,
* the channel property `zigbee_shortpress_cluster_id` specifies the cluster of the generated command,
* the channel property `zigbee_shortpress_command_id` specifies the id of the command,
* and the optional channel properties `zigbee_shortpress_parameter_name` and `zigbee_shortpress_parameter_value` specify a parameter sent with the command.
* The same four properties exist also for `longpress` and `doublepress` (to be used in devices that support different press types, unlike the bitronhome remote I use as example here).

```xml
  <channels>
        <!-- The button marked with 1 dot -->
        <channel typeId="system.button" id="key1" zigbee-endpoint="1">
          <label>Button 1</label>
          <description>Button marked with one dot</description>
          <properties>
            <!-- This trigger channel triggers when a StepWithOnOff command with stepMode 0 is received -->
            <property name="zigbee_shortpress_cluster_id">0x0008</property>
            <property name="zigbee_shortpress_command_id">0x06</property>
            <property name="zigbee_shortpress_parameter_name">stepMode</property>
            <property name="zigbee_shortpress_parameter_value">0</property>
          </properties>
        </channel>
        
        <!-- The button marked with 2 dots -->
        <channel typeId="system.button" id="key2" zigbee-endpoint="1">
          <label>Button 2</label>
          <description>Button marked with two dots</description>
          <properties>
            <!-- This trigger channel triggers when an On command is received -->
            <property name="zigbee_shortpress_cluster_id">0x0006</property>
            <property name="zigbee_shortpress_command_id">0x01</property>
          </properties>
        </channel>
        
        <!-- The button marked with 3 dots -->
        <channel typeId="system.button" id="key3" zigbee-endpoint="1">
          <label>Button 3</label>
          <description>Button marked with three dots</description>
          <properties>
            <!-- This trigger channel triggers when an Off command is received -->
            <property name="zigbee_shortpress_cluster_id">0x0006</property>
            <property name="zigbee_shortpress_command_id">0x00</property>
          </properties>
        </channel>
        
        <!-- The button marked with 4 dots -->
        <channel typeId="system.button" id="key4" zigbee-endpoint="1">
          <label>Button 4</label>
          <description>Button marked with four dots</description>
          <properties>
            <!-- This trigger channel triggers when a StepWithOnOff command with stepMode 1 is received -->
            <property name="zigbee_shortpress_cluster_id">0x0008</property>
            <property name="zigbee_shortpress_command_id">0x06</property>
            <property name="zigbee_shortpress_parameter_name">stepMode</property>
            <property name="zigbee_shortpress_parameter_value">1</property>
          </properties>
        </channel>
    </channels>
```

I am wondering whether the solution for specifying the command's parameter is the ideal one. The solution implemented here uses reflection to get the value of a command parameter (e.g., to call the method `StepWithOnOffCommand# getStepMode()` to get the step mode of a StepWithOnOff command). I could not see any other option with the current version of the core framework, where the generated command classes only permit to read parameters using named getter methods. If the core framework would permit to get, say, "the second parameter of the command" (where order of parameters is as specified in the cluster library), one could omit reflection. Do you have any thoughts on this, @cdjackson?

Besides this question on handling of command parameters, what do you think of the general approach of supporting different remote controls / wall switches?