### PR TITLE
Do not set thing status to OFFLINE on node removal during thing removal

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -580,7 +580,9 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
         properties.put(ZigBeeBindingConstants.THING_PROPERTY_ASSOCIATEDDEVICES, "[]");
         updateProperties(properties);
 
-        updateStatus(ThingStatus.OFFLINE);
+        if (getThing().getStatus() != ThingStatus.REMOVING) {
+            updateStatus(ThingStatus.OFFLINE);
+        }
     }
 
     @Override


### PR DESCRIPTION
Setting the status to `OFFLINE` for a thing in status `REMOVING` leads to an invalid thing status transition, as one can only go to `REMOVED` from `REMOVING` state.

Fixes #282 
