### PR TITLE
Add support for Xiaomi Aqara Sensor HT via static thing definition XML (issue #314)

### DIFF
--- a/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensorht.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensorht.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zigbee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="xiaomi_lumisensorht">
+		<label>Xiaomi Temperature and Humidity Sensor</label>
+		<description>Xiaomi Temperature and Humidity Sensor</description>
+
+		<channels>
+			<channel id="temperature" typeId="measurement_temperature">
+				<properties>
+					<property name="zigbee_endpoint">1</property>
+					<property name="zigbee_inputclusters">1026</property>
+				</properties>
+			</channel>
+			<channel id="humidity" typeId="measurement_relativehumidity">
+				<properties>
+					<property name="zigbee_endpoint">1</property>
+					<property name="zigbee_inputclusters">1029</property>
+				</properties>
+			</channel>
+		</channels>
+
+		<properties>
+			<property name="vendor">Xiaomi</property>
+			<property name="modelId">lumi.sensor_ht</property>
+			<property name="zigbee_logicaltype">END_DEVICE</property>
+		</properties>
+
+		<representation-property>zigbee_macaddress</representation-property>
+
+		<config-description>
+			<parameter name="zigbee_macaddress" type="text" readOnly="true" required="true">
+				<label>MAC Address</label>
+			</parameter>
+		</config-description>
+	</thing-type>
+</thing:thing-descriptions>

--- a/org.openhab.binding.zigbee/src/main/resources/discovery.txt
+++ b/org.openhab.binding.zigbee/src/main/resources/discovery.txt
@@ -2,4 +2,5 @@ philips_sml001,vendor=Philips,modelId=SML001
 smartthings_motionv4,vendor=SmartThings,modelId=motionv4
 bitron-video-902010-23,vendor=Bitron Home,modelId=902010/23
 bitron-video-av2010-34,vendor=Bitron Video,modelId=AV2010/34
+xiaomi_lumisensorht,modelId=lumi.sensor_ht
 innr-rc-110,vendor=innr,modelId=RC 110


### PR DESCRIPTION
Added static definition xml file for "Xiaomi Aqara Sensor HT" overriding incorrectly reported input clusters
Added entry in discovery.txt file identifying these devices by "modelId=lumi.sensor_ht"

Signed-off-by: Pedro Garcia <pg@puzzle-star.com>