### PR TITLE
Refresh devices when they announce themselves

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -63,9 +63,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.ZigBeeAnnounceListener;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.ZigBeeNetworkNodeListener;
 import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.ZigBeeNodeStatus;
 import com.zsmartsystems.zigbee.ZigBeeProfileType;
 import com.zsmartsystems.zigbee.app.otaserver.ZclOtaUpgradeServer;
 import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaFile;
@@ -81,8 +83,8 @@ import com.zsmartsystems.zigbee.zdo.field.RoutingTable;
  * @author Chris Jackson - Initial Contribution
  * @author Thomas Höfer - Injected ZigBeeChannelConverterFactory via constructor
  */
-public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetworkNodeListener, FirmwareUpdateHandler,
-        ConfigDescriptionProvider, DynamicStateDescriptionProvider {
+public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetworkNodeListener, ZigBeeAnnounceListener,
+        FirmwareUpdateHandler, ConfigDescriptionProvider, DynamicStateDescriptionProvider {
     /**
      * Our logger
      */
@@ -188,6 +190,7 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
 
         coordinatorHandler = (ZigBeeCoordinatorHandler) getBridge().getHandler();
         coordinatorHandler.addNetworkNodeListener(this);
+        coordinatorHandler.addAnnounceListener(this);
         coordinatorHandler.rediscoverNode(nodeIeeeAddress);
 
         initialiseZigBeeNode();
@@ -436,6 +439,7 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
         if (nodeIeeeAddress != null) {
             if (coordinatorHandler != null) {
                 coordinatorHandler.removeNetworkNodeListener(this);
+                coordinatorHandler.removeAnnounceListener(this);
             }
             nodeIeeeAddress = null;
         }
@@ -509,6 +513,17 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
                     pollingPeriodMs, TimeUnit.MILLISECONDS);
             logger.debug("{}: Polling initialised at {}ms", nodeIeeeAddress, pollingPeriodMs);
         }
+    }
+
+    @Override
+    public void deviceStatusUpdate(ZigBeeNodeStatus deviceStatus, Integer networkAddress, IeeeAddress ieeeAddress) {
+        // A node has joined - or come back online
+        if (!nodeIeeeAddress.equals(ieeeAddress)) {
+            return;
+        }
+
+        // Use this to update channel information - eg bulb state will likely change when the device was powered off/on.
+        startPolling();
     }
 
     @Override


### PR DESCRIPTION
This adds a ```ZigBeeAnnounceListener``` to detect if the device has potentially been reset, and will refresh the thing state through restarting the polling. This means that the binding will update a bulb state if it was powered off/on again, as requested in #261.

Closes #261

Signed-off-by: Chris Jackson <chris@cd-jackson.com>