### PR TITLE
Changed channels and converters to to use QuantityType where units occur

### DIFF
--- a/org.openhab.binding.zigbee/ESH-INF/thing/channels.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/channels.xml
@@ -161,7 +161,7 @@
         <label>Atmospheric Pressure</label>
         <description>Indicates the current pressure</description>
         <category>Pressure</category>
-        <state pattern="%.1f" readOnly="true" />
+        <state pattern="%.1f %unit%" readOnly="true" />
     </channel-type>
 
     <!-- Humidity Channel -->
@@ -179,7 +179,7 @@
 		<label>Temperature</label>
 		<description>Indicates the current temperature</description>
 		<category>Temperature</category>
-		<state pattern="%.1f" readOnly="true" />
+		<state pattern="%.1f %unit%" readOnly="true" />
 	</channel-type>
 
 	<!-- Occupancy sensor -->

--- a/org.openhab.binding.zigbee/ESH-INF/thing/channels.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/channels.xml
@@ -148,11 +148,11 @@
 
     <!-- Illuminance Channel -->
     <channel-type id="measurement_illuminance">
-        <item-type>Number:Illuminance</item-type>
+        <item-type>Number</item-type>
         <label>Illuminance</label>
         <description>Indicates the current illuminance</description>
         <category></category>
-        <state pattern="%.1f %unit%" readOnly="true" />
+        <state pattern="%.1f" readOnly="true" />
     </channel-type>
     
     <!-- Atmospheric Pressure Channel -->

--- a/org.openhab.binding.zigbee/ESH-INF/thing/channels.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/channels.xml
@@ -5,11 +5,11 @@
 
     <!-- Battery Voltage -->
     <channel-type id="battery_voltage">
-        <item-type>Number</item-type>
+        <item-type>Number:ElectricPotential</item-type>
         <label>Battery Voltage</label>
         <description>The current battery voltage</description>
         <category>Energy</category>
-        <state pattern="%.1f" readOnly="true" />
+        <state pattern="%.1f %unit%" readOnly="true" />
     </channel-type>
     
     <!-- Battery Alarm -->
@@ -49,29 +49,29 @@
     
     <!-- Electrical Measurement Active Power -->
     <channel-type id="electrical_activepower">
-        <item-type>Number</item-type>
+        <item-type>Number:Power</item-type>
         <label>Total Active Power</label>
         <description>The total power consumed by the device</description>
         <category>Energy</category>
-        <state pattern="%.1f" readOnly="true" />
+        <state pattern="%.1f %unit%" readOnly="true" />
     </channel-type>
 
     <!-- RMS Current -->
     <channel-type id="electrical_rmscurrent">
-        <item-type>Number</item-type>
+        <item-type>Number:ElectricCurrent</item-type>
         <label>Current</label>
         <description>The current RMS current measurement</description>
         <category>Energy</category>
-        <state pattern="%.1f" readOnly="true" />
+        <state pattern="%.1f %unit%" readOnly="true" />
     </channel-type>
 
     <!-- RMS Voltage -->
     <channel-type id="electrical_rmsvoltage">
-        <item-type>Number</item-type>
+        <item-type>Number:ElectricPotential</item-type>
         <label>Voltage</label>
         <description>The current RMS voltage measurement</description>
         <category>Energy</category>
-        <state pattern="%.1f" readOnly="true" />
+        <state pattern="%.1f %unit%" readOnly="true" />
     </channel-type>
 
     <!-- IAS Contact Channel -->
@@ -148,11 +148,11 @@
 
     <!-- Illuminance Channel -->
     <channel-type id="measurement_illuminance">
-        <item-type>Number</item-type>
+        <item-type>Number:Illuminance</item-type>
         <label>Illuminance</label>
         <description>Indicates the current illuminance</description>
         <category></category>
-        <state pattern="%.1f" readOnly="true" />
+        <state pattern="%.1f %unit%" readOnly="true" />
     </channel-type>
     
     <!-- Atmospheric Pressure Channel -->

--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -150,12 +150,12 @@ The following channels are supported -:
 | Channel UID | ZigBee Cluster | Type     |Description                  |
 |-------------|----------------|----------|-----------------------------|
 | battery-level | ```POWER_CONFIGURATION``` (0x0001) | Number |   |
-| battery_voltage | ```POWER_CONFIGURATION``` (0x0001) | Number |   |
+| battery_voltage | ```POWER_CONFIGURATION``` (0x0001) | Number:ElectricPotential |   |
 | color_color | ```COLOR_CONTROL``` (0x0300) | Color |   |
 | color_temperature | ```COLOR_CONTROL``` (0x0300) | Dimmer |   |
-| electrical_activepower | ```ELECTRICAL_MEASUREMENT``` (0x0B04) | Number |   |
-| electrical_rmscurrent | ```ELECTRICAL_MEASUREMENT``` (0x0B04)  | Number |   |
-| electrical_rmsvoltage | ```ELECTRICAL_MEASUREMENT``` (0x0B04)  | Number |   |
+| electrical_activepower | ```ELECTRICAL_MEASUREMENT``` (0x0B04) | Number:Power |   |
+| electrical_rmscurrent | ```ELECTRICAL_MEASUREMENT``` (0x0B04)  | Number:ElectricCurrent |   |
+| electrical_rmsvoltage | ```ELECTRICAL_MEASUREMENT``` (0x0B04)  | Number:ElectricPotential |   |
 | ias_codetector | ```IAS_ZONE``` (0x0500)  | Switch |   |
 | ias_contactportal1 | ```IAS_ZONE``` (0x0500) | Switch |  |
 | ias_fire | ```IAS_ZONE``` (0x0500)  | Switch |   |
@@ -164,7 +164,7 @@ The following channels are supported -:
 | ias_standard_system | ```IAS_ZONE``` (0x0500) | Switch |  |
 | ias_water | ```IAS_ZONE``` (0x0500) | Switch |  |
 | measurement_illuminance | ```ILLUMINANCE_MEASUREMENT``` (0x0400) | Number |   |
-| measurement_pressure | ```PRESSURE_MEASUREMENT``` (0x0403) | Number |   |
+| measurement_pressure | ```PRESSURE_MEASUREMENT``` (0x0403) | Number:Pressure |   |
 | measurement_relativehumidity | ```RELATIVE_HUMIDITY_MEASUREMENT``` (0x0405) | Number |   |
 | measurement_temperature | ```TEMPERATURE_MEASUREMENT``` (0x0402) | Number:Temperature |   |
 | sensor_occupancy | ```OCCUPANCY_SENSING``` (0x0406) | Switch  |  |

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
@@ -125,7 +125,8 @@ public class ZigBeeConverterBatteryVoltage extends ZigBeeBaseChannelConverter im
                 // The value 0xFF indicates an invalid or unknown reading.
                 return;
             }
-            updateChannelState(new QuantityType<ElectricPotential>(BigDecimal.valueOf(value, 1), SmartHomeUnits.VOLT));
+            BigDecimal valueInVolt = BigDecimal.valueOf(value, 1);
+            updateChannelState(new QuantityType<ElectricPotential>(valueInVolt, SmartHomeUnits.VOLT));
         }
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
@@ -125,10 +125,7 @@ public class ZigBeeConverterBatteryVoltage extends ZigBeeBaseChannelConverter im
                 // The value 0xFF indicates an invalid or unknown reading.
                 return;
             }
-            updateChannelState(
-                    new QuantityType<ElectricPotential>(BigDecimal.valueOf(value, 1),
-                            SmartHomeUnits.VOLT));
-
+            updateChannelState(new QuantityType<ElectricPotential>(BigDecimal.valueOf(value, 1), SmartHomeUnits.VOLT));
         }
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
@@ -11,7 +11,10 @@ package org.openhab.binding.zigbee.internal.converter;
 import java.math.BigDecimal;
 import java.util.concurrent.ExecutionException;
 
-import org.eclipse.smarthome.core.library.types.DecimalType;
+import javax.measure.quantity.ElectricPotential;
+
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
@@ -122,7 +125,10 @@ public class ZigBeeConverterBatteryVoltage extends ZigBeeBaseChannelConverter im
                 // The value 0xFF indicates an invalid or unknown reading.
                 return;
             }
-            updateChannelState(new DecimalType(BigDecimal.valueOf(value, 1)));
+            updateChannelState(
+                    new QuantityType<ElectricPotential>(BigDecimal.valueOf(value, 1),
+                            SmartHomeUnits.VOLT));
+
         }
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
@@ -10,7 +10,10 @@ package org.openhab.binding.zigbee.internal.converter;
 
 import java.math.BigDecimal;
 
-import org.eclipse.smarthome.core.library.types.DecimalType;
+import javax.measure.quantity.Illuminance;
+
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
@@ -86,7 +89,8 @@ public class ZigBeeConverterIlluminance extends ZigBeeBaseChannelConverter imple
                 && attribute.getId() == ZclIlluminanceMeasurementCluster.ATTR_MEASUREDVALUE) {
             Integer value = (Integer) attribute.getLastValue();
             if (value != null) {
-                updateChannelState(new DecimalType(BigDecimal.valueOf(value, 2)));
+                updateChannelState(new QuantityType<Illuminance>(BigDecimal.valueOf(value, 2),
+                        SmartHomeUnits.LUX));
             }
         }
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
@@ -10,10 +10,7 @@ package org.openhab.binding.zigbee.internal.converter;
 
 import java.math.BigDecimal;
 
-import javax.measure.quantity.Illuminance;
-
-import org.eclipse.smarthome.core.library.types.QuantityType;
-import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
+import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
@@ -89,8 +86,7 @@ public class ZigBeeConverterIlluminance extends ZigBeeBaseChannelConverter imple
                 && attribute.getId() == ZclIlluminanceMeasurementCluster.ATTR_MEASUREDVALUE) {
             Integer value = (Integer) attribute.getLastValue();
             if (value != null) {
-                updateChannelState(new QuantityType<Illuminance>(BigDecimal.valueOf(value, 2),
-                        SmartHomeUnits.LUX));
+                updateChannelState(new DecimalType(BigDecimal.valueOf(value, 2)));
             }
         }
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
@@ -140,8 +140,8 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
                 && attribute.getId() == ZclElectricalMeasurementCluster.ATTR_ACTIVEPOWER) {
             Integer value = (Integer) attribute.getLastValue();
             if (value != null) {
-                updateChannelState(
-                        new QuantityType<Power>(BigDecimal.valueOf(value * multiplier / divisor), SmartHomeUnits.WATT));
+                BigDecimal valueInWatt = BigDecimal.valueOf(value * multiplier / divisor);
+                updateChannelState(new QuantityType<Power>(valueInWatt, SmartHomeUnits.WATT));
             }
         }
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
@@ -8,9 +8,13 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import java.math.BigDecimal;
 import java.util.concurrent.ExecutionException;
 
-import org.eclipse.smarthome.core.library.types.DecimalType;
+import javax.measure.quantity.Power;
+
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
@@ -136,7 +140,8 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
                 && attribute.getId() == ZclElectricalMeasurementCluster.ATTR_ACTIVEPOWER) {
             Integer value = (Integer) attribute.getLastValue();
             if (value != null) {
-                updateChannelState(new DecimalType(value * multiplier / divisor));
+                updateChannelState(
+                        new QuantityType<Power>(BigDecimal.valueOf(value * multiplier / divisor), SmartHomeUnits.WATT));
             }
         }
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
@@ -138,8 +138,8 @@ public class ZigBeeConverterMeasurementRmsCurrent extends ZigBeeBaseChannelConve
                 && attribute.getId() == ZclElectricalMeasurementCluster.ATTR_RMSCURRENT) {
             Integer value = (Integer) attribute.getLastValue();
             if (value != null) {
-                updateChannelState(new QuantityType<ElectricCurrent>(BigDecimal.valueOf(value * multiplier / divisor),
-                        SmartHomeUnits.AMPERE));
+                BigDecimal valueInAmpere = BigDecimal.valueOf(value * multiplier / divisor);
+                updateChannelState(new QuantityType<ElectricCurrent>(valueInAmpere, SmartHomeUnits.AMPERE));
             }
         }
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
@@ -8,9 +8,13 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import java.math.BigDecimal;
 import java.util.concurrent.ExecutionException;
 
-import org.eclipse.smarthome.core.library.types.DecimalType;
+import javax.measure.quantity.ElectricCurrent;
+
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
@@ -134,7 +138,8 @@ public class ZigBeeConverterMeasurementRmsCurrent extends ZigBeeBaseChannelConve
                 && attribute.getId() == ZclElectricalMeasurementCluster.ATTR_RMSCURRENT) {
             Integer value = (Integer) attribute.getLastValue();
             if (value != null) {
-                updateChannelState(new DecimalType(value * multiplier / divisor));
+                updateChannelState(new QuantityType<ElectricCurrent>(BigDecimal.valueOf(value * multiplier / divisor),
+                        SmartHomeUnits.AMPERE));
             }
         }
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
@@ -138,8 +138,8 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
                 && attribute.getId() == ZclElectricalMeasurementCluster.ATTR_RMSVOLTAGE) {
             Integer value = (Integer) attribute.getLastValue();
             if (value != null) {
-                updateChannelState(new QuantityType<ElectricPotential>(BigDecimal.valueOf(value * multiplier / divisor),
-                        SmartHomeUnits.VOLT));
+                BigDecimal valueInVolts = BigDecimal.valueOf(value * multiplier / divisor);
+                updateChannelState(new QuantityType<ElectricPotential>(valueInVolts, SmartHomeUnits.VOLT));
             }
         }
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
@@ -8,9 +8,13 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import java.math.BigDecimal;
 import java.util.concurrent.ExecutionException;
 
-import org.eclipse.smarthome.core.library.types.DecimalType;
+import javax.measure.quantity.ElectricPotential;
+
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
@@ -134,7 +138,8 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
                 && attribute.getId() == ZclElectricalMeasurementCluster.ATTR_RMSVOLTAGE) {
             Integer value = (Integer) attribute.getLastValue();
             if (value != null) {
-                updateChannelState(new DecimalType(value * multiplier / divisor));
+                updateChannelState(new QuantityType<ElectricPotential>(BigDecimal.valueOf(value * multiplier / divisor),
+                        SmartHomeUnits.VOLT));
             }
         }
     }


### PR DESCRIPTION
Resolves #331 

The item-type of following channels have been changed:

channel-type               | item-type
------------------------------------------------------
battery_voltage 	   | Number:ElectricPotential
electrical_activepower 	   | Number:Power
electrical_rmscurrent 	   | Number:ElectricCurrent
electrical_rmsvoltage 	   | Number:ElectricPotential
measurement_illuminance    | Number:Illuminance

Signed-off-by: Tommaso Travaglino <tommaso.travaglino@telekom.de>