### PR TITLE
Provide configuration option for mesh update period

### DIFF
--- a/org.openhab.binding.zigbee.cc2531/ESH-INF/thing/controller_ti2351.xml
+++ b/org.openhab.binding.zigbee.cc2531/ESH-INF/thing/controller_ti2351.xml
@@ -97,6 +97,21 @@
                 <advanced>true</advanced>
             </parameter>
 
+            <parameter name="zigbee_meshupdateperiod" type="integer" groupName="network">
+                <label>Mesh Update Period</label>
+                <description>The period between subsequent updates of the mesh topology</description>
+                <advanced>true</advanced>
+                <default>86400</default>
+                <options>
+                    <option value="0">Never</option>
+                    <option value="300">5 Minutes</option>
+                    <option value="1800">30 Minutes</option>
+                    <option value="3600">1 Hour</option>
+                    <option value="21600">6 Hours</option>
+                    <option value="86400">1 Day</option>
+                    <option value="604800">1 Week</option>
+                </options>
+            </parameter>
 		</config-description>
 
 	</bridge-type>

--- a/org.openhab.binding.zigbee.ember/ESH-INF/thing/controller_ember.xml
+++ b/org.openhab.binding.zigbee.ember/ESH-INF/thing/controller_ember.xml
@@ -84,25 +84,27 @@
 					<option value="0">Normal</option>
 				</options>
 			</parameter>
-			
-            <parameter name="zigbee_childtimeout" type="integer" groupName="ember">
-                <label>Child Aging Timeout</label>
-                <description>Sets the period over which the coordinator will age children. Children who have not checked in within this period will be removed from the child table may be asked to rejoin the network. Note that setting this value too high may prevent new devices joining the network.</description>
-                <default>86400</default>
-                <options>
-                    <option value="320">5 Minutes</option>
-                    <option value="1800">30 Minutes</option>
-                    <option value="7200">2 Hours</option>
-                    <option value="43200">12 Hours</option>
-                    <option value="86400">1 Day</option>
-                    <option value="172800">2 Days</option>
-                    <option value="432000">5 Days</option>
-                    <option value="864000">10 Days</option>
-                    <option value="1209600">2 Weeks</option>
-                    <option value="2419200">4 Weeks</option>
-                    <option value="4233600">7 Weeks</option>
-                </options>
-            </parameter>
+
+			<parameter name="zigbee_childtimeout" type="integer" groupName="ember">
+				<label>Child Aging Timeout</label>
+				<description>Sets the period over which the coordinator will age children. Children who have not checked in within
+					this period will be removed from the child table may be asked to rejoin the network. Note that setting this value
+					too high may prevent new devices joining the network.</description>
+				<default>86400</default>
+				<options>
+					<option value="320">5 Minutes</option>
+					<option value="1800">30 Minutes</option>
+					<option value="7200">2 Hours</option>
+					<option value="43200">12 Hours</option>
+					<option value="86400">1 Day</option>
+					<option value="172800">2 Days</option>
+					<option value="432000">5 Days</option>
+					<option value="864000">10 Days</option>
+					<option value="1209600">2 Weeks</option>
+					<option value="2419200">4 Weeks</option>
+					<option value="4233600">7 Weeks</option>
+				</options>
+			</parameter>
 
 			<parameter name="zigbee_initialise" type="boolean" groupName="network">
 				<label>Reset Controller</label>
@@ -185,6 +187,22 @@
 				<label>Install Code</label>
 				<description>Add a temporary install key for device installation</description>
 				<advanced>true</advanced>
+			</parameter>
+
+			<parameter name="zigbee_meshupdateperiod" type="integer" groupName="network">
+				<label>Mesh Update Period</label>
+				<description>The period between subsequent updates of the mesh topology</description>
+				<advanced>true</advanced>
+				<default>86400</default>
+				<options>
+					<option value="0">Never</option>
+					<option value="300">5 Minutes</option>
+					<option value="1800">30 Minutes</option>
+					<option value="3600">1 Hour</option>
+					<option value="21600">6 Hours</option>
+					<option value="86400">1 Day</option>
+					<option value="604800">1 Week</option>
+				</options>
 			</parameter>
 		</config-description>
 	</bridge-type>

--- a/org.openhab.binding.zigbee.telegesis/ESH-INF/thing/controller_telegesis.xml
+++ b/org.openhab.binding.zigbee.telegesis/ESH-INF/thing/controller_telegesis.xml
@@ -102,7 +102,22 @@
                 <default>TC_JOIN_SECURE</default>
                 <advanced>true</advanced>
             </parameter>
-            
+
+            <parameter name="zigbee_meshupdateperiod" type="integer" groupName="network">
+                <label>Mesh Update Period</label>
+                <description>The period between subsequent updates of the mesh topology</description>
+                <advanced>true</advanced>
+                <default>86400</default>
+                <options>
+                    <option value="0">Never</option>
+                    <option value="300">5 Minutes</option>
+                    <option value="1800">30 Minutes</option>
+                    <option value="3600">1 Hour</option>
+                    <option value="21600">6 Hours</option>
+                    <option value="86400">1 Day</option>
+                    <option value="604800">1 Week</option>
+                </options>
+            </parameter>
         </config-description>
 	</bridge-type>
 	

--- a/org.openhab.binding.zigbee.xbee/ESH-INF/thing/controller_xbee.xml
+++ b/org.openhab.binding.zigbee.xbee/ESH-INF/thing/controller_xbee.xml
@@ -101,6 +101,21 @@
                 <advanced>true</advanced>
             </parameter>
 
+            <parameter name="zigbee_meshupdateperiod" type="integer" groupName="network">
+                <label>Mesh Update Period</label>
+                <description>The period between subsequent updates of the mesh topology</description>
+                <advanced>true</advanced>
+                <default>86400</default>
+                <options>
+                    <option value="0">Never</option>
+                    <option value="300">5 Minutes</option>
+                    <option value="1800">30 Minutes</option>
+                    <option value="3600">1 Hour</option>
+                    <option value="21600">6 Hours</option>
+                    <option value="86400">1 Day</option>
+                    <option value="604800">1 Week</option>
+                </options>
+            </parameter>
 		</config-description>
 
 	</bridge-type>

--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -35,6 +35,10 @@ Once a child is removed from the child table of a router, it will be asked to re
 
 Note that ZigBee compliant devices should rejoin the network seamlessly, however some non-compliant devices may not rejoin which may leave them unusable without a manual rejoin.
 
+##### Mesh Update Period (zigbee_meshupdateperiod)
+
+The binding is able to search the network to get a list of what devices can communicate with other devices. This is a useful diagnostic feature as it allows users to see the links between devices, and the quality of these links. However, this can generate considerable traffic, and some battery devices may not poll their parents often enough to provide these updates, and users may consider that it is better to reduce the period, or disable this feature.
+
 #### Supported Coordinators
 
 The following coordinators are known to be supported.

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -189,6 +189,7 @@ public class ZigBeeBindingConstants {
     public static final String CONFIGURATION_TRUSTCENTREMODE = "zigbee_trustcentremode";
     public static final String CONFIGURATION_POWERMODE = "zigbee_powermode";
     public static final String CONFIGURATION_TXPOWER = "zigbee_txpower";
+    public static final String CONFIGURATION_MESHUPDATEPERIOD = "zigbee_meshupdateperiod";
 
     public static final String CONFIGURATION_MACADDRESS = "zigbee_macaddress";
     public static final String CONFIGURATION_JOINENABLE = "zigbee_joinenable";

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -109,7 +109,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
 
     private boolean macAddressSet = false;
 
-    private final int MESH_UPDATE_TIME = 300;
+    private final int MESH_UPDATE_PERIOD = 86400;
 
     /**
      * Set to true on startup if we want to reinitialize the network
@@ -373,9 +373,15 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
         networkManager.addNetworkStateListener(this);
         networkManager.addNetworkNodeListener(this);
 
+        int meshUpdateTime = MESH_UPDATE_PERIOD;
+        if (getConfig().get(CONFIGURATION_MESHUPDATEPERIOD) != null) {
+            logger.debug("Mesh Update Period {}", getConfig().get(CONFIGURATION_MESHUPDATEPERIOD));
+            meshUpdateTime = ((BigDecimal) getConfig().get(CONFIGURATION_MESHUPDATEPERIOD)).intValue();
+        }
+
         // Add the extensions to the network
         ZigBeeDiscoveryExtension discoveryExtension = new ZigBeeDiscoveryExtension();
-        discoveryExtension.setUpdatePeriod(MESH_UPDATE_TIME);
+        discoveryExtension.setUpdatePeriod(meshUpdateTime);
         networkManager.addExtension(discoveryExtension);
 
         networkManager.addExtension(new ZigBeeIasCieExtension());


### PR DESCRIPTION
This adds a configuration option to set the period used for the mesh updates...

The binding is able to search the network to get a list of what devices can communicate with other devices. This is a useful diagnostic feature as it allows users to see the links between devices, and the quality of these links. However, this can generate considerable traffic, and some battery devices may not poll their parents often enough to provide these updates, and users may consider that it is better to reduce the period, or disable this feature.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>