### PR TITLE
Added info for Bitron Funkstick to README.md

### DIFF
--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -65,6 +65,18 @@ The Ember EZSP NCP (Network Co-Processor) supports the Silabs EM358 or MightyGec
 
 Note that there are generally two versions of the Ember NCP firmware in use. One operates at a baud rate of 115200 with RTS/CTS flow control (i.e. hardware flow control), the other operates at a baud rate of 57600, and XON/XOFF flow control (i.e. software flow control). If you are programming your own stick (e.g. the CEL stick) then it should be advisable to use the hardware flow control version - many commercial sticks seem to use the lower speed and software flow control (e.g. Bitron and Nortek HUSBZB-1).
 
+If the usb dongle is not recognized, it might be necessary to make the dongle's device id known to the CP240x driver by Silicon Labs:
+
+- Find the device id (as listed by the command ```lsusb```). For the Bitron Funkstick that might be 10c4 8b34. 
+- Unplug the device
+- Enter the following commands (replace the id 10c4 8b34 with the one listed by  ```lsusb```):
+```
+sudo -s
+modprobe cp210x
+echo 10c4 8b34 > /sys/bus/usb-serial/drivers/cp210x/new_id
+```
+- Plug in the dongle. It should now be recognized properly as ttyUSBx.
+
 #### Telegesis ETRX3
 
 The thing type is ```coordinator_telegesis```.


### PR DESCRIPTION
As dicussed [here](https://community.openhab.org/t/zigbee-binding/15763/1643), I've added the description how to make certain usb dongles known to the system. 

Not sure if this only applies for Ember coordinator's though.