### PR TITLE
Implemented reconnecting to USB dongle after OH has been started

### DIFF
--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
@@ -136,9 +136,8 @@ public class EmberHandler extends ZigBeeCoordinatorHandler implements FirmwareUp
     public void updateFirmware(Firmware firmware, ProgressCallback progressCallback) {
         logger.debug("Ember coordinator: update firmware with {}", firmware.getVersion());
 
-        updateStatus(ThingStatus.OFFLINE);
-        zigbeeTransport.shutdown();
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.FIRMWARE_UPDATING);
+        zigbeeTransport.shutdown();
 
         // Define the sequence of the firmware update so that external consumers can listen for the progress
         progressCallback.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING, ProgressStep.UPDATING);

--- a/org.openhab.binding.zigbee.telegesis/src/main/java/org/openhab/binding/zigbee/telegesis/handler/TelegesisHandler.java
+++ b/org.openhab.binding.zigbee.telegesis/src/main/java/org/openhab/binding/zigbee/telegesis/handler/TelegesisHandler.java
@@ -90,9 +90,8 @@ public class TelegesisHandler extends ZigBeeCoordinatorHandler implements Firmwa
     public void updateFirmware(Firmware firmware, ProgressCallback progressCallback) {
         logger.debug("Telegesis coordinator: update firmware with {}", firmware.getVersion());
 
-        updateStatus(ThingStatus.OFFLINE);
-        zigbeeTransport.shutdown();
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.FIRMWARE_UPDATING);
+        zigbeeTransport.shutdown();
 
         // Define the sequence of the firmware update so that external consumers can listen for the progress
         progressCallback.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING, ProgressStep.UPDATING);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -810,6 +810,12 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
                 }
                 break;
             case OFFLINE:
+                Bridge bridge = getThing();
+                // do not try to reconnect if there is a firmware update in progress
+                if (bridge.getStatus() == ThingStatus.OFFLINE
+                        && bridge.getStatusInfo().getStatusDetail() == ThingStatusDetail.FIRMWARE_UPDATING) {
+                    break;
+                }
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
                 startReconnectJobIfNotRunning();
                 break;


### PR DESCRIPTION
With this PR is is possible to plug in the zigbee USB dongle AFTER OH has been started.

Once https://github.com/zsmartsystems/com.zsmartsystems.zigbee/pull/455 has been merged its even possible to unplug and plug the dongle again at runtime and the bridge will go offline/online accordingly.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>