### PR TITLE
Reduce logging of bind error to debug level

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -42,7 +42,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
  */
 public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
         implements ZclAttributeListener, ZclCommandListener {
-    private Logger logger = LoggerFactory.getLogger(ZigBeeConverterSwitchOnoff.class);
+    private final Logger logger = LoggerFactory.getLogger(ZigBeeConverterSwitchOnoff.class);
 
     private ZclOnOffCluster clusterOnOffClient;
     private ZclOnOffCluster clusterOnOffServer;
@@ -67,7 +67,7 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
                         pollingPeriod = POLLING_PERIOD_HIGH;
                     }
                 } else {
-                    logger.error("{}: Error 0x{} setting server binding", endpoint.getIeeeAddress(),
+                    logger.debug("{}: Error 0x{} setting server binding", endpoint.getIeeeAddress(),
                             Integer.toHexString(bindResponse.getStatusCode()));
                     pollingPeriod = POLLING_PERIOD_HIGH;
                 }


### PR DESCRIPTION
We are a little inconsistent with the logging in different converters, but in any case I don't think this should be logged as ERROR level since the binding will just revert to polling and the user won't see much difference. This seems to be more consistent with what I've done elsewhere (where anything is logged at all!).
Signed-off-by: Chris Jackson <chris@cd-jackson.com>