### PR TITLE
Fixes log statements with format parameters and exceptions

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeDiscoveryService.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeDiscoveryService.java
@@ -222,7 +222,9 @@ public class ZigBeeDiscoveryService extends AbstractDiscoveryService implements 
                             thingDiscovered(discoveryResult);
                         }
                     } catch (Exception e) {
-                        logger.error("Participant '{}' threw an exception", participant.getClass().getName(), e);
+                        logger.error(
+                                String.format("Participant '%s' threw an exception", participant.getClass().getName()),
+                                e);
                     }
                 }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -165,7 +165,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
                 linkKeyString = (String) param;
             }
         } catch (ClassCastException | NumberFormatException e) {
-            logger.error("{}: ZigBee initialisation exception ", thing.getUID(), e);
+            logger.error(String.format("%s: ZigBee initialisation exception", thing.getUID()), e);
             updateStatus(ThingStatus.OFFLINE);
             return;
         }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeSerialPort.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeSerialPort.java
@@ -199,7 +199,7 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
                 logger.debug("Serial port '{}' closed.", portName);
             }
         } catch (Exception e) {
-            logger.error("Error closing serial port: '{}' ", portName, e);
+            logger.error(String.format("Error closing serial port: '%s' ", portName), e);
         }
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -339,7 +339,7 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
                 }
             }
         } catch (Exception e) {
-            logger.error("{}: Exception creating channels ", nodeIeeeAddress, e);
+            logger.error(String.format("%s: Exception creating channels ", nodeIeeeAddress), e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR);
             return;
         }
@@ -352,7 +352,7 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
                 logger.debug("{}: Error getting binding table", nodeIeeeAddress);
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception getting binding table ", nodeIeeeAddress, e);
+            logger.error(String.format("%s: Exception getting binding table", nodeIeeeAddress), e);
         }
 
         updateStatus(ThingStatus.ONLINE);
@@ -444,7 +444,7 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
                         }
                     }
                 } catch (Exception e) {
-                    logger.warn("{}: Polling aborted due to exception ", nodeIeeeAddress, e);
+                    logger.warn(String.format("%s: Polling aborted due to exception", nodeIeeeAddress), e);
                 }
             }
         };
@@ -548,7 +548,9 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
                         handler.handleCommand(command);
                     }
                 } catch (Exception e) {
-                    logger.debug("{}: Exception sending command to channel {}", nodeIeeeAddress, channelUID, e);
+                    logger.debug(
+                            String.format("%s: Exception sending command to channel %s", nodeIeeeAddress, channelUID),
+                            e);
                 }
             }
         };

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactory.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactory.java
@@ -97,7 +97,7 @@ public final class ZigBeeChannelConverterFactory {
                 }
             } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
                     | InvocationTargetException | NoSuchMethodException | SecurityException e) {
-                logger.debug("{}: Exception while getting channels: ", endpoint.getIeeeAddress(), e);
+                logger.debug(String.format("%s: Exception while getting channels: ", endpoint.getIeeeAddress()), e);
             }
         }
 
@@ -139,7 +139,7 @@ public final class ZigBeeChannelConverterFactory {
             instance.initialize(thingHandler, channel, coordinatorHandler, ieeeAddress, endpointId);
             return instance;
         } catch (Exception e) {
-            logger.error("{}: Unable to create channel {}", ieeeAddress, channel.getUID(), e);
+            logger.error(String.format("%s: Unable to create channel {}", ieeeAddress, channel.getUID()), e);
         }
 
         return null;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
@@ -91,7 +91,9 @@ public class ZigBeeConverterBatteryAlarm extends ZigBeeBaseChannelConverter impl
                         BATTERY_ALARM_POLLING_PERIOD);
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting of battery alarm state ", endpoint.getIeeeAddress(), e);
+            logger.error(
+                    String.format("%s: Exception setting reporting of battery alarm state ", endpoint.getIeeeAddress()),
+                    e);
             return false;
         }
 
@@ -128,8 +130,8 @@ public class ZigBeeConverterBatteryAlarm extends ZigBeeBaseChannelConverter impl
                 return null;
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.warn("{}: Exception discovering attributes in power configuration cluster",
-                    endpoint.getIeeeAddress(), e);
+            logger.warn(String.format("%s: Exception discovering attributes in power configuration cluster",
+                    endpoint.getIeeeAddress()), e);
             return null;
         }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
@@ -54,7 +54,7 @@ public class ZigBeeConverterBatteryPercent extends ZigBeeBaseChannelConverter im
                 cluster.setBatteryPercentageRemainingReporting(600, 7200, 1).get();
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            logger.error(String.format("%s: Exception setting reporting ", endpoint.getIeeeAddress()), e);
         }
 
         // Add a listener, then request the status
@@ -97,8 +97,8 @@ public class ZigBeeConverterBatteryPercent extends ZigBeeBaseChannelConverter im
                 return null;
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.warn("{}: Exception discovering attributes in power configuration cluster",
-                    endpoint.getIeeeAddress(), e);
+            logger.warn(String.format("%s: Exception discovering attributes in power configuration cluster",
+                    endpoint.getIeeeAddress()), e);
             return null;
         }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
@@ -56,7 +56,7 @@ public class ZigBeeConverterBatteryVoltage extends ZigBeeBaseChannelConverter im
                 cluster.setReporting(attribute, 600, 7200, 1).get();
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            logger.error(String.format("%s: Exception setting reporting ", endpoint.getIeeeAddress()), e);
         }
 
         // Add a listener, then request the status
@@ -99,8 +99,8 @@ public class ZigBeeConverterBatteryVoltage extends ZigBeeBaseChannelConverter im
                 return null;
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.warn("{}: Exception discovering attributes in power configuration cluster",
-                    endpoint.getIeeeAddress(), e);
+            logger.warn(String.format("%s: Exception discovering attributes in power configuration cluster",
+                    endpoint.getIeeeAddress()), e);
             return null;
         }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
@@ -116,9 +116,9 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                 return false;
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.warn(
-                    "{}: Exception checking whether device endpoint supports RGB color. Assuming it supports HUE/SAT",
-                    endpoint.getIeeeAddress(), e);
+            logger.warn(String.format(
+                    "%s: Exception checking whether device endpoint supports RGB color. Assuming it supports HUE/SAT",
+                    endpoint.getIeeeAddress()), e);
             supportsHue = true;
         }
 
@@ -147,7 +147,7 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                 clusterColorControl.setCurrentYReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
             }
         } catch (ExecutionException | InterruptedException e) {
-            logger.debug("{}: Exception configuring color reporting", endpoint.getIeeeAddress(), e);
+            logger.debug(String.format("%s: Exception configuring color reporting", endpoint.getIeeeAddress()), e);
         }
 
         if (clusterLevelControl != null) {
@@ -163,7 +163,7 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                     pollingPeriod = POLLING_PERIOD_HIGH;
                 }
             } catch (ExecutionException | InterruptedException e) {
-                logger.debug("{}: Exception configuring level reporting", endpoint.getIeeeAddress(), e);
+                logger.debug(String.format("%s: Exception configuring level reporting", endpoint.getIeeeAddress()), e);
             }
         }
 
@@ -179,7 +179,7 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                     pollingPeriod = POLLING_PERIOD_HIGH;
                 }
             } catch (ExecutionException | InterruptedException e) {
-                logger.debug("{}: Exception configuring on/off reporting", endpoint.getIeeeAddress(), e);
+                logger.debug(String.format("%s: Exception configuring on/off reporting", endpoint.getIeeeAddress()), e);
             }
         }
 
@@ -349,7 +349,7 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                 changeOnOff((OnOffType) command);
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.warn("{}: Exception processing command", endpoint.getIeeeAddress(), e);
+            logger.warn(String.format("%s: Exception processing command", endpoint.getIeeeAddress()), e);
         }
     }
 
@@ -394,7 +394,8 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                 return null;
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.warn("{}: Exception discovering attributes in color control cluster", endpoint.getIeeeAddress(), e);
+            logger.warn(String.format("%s: Exception discovering attributes in color control cluster",
+                    endpoint.getIeeeAddress()), e);
         }
 
         return ChannelBuilder
@@ -536,8 +537,8 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                                             updateColorXY();
                                         }
                                     } catch (Exception e) {
-                                        logger.debug("{}: Exception in deferred attribute update",
-                                                endpoint.getIeeeAddress(), e);
+                                        logger.debug(String.format("%s: Exception in deferred attribute update",
+                                                endpoint.getIeeeAddress()), e);
                                     }
 
                                     colorUpdateTimer = null;
@@ -547,7 +548,7 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                     }
                 }
             } catch (Exception e) {
-                logger.debug("{}: Exception in attribute update", endpoint.getIeeeAddress(), e);
+                logger.debug(String.format("%s: Exception in attribute update", endpoint.getIeeeAddress()), e);
             }
         }
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterDoorLock.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterDoorLock.java
@@ -59,7 +59,7 @@ public class ZigBeeConverterDoorLock extends ZigBeeBaseChannelConverter implemen
                 pollingPeriod = POLLING_PERIOD_HIGH;
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            logger.error(String.format("%s: Exception setting reporting ", endpoint.getIeeeAddress()), e);
         }
 
         // Add the listener

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
@@ -65,7 +65,7 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
                 pollingPeriod = POLLING_PERIOD_HIGH;
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            logger.error(String.format("%s: Exception setting reporting ", endpoint.getIeeeAddress()), e);
         }
 
         divisor = clusterMeasurement.getAcPowerDivisor(Long.MAX_VALUE);
@@ -115,8 +115,8 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
                 return null;
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.warn("{}: Exception discovering attributes in electrical measurement cluster",
-                    endpoint.getIeeeAddress(), e);
+            logger.warn(String.format("%s: Exception discovering attributes in electrical measurement cluster",
+                    endpoint.getIeeeAddress()), e);
             return null;
         }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
@@ -66,7 +66,7 @@ public class ZigBeeConverterMeasurementRmsCurrent extends ZigBeeBaseChannelConve
                 pollingPeriod = POLLING_PERIOD_HIGH;
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            logger.error(String.format("%s: Exception setting reporting ", endpoint.getIeeeAddress()), e);
         }
 
         divisor = clusterMeasurement.getAcCurrentDivisor(Long.MAX_VALUE);
@@ -114,8 +114,8 @@ public class ZigBeeConverterMeasurementRmsCurrent extends ZigBeeBaseChannelConve
                 return null;
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.warn("{}: Exception discovering attributes in electrical measurement cluster",
-                    endpoint.getIeeeAddress(), e);
+            logger.warn(String.format("%s: Exception discovering attributes in electrical measurement cluster",
+                    endpoint.getIeeeAddress()), e);
             return null;
         }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
@@ -66,7 +66,7 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
                 pollingPeriod = POLLING_PERIOD_HIGH;
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            logger.error(String.format("%s: Exception setting reporting ", endpoint.getIeeeAddress()), e);
         }
 
         divisor = clusterMeasurement.getAcVoltageDivisor(Long.MAX_VALUE);
@@ -114,8 +114,8 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
                 return null;
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.warn("{}: Exception discovering attributes in electrical measurement cluster",
-                    endpoint.getIeeeAddress(), e);
+            logger.warn(String.format("%s: Exception discovering attributes in electrical measurement cluster",
+                    endpoint.getIeeeAddress()), e);
             return null;
         }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -72,7 +72,7 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
                     pollingPeriod = POLLING_PERIOD_HIGH;
                 }
             } catch (InterruptedException | ExecutionException e) {
-                logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+                logger.error(String.format("%s: Exception setting reporting ", endpoint.getIeeeAddress()), e);
             }
 
             // Add the listener
@@ -87,7 +87,7 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
                             Integer.toHexString(bindResponse.getStatusCode()));
                 }
             } catch (InterruptedException | ExecutionException e) {
-                logger.error("{}: Exception setting binding ", endpoint.getIeeeAddress(), e);
+                logger.error(String.format("%s: Exception setting binding ", endpoint.getIeeeAddress()), e);
             }
 
             // Add the command listener

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
@@ -58,7 +58,7 @@ public class ZigBeeConverterTemperature extends ZigBeeBaseChannelConverter imple
                 cluster.setMeasuredValueReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 0.1);
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            logger.error(String.format("%s: Exception setting reporting ", endpoint.getIeeeAddress()), e);
         }
 
         // Add a listener, then request the status

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclLevelControlConfig.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclLevelControlConfig.java
@@ -57,8 +57,8 @@ public class ZclLevelControlConfig implements ZclClusterConfigHandler {
                         cluster.getClusterName());
             }
         } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Error getting supported attributes for {}. ", cluster.getZigBeeAddress(),
-                    cluster.getClusterName(), e);
+            logger.error(String.format("%s: Error getting supported attributes for {}. ", cluster.getZigBeeAddress(),
+                    cluster.getClusterName()), e);
         }
 
         // Build a list of configuration supported by this channel based on the attributes the cluster supports


### PR DESCRIPTION
At several places, there are log statements of the form `logger.info("some format string with one format parameter", formatParameter, exception)`. This results in not logging the exception (as it is considered as a format parameter, which is not used in the format). This commit circumvents this by using `String.format` in those cases.