### PR TITLE
Update README.md

### DIFF
--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -101,6 +101,7 @@ The following devices have been tested with the binding
 | Hue Motion Sensor          | Motion and Luminance sensor                       |
 | Innr Bulbs                 | *note1*                                           |
 | Osram Bulbs                |                                                   |
+| Osram Motion Sensor        | Osram Smart+ Motion Sensor                        |
 | SmartThings Plug           | Metered Plug                                      |
 | SmartThings Motion Sensor  | CentraLite 3325-S Motion and Temperature sensor   |
 | SmartThings Contact Sensor | Contact and Temperature sensor                    |


### PR DESCRIPTION
Added Osram Smart+ Motion Sensor to the list of tested devices for the zigbee binding