### PR TITLE
Add a converter for battery alarms from the power configuration profile

### DIFF
--- a/org.openhab.binding.zigbee/ESH-INF/thing/channels.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/channels.xml
@@ -20,11 +20,11 @@
         <category>Energy</category>
         <state readOnly="true">
           <options>
-            <option value="minThresholdReached">Battery level dropped below minimal threshold</option>
-            <option value="threshold1Reached">Battery level dropped below threshold 1</option>
-            <option value="threshold2Reached">Battery level dropped below threshold 2</option>
-            <option value="threshold3Reached">Battery level dropped below threshold 3</option>
-            <option value="noThresholdReached">No battery alarm</option>
+            <option value="minThreshold">Below min threshold</option>
+            <option value="threshold1">Below threshold 1</option>
+            <option value="threshold2">Below threshold 2</option>
+            <option value="threshold3">Below threshold 3</option>
+            <option value="noThreshold">No battery alarm</option>
           </options>
         </state>
     </channel-type>

--- a/org.openhab.binding.zigbee/ESH-INF/thing/channels.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/channels.xml
@@ -11,6 +11,23 @@
         <category>Energy</category>
         <state pattern="%.1f" readOnly="true" />
     </channel-type>
+    
+    <!-- Battery Alarm -->
+    <channel-type id="battery_alarm">
+        <item-type>String</item-type>
+        <label>Battery Alarm</label>
+        <description>The battery alarm state</description>
+        <category>Energy</category>
+        <state readOnly="true">
+          <options>
+            <option value="minThresholdReached">Battery level dropped below minimal threshold</option>
+            <option value="threshold1Reached">Battery level dropped below threshold 1</option>
+            <option value="threshold2Reached">Battery level dropped below threshold 2</option>
+            <option value="threshold3Reached">Battery level dropped below threshold 3</option>
+            <option value="noThresholdReached">No battery alarm</option>
+          </options>
+        </state>
+    </channel-type>
 
     <!-- Color Channel -->
     <channel-type id="color_color">

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -199,11 +199,11 @@ public class ZigBeeBindingConstants {
     public static final String FIRMWARE_FAILED = "@text/zigbee.firmware.failed";
 
     // List of channel state constants
-    public static final String STATE_OPTION_BATTERY_MIN_THRESHOLD_REACHED = "minThresholdReached";
-    public static final String STATE_OPTION_BATTERY_THRESHOLD_1_REACHED = "threshold1Reached";
-    public static final String STATE_OPTION_BATTERY_THRESHOLD_2_REACHED = "threshold2Reached";
-    public static final String STATE_OPTION_BATTERY_THRESHOLD_3_REACHED = "threshold3Reached";
-    public static final String STATE_OPTION_BATTERY_NO_THRESHOLD_REACHED = "noThresholdReached";
+    public static final String STATE_OPTION_BATTERY_MIN_THRESHOLD = "minThreshold";
+    public static final String STATE_OPTION_BATTERY_THRESHOLD_1 = "threshold1";
+    public static final String STATE_OPTION_BATTERY_THRESHOLD_2 = "threshold2";
+    public static final String STATE_OPTION_BATTERY_THRESHOLD_3 = "threshold3";
+    public static final String STATE_OPTION_BATTERY_NO_THRESHOLD = "noThreshold";
 
     // List of configuration values for flow control
     public static final Integer FLOWCONTROL_CONFIG_NONE = Integer.valueOf(0);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -128,6 +128,10 @@ public class ZigBeeBindingConstants {
     public static final String CHANNEL_LABEL_POWER_BATTERYVOLTAGE = "Battery Voltage";
     public static final ChannelTypeUID CHANNEL_POWER_BATTERYVOLTAGE = new ChannelTypeUID("zigbee:battery_voltage");
 
+    public static final String CHANNEL_NAME_POWER_BATTERYALARM = "batteryalarm";
+    public static final String CHANNEL_LABEL_POWER_BATTERYALARM = "Battery Alarm";
+    public static final ChannelTypeUID CHANNEL_POWER_BATTERYALARM = new ChannelTypeUID("zigbee:battery_alarm");
+
     public static final String CHANNEL_NAME_ELECTRICAL_RMSCURRENT = "current";
     public static final String CHANNEL_LABEL_ELECTRICAL_RMSCURRENT = "Current";
     public static final ChannelTypeUID CHANNEL_ELECTRICAL_RMSCURRENT = new ChannelTypeUID(
@@ -146,6 +150,7 @@ public class ZigBeeBindingConstants {
     public static final String ITEM_TYPE_NUMBER_PRESSURE = "Number:Pressure";
     public static final String ITEM_TYPE_NUMBER_TEMPERATURE = "Number:Temperature";
     public static final String ITEM_TYPE_SWITCH = "Switch";
+    public static final String ITEM_TYPE_STRING = "String";
 
     public static final String THING_PROPERTY_STKVERSION = "zigbee_stkversion";
     public static final String THING_PROPERTY_ZCLVERSION = "zigbee_zclversion";
@@ -192,6 +197,13 @@ public class ZigBeeBindingConstants {
     public static final String OFFLINE_DISCOVERY_INCOMPLETE = "@text/zigbee.status.offline_discoveryincomplete";
 
     public static final String FIRMWARE_FAILED = "@text/zigbee.firmware.failed";
+
+    // List of channel state constants
+    public static final String STATE_OPTION_BATTERY_MIN_THRESHOLD_REACHED = "minThresholdReached";
+    public static final String STATE_OPTION_BATTERY_THRESHOLD_1_REACHED = "threshold1Reached";
+    public static final String STATE_OPTION_BATTERY_THRESHOLD_2_REACHED = "threshold2Reached";
+    public static final String STATE_OPTION_BATTERY_THRESHOLD_3_REACHED = "threshold3Reached";
+    public static final String STATE_OPTION_BATTERY_NO_THRESHOLD_REACHED = "noThresholdReached";
 
     // List of configuration values for flow control
     public static final Integer FLOWCONTROL_CONFIG_NONE = Integer.valueOf(0);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactory.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactory.java
@@ -72,6 +72,7 @@ public class ZigBeeChannelConverterFactory {
         channelMap.put(ZigBeeBindingConstants.CHANNEL_OCCUPANCY_SENSOR, ZigBeeConverterOccupancy.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_POWER_BATTERYPERCENT, ZigBeeConverterBatteryPercent.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_POWER_BATTERYVOLTAGE, ZigBeeConverterBatteryVoltage.class);
+        channelMap.put(ZigBeeBindingConstants.CHANNEL_POWER_BATTERYALARM, ZigBeeConverterBatteryAlarm.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_PRESSURE_VALUE, ZigBeeConverterAtmosphericPressure.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_SWITCH_ONOFF, ZigBeeConverterSwitchOnoff.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_SWITCH_LEVEL, ZigBeeConverterSwitchLevel.class);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zigbee.internal.converter;
+
+import static com.zsmartsystems.zigbee.zcl.clusters.ZclPowerConfigurationCluster.ATTR_BATTERYALARMSTATE;
+import static java.time.Duration.*;
+import static org.openhab.binding.zigbee.ZigBeeBindingConstants.*;
+
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
+import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.zsmartsystems.zigbee.CommandResult;
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.zcl.ZclAttribute;
+import com.zsmartsystems.zigbee.zcl.ZclAttributeListener;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclPowerConfigurationCluster;
+import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
+
+/**
+ * Converter for a battery alarm channel.
+ * <p>
+ * This converter relies on reports for the BatteryAlarmState attribute of the power configuration cluster, setting the
+ * state of the battery alarm channel depending on the bits set in the BatteryAlarmState.
+ * <p>
+ * Possible future improvements:
+ * <ul>
+ * <li>The BatteryAlarmState provides battery level information for up to three batteries; this converter only considers
+ * the information for the first battery.
+ * <li>Devices might use alarms from the Alarms cluster instead of the BatteryAlarmState attribute to indicate battery
+ * alarms. This is currently not supported by this converter.
+ * <li>Devices might permit to configure the four battery level/voltage thresholds on which battery alarms are signaled;
+ * such configuration is currently not supported.
+ * </ul>
+ *
+ * @author Henning Sudbrock - Initial Contribution
+ */
+public class ZigBeeConverterBatteryAlarm extends ZigBeeBaseChannelConverter implements ZclAttributeListener {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private static final int ALARMSTATE_MIN_REPORTING_INTERVAL = (int) ofMinutes(10).getSeconds();
+    private static final int ALARMSTATE_MAX_REPORTING_INTERVAL = (int) ofHours(2).getSeconds();
+
+    private static final int MIN_THRESHOLD_BITMASK = 0b0001;
+    private static final int THRESHOLD_1_BITMASK = 0b0010;
+    private static final int THRESHOLD_2_BITMASK = 0b0100;
+    private static final int THRESHOLD_3_BITMASK = 0b1000;
+
+    private static final int BATTERY_ALARM_POLLING_PERIOD = (int) ofMinutes(30).getSeconds();
+
+    private ZclPowerConfigurationCluster cluster;
+
+    @Override
+    public boolean initializeConverter() {
+        logger.debug("{}: Initialising device battery alarm converter", endpoint.getIeeeAddress());
+
+        cluster = (ZclPowerConfigurationCluster) endpoint.getInputCluster(ZclPowerConfigurationCluster.CLUSTER_ID);
+        if (cluster == null) {
+            logger.error("{}: Error opening power configuration cluster", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        try {
+            CommandResult bindResponse = cluster.bind().get();
+            if (bindResponse.isSuccess()) {
+                CommandResult reportingResponse = cluster.setReporting(cluster.getAttribute(ATTR_BATTERYALARMSTATE),
+                        ALARMSTATE_MIN_REPORTING_INTERVAL, ALARMSTATE_MAX_REPORTING_INTERVAL).get();
+                if (reportingResponse.isError()) {
+                    logger.debug("Could not configure reporting for the battery alarm state; polling every {} seconds",
+                            BATTERY_ALARM_POLLING_PERIOD);
+                    pollingPeriod = BATTERY_ALARM_POLLING_PERIOD;
+                }
+            } else {
+                pollingPeriod = BATTERY_ALARM_POLLING_PERIOD;
+                logger.debug(
+                        "Could not bind to the power configuration cluster; polling battery alarm state every {} seconds",
+                        BATTERY_ALARM_POLLING_PERIOD);
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error("{}: Exception setting reporting of battery alarm state ", endpoint.getIeeeAddress(), e);
+            return false;
+        }
+
+        cluster.addAttributeListener(this);
+        return true;
+    }
+
+    @Override
+    public void disposeConverter() {
+        logger.debug("{}: Closing battery alarm converter", endpoint.getIeeeAddress());
+        cluster.removeAttributeListener(this);
+    }
+
+    @Override
+    public void handleRefresh() {
+        cluster.getBatteryAlarmState(0);
+    }
+
+    @Override
+    public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
+        ZclPowerConfigurationCluster powerConfigurationCluster = (ZclPowerConfigurationCluster) endpoint
+                .getInputCluster(ZclPowerConfigurationCluster.CLUSTER_ID);
+        if (powerConfigurationCluster == null) {
+            logger.trace("{}: Power configuration cluster not found on endpoint {}", endpoint.getIeeeAddress(),
+                    endpoint.getEndpointId());
+            return null;
+        }
+
+        try {
+            if (!powerConfigurationCluster.discoverAttributes(false).get() && !powerConfigurationCluster
+                    .isAttributeSupported(ZclPowerConfigurationCluster.ATTR_BATTERYALARMSTATE)) {
+                logger.trace("{}: Power configuration cluster battery alarm state not supported",
+                        endpoint.getIeeeAddress());
+                return null;
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.warn("{}: Exception discovering attributes in power configuration cluster",
+                    endpoint.getIeeeAddress(), e);
+            return null;
+        }
+
+        return ChannelBuilder
+                .create(createChannelUID(thingUID, endpoint, ZigBeeBindingConstants.CHANNEL_NAME_POWER_BATTERYALARM),
+                        ZigBeeBindingConstants.ITEM_TYPE_STRING)
+                .withType(ZigBeeBindingConstants.CHANNEL_POWER_BATTERYALARM)
+                .withLabel(ZigBeeBindingConstants.CHANNEL_LABEL_POWER_BATTERYALARM)
+                .withProperties(createProperties(endpoint)).build();
+    }
+
+    @Override
+    public void attributeUpdated(ZclAttribute attribute) {
+        if (attribute.getCluster() == ZclClusterType.POWER_CONFIGURATION
+                && attribute.getId() == ZclPowerConfigurationCluster.ATTR_BATTERYALARMSTATE) {
+
+            logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+
+            // The value is a 32-bit bitmap, represented by an Integer
+            Integer value = (Integer) attribute.getLastValue();
+            if (value == null) {
+                return;
+            }
+
+            if ((value & MIN_THRESHOLD_BITMASK) != 0) {
+                updateChannelState(new StringType(STATE_OPTION_BATTERY_MIN_THRESHOLD_REACHED));
+            } else if ((value & THRESHOLD_1_BITMASK) != 0) {
+                updateChannelState(new StringType(STATE_OPTION_BATTERY_THRESHOLD_1_REACHED));
+            } else if ((value & THRESHOLD_2_BITMASK) != 0) {
+                updateChannelState(new StringType(STATE_OPTION_BATTERY_THRESHOLD_2_REACHED));
+            } else if ((value & THRESHOLD_3_BITMASK) != 0) {
+                updateChannelState(new StringType(STATE_OPTION_BATTERY_THRESHOLD_3_REACHED));
+            } else {
+                updateChannelState(new StringType(STATE_OPTION_BATTERY_NO_THRESHOLD_REACHED));
+            }
+        }
+    }
+}

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
@@ -154,15 +154,15 @@ public class ZigBeeConverterBatteryAlarm extends ZigBeeBaseChannelConverter impl
             }
 
             if ((value & MIN_THRESHOLD_BITMASK) != 0) {
-                updateChannelState(new StringType(STATE_OPTION_BATTERY_MIN_THRESHOLD_REACHED));
+                updateChannelState(new StringType(STATE_OPTION_BATTERY_MIN_THRESHOLD));
             } else if ((value & THRESHOLD_1_BITMASK) != 0) {
-                updateChannelState(new StringType(STATE_OPTION_BATTERY_THRESHOLD_1_REACHED));
+                updateChannelState(new StringType(STATE_OPTION_BATTERY_THRESHOLD_1));
             } else if ((value & THRESHOLD_2_BITMASK) != 0) {
-                updateChannelState(new StringType(STATE_OPTION_BATTERY_THRESHOLD_2_REACHED));
+                updateChannelState(new StringType(STATE_OPTION_BATTERY_THRESHOLD_2));
             } else if ((value & THRESHOLD_3_BITMASK) != 0) {
-                updateChannelState(new StringType(STATE_OPTION_BATTERY_THRESHOLD_3_REACHED));
+                updateChannelState(new StringType(STATE_OPTION_BATTERY_THRESHOLD_3));
             } else {
-                updateChannelState(new StringType(STATE_OPTION_BATTERY_NO_THRESHOLD_REACHED));
+                updateChannelState(new StringType(STATE_OPTION_BATTERY_NO_THRESHOLD));
             }
         }
     }

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarmTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarmTest.java
@@ -1,0 +1,119 @@
+package org.openhab.binding.zigbee.internal.converter;
+
+import static com.zsmartsystems.zigbee.zcl.clusters.ZclPowerConfigurationCluster.*;
+import static com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.openhab.binding.zigbee.ZigBeeBindingConstants.*;
+
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
+
+import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.zcl.ZclAttribute;
+import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
+
+/**
+ * Unit tests for the {@link ZigBeeConverterBatteryAlarm}.
+ *
+ * @author Henning Sudbrock - initial contribution
+ */
+public class ZigBeeConverterBatteryAlarmTest {
+
+    private ZigBeeConverterBatteryAlarm converter;
+
+    private ZigBeeThingHandler thingHandler;
+    private Channel channel;
+    private ZigBeeCoordinatorHandler coordinatorHandler;
+    private ZigBeeEndpoint endpoint;
+
+    @Before
+    public void setup() {
+        IeeeAddress ieeeAddress = new IeeeAddress();
+        int endpointId = 1;
+
+        endpoint = mock(ZigBeeEndpoint.class);
+        channel = mock(Channel.class);
+        thingHandler = mock(ZigBeeThingHandler.class);
+
+        coordinatorHandler = mock(ZigBeeCoordinatorHandler.class);
+        when(coordinatorHandler.getEndpoint(ieeeAddress, endpointId)).thenReturn(endpoint);
+
+        converter = new ZigBeeConverterBatteryAlarm();
+        converter.initialize(thingHandler, channel, coordinatorHandler, ieeeAddress, endpointId);
+    }
+
+    @Test
+    public void testAttributeUpdateForMinThreshold() {
+        // Bit 0 indicates BatteryMinThreshold
+        converter.attributeUpdated(makeAlarmState(0b0001));
+        Mockito.verify(thingHandler).setChannelState(channel.getUID(),
+                new StringType(STATE_OPTION_BATTERY_MIN_THRESHOLD_REACHED));
+    }
+
+    @Test
+    public void testAttributeUpdateForThreshold1() {
+        // Bit 1 indicates threshold 1
+        converter.attributeUpdated(makeAlarmState(0b0010));
+        Mockito.verify(thingHandler).setChannelState(channel.getUID(),
+                new StringType(STATE_OPTION_BATTERY_THRESHOLD_1_REACHED));
+    }
+
+    @Test
+    public void testAttributeUpdateForThreshold2() {
+        // Bit 2 indicates threshold 2
+        converter.attributeUpdated(makeAlarmState(0b0100));
+        Mockito.verify(thingHandler).setChannelState(channel.getUID(),
+                new StringType(STATE_OPTION_BATTERY_THRESHOLD_2_REACHED));
+    }
+
+    @Test
+    public void testAttributeUpdateForThreshold3() {
+        // Bit 3 indicates threshold 3
+        converter.attributeUpdated(makeAlarmState(0b1000));
+        Mockito.verify(thingHandler).setChannelState(channel.getUID(),
+                new StringType(STATE_OPTION_BATTERY_THRESHOLD_3_REACHED));
+    }
+
+    @Test
+    public void testAttributeUpdateForNoThreshold() {
+        converter.attributeUpdated(makeAlarmState(0b0000));
+        Mockito.verify(thingHandler).setChannelState(channel.getUID(),
+                new StringType(STATE_OPTION_BATTERY_NO_THRESHOLD_REACHED));
+    }
+
+    @Test
+    public void testAttributeUpdateMultipleThresholds() {
+        converter.attributeUpdated(makeAlarmState(0b1110));
+        Mockito.verify(thingHandler).setChannelState(channel.getUID(),
+                new StringType(STATE_OPTION_BATTERY_THRESHOLD_1_REACHED));
+    }
+
+    @Test
+    public void testAttributeUpdateUnsuitableAttribute() {
+        converter.attributeUpdated(new ZclAttribute(POWER_CONFIGURATION, ATTR_BATTERYALARMMASK, "alarm_mask",
+                ZclDataType.BITMAP_32_BIT, false, true, false, true));
+        Mockito.verify(thingHandler, never()).setChannelState(any(), any());
+    }
+
+    @Test
+    public void testAttributeUpdateUnsuitableCluster() {
+        converter.attributeUpdated(new ZclAttribute(FAN_CONTROL, ATTR_BATTERYALARMMASK, "bla",
+                ZclDataType.BITMAP_32_BIT, false, true, false, true));
+        Mockito.verify(thingHandler, never()).setChannelState(any(), any());
+    }
+
+    private ZclAttribute makeAlarmState(int bitmask) {
+        ZclAttribute attribute = new ZclAttribute(POWER_CONFIGURATION, ATTR_BATTERYALARMSTATE, "alarm_state",
+                ZclDataType.BITMAP_32_BIT, false, true, false, true);
+        attribute.updateValue(Integer.valueOf(bitmask));
+        return attribute;
+    }
+
+}

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarmTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarmTest.java
@@ -55,7 +55,7 @@ public class ZigBeeConverterBatteryAlarmTest {
         // Bit 0 indicates BatteryMinThreshold
         converter.attributeUpdated(makeAlarmState(0b0001));
         verify(thingHandler).setChannelState(channel.getUID(),
-                new StringType(STATE_OPTION_BATTERY_MIN_THRESHOLD_REACHED));
+                new StringType(STATE_OPTION_BATTERY_MIN_THRESHOLD));
     }
 
     @Test
@@ -63,7 +63,7 @@ public class ZigBeeConverterBatteryAlarmTest {
         // Bit 1 indicates threshold 1
         converter.attributeUpdated(makeAlarmState(0b0010));
         verify(thingHandler).setChannelState(channel.getUID(),
-                new StringType(STATE_OPTION_BATTERY_THRESHOLD_1_REACHED));
+                new StringType(STATE_OPTION_BATTERY_THRESHOLD_1));
     }
 
     @Test
@@ -71,7 +71,7 @@ public class ZigBeeConverterBatteryAlarmTest {
         // Bit 2 indicates threshold 2
         converter.attributeUpdated(makeAlarmState(0b0100));
         verify(thingHandler).setChannelState(channel.getUID(),
-                new StringType(STATE_OPTION_BATTERY_THRESHOLD_2_REACHED));
+                new StringType(STATE_OPTION_BATTERY_THRESHOLD_2));
     }
 
     @Test
@@ -79,21 +79,21 @@ public class ZigBeeConverterBatteryAlarmTest {
         // Bit 3 indicates threshold 3
         converter.attributeUpdated(makeAlarmState(0b1000));
         verify(thingHandler).setChannelState(channel.getUID(),
-                new StringType(STATE_OPTION_BATTERY_THRESHOLD_3_REACHED));
+                new StringType(STATE_OPTION_BATTERY_THRESHOLD_3));
     }
 
     @Test
     public void testAttributeUpdateForNoThreshold() {
         converter.attributeUpdated(makeAlarmState(0b0000));
         verify(thingHandler).setChannelState(channel.getUID(),
-                new StringType(STATE_OPTION_BATTERY_NO_THRESHOLD_REACHED));
+                new StringType(STATE_OPTION_BATTERY_NO_THRESHOLD));
     }
 
     @Test
     public void testAttributeUpdateMultipleThresholds() {
         converter.attributeUpdated(makeAlarmState(0b1110));
         verify(thingHandler).setChannelState(channel.getUID(),
-                new StringType(STATE_OPTION_BATTERY_THRESHOLD_1_REACHED));
+                new StringType(STATE_OPTION_BATTERY_THRESHOLD_1));
     }
 
     @Test

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarmTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarmTest.java
@@ -8,9 +8,10 @@ import static org.openhab.binding.zigbee.ZigBeeBindingConstants.*;
 
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.types.State;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 
@@ -53,7 +54,7 @@ public class ZigBeeConverterBatteryAlarmTest {
     public void testAttributeUpdateForMinThreshold() {
         // Bit 0 indicates BatteryMinThreshold
         converter.attributeUpdated(makeAlarmState(0b0001));
-        Mockito.verify(thingHandler).setChannelState(channel.getUID(),
+        verify(thingHandler).setChannelState(channel.getUID(),
                 new StringType(STATE_OPTION_BATTERY_MIN_THRESHOLD_REACHED));
     }
 
@@ -61,7 +62,7 @@ public class ZigBeeConverterBatteryAlarmTest {
     public void testAttributeUpdateForThreshold1() {
         // Bit 1 indicates threshold 1
         converter.attributeUpdated(makeAlarmState(0b0010));
-        Mockito.verify(thingHandler).setChannelState(channel.getUID(),
+        verify(thingHandler).setChannelState(channel.getUID(),
                 new StringType(STATE_OPTION_BATTERY_THRESHOLD_1_REACHED));
     }
 
@@ -69,7 +70,7 @@ public class ZigBeeConverterBatteryAlarmTest {
     public void testAttributeUpdateForThreshold2() {
         // Bit 2 indicates threshold 2
         converter.attributeUpdated(makeAlarmState(0b0100));
-        Mockito.verify(thingHandler).setChannelState(channel.getUID(),
+        verify(thingHandler).setChannelState(channel.getUID(),
                 new StringType(STATE_OPTION_BATTERY_THRESHOLD_2_REACHED));
     }
 
@@ -77,21 +78,21 @@ public class ZigBeeConverterBatteryAlarmTest {
     public void testAttributeUpdateForThreshold3() {
         // Bit 3 indicates threshold 3
         converter.attributeUpdated(makeAlarmState(0b1000));
-        Mockito.verify(thingHandler).setChannelState(channel.getUID(),
+        verify(thingHandler).setChannelState(channel.getUID(),
                 new StringType(STATE_OPTION_BATTERY_THRESHOLD_3_REACHED));
     }
 
     @Test
     public void testAttributeUpdateForNoThreshold() {
         converter.attributeUpdated(makeAlarmState(0b0000));
-        Mockito.verify(thingHandler).setChannelState(channel.getUID(),
+        verify(thingHandler).setChannelState(channel.getUID(),
                 new StringType(STATE_OPTION_BATTERY_NO_THRESHOLD_REACHED));
     }
 
     @Test
     public void testAttributeUpdateMultipleThresholds() {
         converter.attributeUpdated(makeAlarmState(0b1110));
-        Mockito.verify(thingHandler).setChannelState(channel.getUID(),
+        verify(thingHandler).setChannelState(channel.getUID(),
                 new StringType(STATE_OPTION_BATTERY_THRESHOLD_1_REACHED));
     }
 
@@ -99,14 +100,14 @@ public class ZigBeeConverterBatteryAlarmTest {
     public void testAttributeUpdateUnsuitableAttribute() {
         converter.attributeUpdated(new ZclAttribute(POWER_CONFIGURATION, ATTR_BATTERYALARMMASK, "alarm_mask",
                 ZclDataType.BITMAP_32_BIT, false, true, false, true));
-        Mockito.verify(thingHandler, never()).setChannelState(any(), any());
+        verify(thingHandler, never()).setChannelState(any(ChannelUID.class), any(State.class));
     }
 
     @Test
     public void testAttributeUpdateUnsuitableCluster() {
         converter.attributeUpdated(new ZclAttribute(FAN_CONTROL, ATTR_BATTERYALARMMASK, "bla",
                 ZclDataType.BITMAP_32_BIT, false, true, false, true));
-        Mockito.verify(thingHandler, never()).setChannelState(any(), any());
+        verify(thingHandler, never()).setChannelState(any(ChannelUID.class), any(State.class));
     }
 
     private ZclAttribute makeAlarmState(int bitmask) {


### PR DESCRIPTION
Resolves #295 by adding a channel converter that provides a battery alarm channel based on the power configuration cluster. This channel takes one out of five values: "No battery alarm was reported" or "The battery level dropped below one of four thresholds defined on the device".

Here's an example how this looks like in Paper UI (channel `Battery Alarm`). (The device also provides the IAS Zone cluster, resulting in the Low Battery channel, and it also provides the battery voltage via the power configuration cluster.)

![image](https://user-images.githubusercontent.com/5314568/48412225-571b4f00-e744-11e8-8b6c-61914bf1e3bd.png)

I would be happy about any feedback.
