### PR TITLE
Verbose debug logging and status handling of the CoordinatorHandler

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -745,10 +745,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
             case INITIALISING:
                 break;
             case ONLINE:
-                // make sure to not confuse child things
-                if (getThing().getStatus() != ThingStatus.ONLINE) {
-                    updateStatus(ThingStatus.ONLINE);
-                }
+                updateStatus(ThingStatus.ONLINE);
                 break;
             case OFFLINE:
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -173,12 +173,15 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
 
         if (getConfig().get(CONFIGURATION_INITIALIZE) != null) {
             initializeNetwork = (Boolean) getConfig().get(CONFIGURATION_INITIALIZE);
+            logger.debug("Config: {} found, initializeNetwork={}", CONFIGURATION_INITIALIZE, initializeNetwork);
         } else {
             initializeNetwork = true;
+            logger.debug("Config: {} not found, initializeNetwork={} ", CONFIGURATION_INITIALIZE, initializeNetwork);
         }
 
         if (extendedPanId == null || extendedPanId.equals(new ExtendedPanId()) || panId == 0) {
             initializeNetwork = true;
+            logger.debug("ExtendedPanId or PanId not set: initializeNetwork={}", initializeNetwork);
         }
 
         // Process the network key
@@ -395,10 +398,13 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
                 return;
         }
 
-        // Get the initial network configuration
+        // Show the initial network configuration for debugging
         ZigBeeChannel currentChannel = networkManager.getZigBeeChannel();
         int currentPanId = networkManager.getZigBeePanId();
         ExtendedPanId currentExtendedPanId = networkManager.getZigBeeExtendedPanId();
+
+        logger.debug("ZigBee Initialise: Previous device configuration was: channel={}, PanID={}, EPanId={}",
+                currentChannel, currentPanId, currentExtendedPanId);
 
         if (initializeNetwork) {
             logger.debug("Link key initialise {}", linkKey);
@@ -412,6 +418,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
 
         if (getConfig().get(CONFIGURATION_TRUSTCENTREMODE) != null) {
             String mode = (String) getConfig().get(CONFIGURATION_TRUSTCENTREMODE);
+            logger.debug("Config: {}={}", CONFIGURATION_TRUSTCENTREMODE, mode);
             TrustCentreJoinMode linkMode = TrustCentreJoinMode.valueOf(mode);
             transportConfig.addOption(TransportConfigOption.TRUST_CENTRE_JOIN_MODE, linkMode);
         }
@@ -731,13 +738,17 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
 
     @Override
     public void networkStateUpdated(final ZigBeeTransportState state) {
+        logger.debug("{}: networkStateUpdated called with state={}", nodeIeeeAddress, state);
         switch (state) {
             case UNINITIALISED:
                 break;
             case INITIALISING:
                 break;
             case ONLINE:
-                updateStatus(ThingStatus.ONLINE);
+                // make sure to not confuse child things
+                if (getThing().getStatus() != ThingStatus.ONLINE) {
+                    updateStatus(ThingStatus.ONLINE);
+                }
                 break;
             case OFFLINE:
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -129,7 +129,8 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
         }
         nodeIeeeAddress = new IeeeAddress(configAddress);
 
-        updateStatus(ThingStatus.OFFLINE);
+        // we do not know the current state of the device until our scheduled job has initialized the device
+        updateStatus(ThingStatus.UNKNOWN);
 
         if (getBridge() != null) {
             bridgeStatusChanged(getBridge().getStatusInfo());


### PR DESCRIPTION
Without this PR the coordinator reacts immediately on changes from the
underlying zss library. However this leads to correct but problematic status
changes, for example: ONLINE -> OFFLINE -> ONLINE

This happens during initialization where the status from the zss library
reports: UNINITIALISED -> ONLINE -> INILIALISING -> OFFLINE -> ONLINE -> ONLINE

The problem with these changes are that the children of such a bridge handler
react immediately with `bridgeStatusChanged()` on whatever state the bridge
has.

Inside the `bridgeStatusChanged()` a child `ThingHandler` might also want
to initialize the network inside the zss library and this will cause
unexpected results.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>