### PR TITLE
Recognize color mode of color bulb

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
@@ -77,6 +77,8 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
     private boolean xChanged = false;
     private boolean yChanged = false;
 
+    private ColorModeEnum lastColorMode;
+
     private final AtomicBoolean currentState = new AtomicBoolean(true);
 
     private ZclLevelControlConfig configLevelControl;
@@ -427,7 +429,7 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
         HSBType newHSB = new HSBType(oldHSB.getHue(), oldHSB.getSaturation(), brightness);
         currentHSB = newHSB;
         lastBrightness = brightness;
-        if (currentState.get() && !isCurrentColorModeTemperature()) {
+        if (currentState.get() && lastColorMode != ColorModeEnum.COLORTEMPERATURE) {
             updateChannelState(newHSB);
         }
     }
@@ -437,7 +439,7 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
         HSBType oldHSB = currentHSB;
         HSBType newHSB = new HSBType(hue, saturation, oldHSB.getBrightness());
         currentHSB = newHSB;
-        if (currentState.get() && !isCurrentColorModeTemperature()) {
+        if (currentState.get() && lastColorMode != ColorModeEnum.COLORTEMPERATURE) {
             updateChannelState(newHSB);
         }
     }
@@ -463,12 +465,6 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
         updateColorXY(x, y);
         xChanged = false;
         yChanged = false;
-    }
-
-    private boolean isCurrentColorModeTemperature() {
-        ZclAttribute colorModeAttribute = clusterColorControl.getAttribute(ZclColorControlCluster.ATTR_COLORMODE);
-        Integer colorMode = (Integer) colorModeAttribute.getLastValue();
-        return ColorModeEnum.COLORTEMPERATURE == ColorModeEnum.getByValue(colorMode);
     }
 
     @Override
@@ -525,7 +521,8 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                         }
                     } else if (attribute.getId() == ZclColorControlCluster.ATTR_COLORMODE) {
                         Integer colorMode = (Integer) attribute.getLastValue();
-                        if (ColorModeEnum.getByValue(colorMode) == ColorModeEnum.COLORTEMPERATURE) {
+                        lastColorMode = ColorModeEnum.getByValue(colorMode);
+                        if (lastColorMode == ColorModeEnum.COLORTEMPERATURE) {
                             updateChannelState(UnDefType.UNDEF);
                         }
                     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
@@ -16,6 +16,7 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
 import org.slf4j.Logger;
@@ -26,6 +27,7 @@ import com.zsmartsystems.zigbee.zcl.ZclAttribute;
 import com.zsmartsystems.zigbee.zcl.ZclAttributeListener;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclColorControlCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.ColorCapabilitiesEnum;
+import com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.ColorModeEnum;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
 
 /**
@@ -81,6 +83,11 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
 
         // Configure reporting - no faster than once per second - no slower than 10 minutes.
         clusterColorControl.setColorTemperatureReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 1);
+
+        // ColorMode reporting
+        ZclAttribute colorModeAttribute = clusterColorControl
+                .getAttribute(ZclColorControlCluster.ATTR_COLORMODE);
+        clusterColorControl.setReporting(colorModeAttribute, 1, REPORTING_PERIOD_DEFAULT_MAX, 1);
 
         return true;
     }
@@ -171,6 +178,12 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
             PercentType percent = miredToPercent(temperatureInMired);
             if (percent != null) {
                 updateChannelState(percent);
+            }
+        } else if (attribute.getCluster() == ZclClusterType.COLOR_CONTROL
+                && attribute.getId() == ZclColorControlCluster.ATTR_COLORMODE) {
+            Integer colorMode = (Integer) attribute.getLastValue();
+            if (ColorModeEnum.COLORTEMPERATURE.getKey() != colorMode) {
+                updateChannelState(UnDefType.UNDEF);
             }
         }
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
@@ -173,6 +173,11 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
                 endpoint.getEndpointId());
         if (attribute.getCluster() == ZclClusterType.COLOR_CONTROL
                 && attribute.getId() == ZclColorControlCluster.ATTR_COLORTEMPERATURE) {
+
+            if (!isCurrentColorModeTemperature()) {
+                return;
+            }
+
             Integer temperatureInMired = (Integer) attribute.getLastValue();
 
             PercentType percent = miredToPercent(temperatureInMired);
@@ -183,6 +188,12 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
                 && attribute.getId() == ZclColorControlCluster.ATTR_COLORMODE) {
             Integer colorMode = (Integer) attribute.getLastValue();
             if (ColorModeEnum.COLORTEMPERATURE.getKey() != colorMode) {
+                updateChannelState(UnDefType.UNDEF);
+            }
+        } else if (attribute.getCluster() == ZclClusterType.COLOR_CONTROL
+                && attribute.getId() == ZclColorControlCluster.ATTR_COLORMODE) {
+            Integer colorMode = (Integer) attribute.getLastValue();
+            if (ColorModeEnum.getByValue(colorMode) != ColorModeEnum.COLORTEMPERATURE) {
                 updateChannelState(UnDefType.UNDEF);
             }
         }
@@ -238,6 +249,12 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
             return null;
         }
         return kelvinToPercent(miredToKelvin(temperatureInMired));
+    }
+
+    private boolean isCurrentColorModeTemperature() {
+        ZclAttribute colorModeAttribute = clusterColorControl.getAttribute(ZclColorControlCluster.ATTR_COLORMODE);
+        Integer colorMode = (Integer) colorModeAttribute.getLastValue();
+        return ColorModeEnum.COLORTEMPERATURE == ColorModeEnum.getByValue(colorMode);
     }
 
 }


### PR DESCRIPTION
Resolves #326

This is an approach to recognize if the color has been set via color scheme or via color temperature scheme. It corresponds to the solution realized in https://github.com/eclipse/smarthome/pull/5762 which sets the color temperature to UnDefType.NULL when the color mode is not "color temperature".

Your feedback is welcome.