### PR TITLE
Add option for Ember child aging

### DIFF
--- a/org.openhab.binding.zigbee.ember/ESH-INF/thing/controller_ember.xml
+++ b/org.openhab.binding.zigbee.ember/ESH-INF/thing/controller_ember.xml
@@ -84,6 +84,25 @@
 					<option value="0">Normal</option>
 				</options>
 			</parameter>
+			
+            <parameter name="zigbee_childtimeout" type="integer" groupName="ember">
+                <label>Child Aging Timeout</label>
+                <description>Sets the period over which the coordinator will age children. Children who have not checked in within this period will be removed from the child table may be asked to rejoin the network. Note that setting this value too high may prevent new devices joining the network.</description>
+                <default>86400</default>
+                <options>
+                    <option value="320">5 Minutes</option>
+                    <option value="1800">30 Minutes</option>
+                    <option value="7200">2 Hours</option>
+                    <option value="43200">12 Hours</option>
+                    <option value="86400">1 Day</option>
+                    <option value="172800">2 Days</option>
+                    <option value="432000">5 Days</option>
+                    <option value="864000">10 Days</option>
+                    <option value="1209600">2 Weeks</option>
+                    <option value="2419200">4 Weeks</option>
+                    <option value="4233600">7 Weeks</option>
+                </options>
+            </parameter>
 
 			<parameter name="zigbee_initialise" type="boolean" groupName="network">
 				<label>Reset Controller</label>

--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
@@ -94,6 +94,52 @@ public class EmberHandler extends ZigBeeCoordinatorHandler implements FirmwareUp
                 Integer.toHexString(panId), extendedPanId, Integer.toString(channelId));
 
         dongle.updateDefaultConfiguration(EzspConfigId.EZSP_CONFIG_TX_POWER_MODE, config.zigbee_powermode);
+
+        // Set the child aging timeout.
+        // Formulae is EZSP_CONFIG_END_DEVICE_POLL_TIMEOUT * 2 ^ EZSP_CONFIG_END_DEVICE_POLL_TIMEOUT_SHIFT
+        int pollTimeoutValue;
+        int pollTimeoutShift;
+
+        if (config.zigbee_childtimeout <= 320) {
+            pollTimeoutValue = 5;
+            pollTimeoutShift = 6;
+        } else if (config.zigbee_childtimeout <= 1800) {
+            pollTimeoutValue = 225;
+            pollTimeoutShift = 3;
+        } else if (config.zigbee_childtimeout <= 7200) {
+            pollTimeoutValue = 225;
+            pollTimeoutShift = 5;
+        } else if (config.zigbee_childtimeout <= 43200) {
+            pollTimeoutValue = 169;
+            pollTimeoutShift = 8;
+        } else if (config.zigbee_childtimeout <= 86400) {
+            pollTimeoutValue = 169;
+            pollTimeoutShift = 9;
+        } else if (config.zigbee_childtimeout <= 172800) {
+            pollTimeoutValue = 169;
+            pollTimeoutShift = 10;
+        } else if (config.zigbee_childtimeout <= 432000) {
+            pollTimeoutValue = 211;
+            pollTimeoutShift = 11;
+        } else if (config.zigbee_childtimeout <= 864000) {
+            pollTimeoutValue = 211;
+            pollTimeoutShift = 12;
+        } else if (config.zigbee_childtimeout <= 1209600) {
+            pollTimeoutValue = 147;
+            pollTimeoutShift = 13;
+        } else if (config.zigbee_childtimeout <= 2419200) {
+            pollTimeoutValue = 147;
+            pollTimeoutShift = 14;
+        } else {
+            pollTimeoutValue = 255;
+            pollTimeoutShift = 14;
+        }
+
+        logger.debug("Ember end device poll timout set to ({} * 2^{}) = {} seconds", pollTimeoutValue, pollTimeoutShift,
+                (int) (pollTimeoutValue * Math.pow(2, pollTimeoutShift)));
+        dongle.updateDefaultConfiguration(EzspConfigId.EZSP_CONFIG_END_DEVICE_POLL_TIMEOUT, pollTimeoutValue);
+        dongle.updateDefaultConfiguration(EzspConfigId.EZSP_CONFIG_END_DEVICE_POLL_TIMEOUT_SHIFT, pollTimeoutShift);
+
         TransportConfig transportConfig = new TransportConfig();
 
         startZigBee(dongle, transportConfig, DefaultSerializer.class, DefaultDeserializer.class);

--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/internal/EmberConfiguration.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/internal/EmberConfiguration.java
@@ -19,4 +19,5 @@ public class EmberConfiguration {
     public Integer zigbee_baud;
     public Integer zigbee_flowcontrol;
     public Integer zigbee_powermode;
+    public Integer zigbee_childtimeout;
 }

--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -12,18 +12,28 @@ Coordinators need to be installed manually and the serial port and baud rate mus
 
 #### Coordinator Configuration
 
+Note that not all configuration parameters are available with all coordinators.
+
 ##### Link Key (zigbee_linkkey)
 
 The key is defined as 16 hexadecimal values. If not defined, this will default to the well known ZigBee HA link key which is required for ZigBee HA 1.2 devices. Do not alter this key if using with a ZigBee HA 1.2 network unless you fully understand the impact.
 
 If defined with the word ```INSTALLCODE:``` before the key, this will create a link key from an install code which may be shorter than 16 bytes.
 
-eg ```5A 69 67 42 65 65 41 6C 6C 69 61 6E 63 65 30 39```
-eg ```INSTALLCODE:00 11 22 33 44 55 66 77```
+e.g. ```5A 69 67 42 65 65 41 6C 6C 69 61 6E 63 65 30 39```
+e.g. ```INSTALLCODE:00 11 22 33 44 55 66 77```
 
 ##### Network Key (zigbee_networkkey)
 
 The key is defined as 16 hexadecimal values. If not defined, a random key will be created.
+
+##### Child Aging (zigbee_childtimeout)
+
+ZigBee routers (and the coordinator) only have room to allow a certain number of devices to join the network via each router - once the child table in a router is full, devices will need to join via another router (assuming the child can communicate via another router). To avoid the child table becoming full of devices that no longer exist, routers will age out children that do not contact them within a specified period of time. 
+
+Once a child is removed from the child table of a router, it will be asked to rejoin if it tries to communicate with the parent again. Setting this time too large may mean that the router fills its tables with devices that no longer exist, while setting it too small can mean devices unnecessarily rejoining the network.
+
+Note that ZigBee compliant devices should rejoin the network seamlessly, however some non-compliant devices may not rejoin which may leave them unusable without a manual rejoin.
 
 #### Supported Coordinators
 


### PR DESCRIPTION
This adds support to change the way that Ember coordinators age out devices in their child tables.

ZigBee routers (and the coordinator) only have room to allow a certain number of devices to join the network via each router - once the child table in a router is full, devices will need to join via another router (assuming the child can communicate via another router). To avoid the child table becoming full of devices that no longer exist, routers will age out children that do not contact them within a specified period of time. 

Once a child is removed from the child table of a router, it will be asked to rejoin if it tries to communicate with the parent again. Setting this time too large may mean that the router fills its tables with devices that no longer exist, while setting it too small can mean devices unnecessarily rejoining the network.

Note that ZigBee compliant devices should rejoin the network seamlessly, however some non-compliant devices may not rejoin which may leave them unusable without a manual rejoin.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>