### PR TITLE
Added possibility to provide things types via DS

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/internal/ZigBeeDefaultDiscoveryParticipant.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/internal/ZigBeeDefaultDiscoveryParticipant.java
@@ -30,7 +30,8 @@ import com.zsmartsystems.zigbee.ZigBeeNode;
  */
 @Component(immediate = true)
 public class ZigBeeDefaultDiscoveryParticipant implements ZigBeeDiscoveryParticipant {
-    private ZigBeeThingTypeMatcher matcher = new ZigBeeThingTypeMatcher();
+
+    private final ZigBeeThingTypeMatcher matcher = ZigBeeThingTypeMatcher.getInstance();
 
     @Override
     public Set<ThingTypeUID> getSupportedThingTypeUIDs() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeHandlerFactory.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeHandlerFactory.java
@@ -41,7 +41,7 @@ public class ZigBeeHandlerFactory extends BaseThingHandlerFactory {
 
     private ZigBeeChannelConverterFactory zigbeeChannelConverterFactory;
 
-    private final Set<ThingTypeUID> thingTypeUIDs = new CopyOnWriteArraySet<>();
+    private final Set<ZigBeeThingTypeProvider> providers = new CopyOnWriteArraySet<>();
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -50,7 +50,8 @@ public class ZigBeeHandlerFactory extends BaseThingHandlerFactory {
             return true;
         }
 
-        return thingTypeUIDs.contains(thingTypeUID);
+        return providers.stream().map(ZigBeeThingTypeProvider::getThingTypeUIDs).flatMap(Set::stream)
+                .anyMatch(uid -> uid.equals(thingTypeUID));
     }
 
     @Override
@@ -79,10 +80,10 @@ public class ZigBeeHandlerFactory extends BaseThingHandlerFactory {
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
     public void addZigBeeThingTypeProvider(ZigBeeThingTypeProvider zigBeeThingTypeProvider) {
-        thingTypeUIDs.addAll(zigBeeThingTypeProvider.getThingTypeUIDs());
+        providers.add(zigBeeThingTypeProvider);
     }
 
     public void removeZigBeeThingTypeProvider(ZigBeeThingTypeProvider zigBeeThingTypeProvider) {
-        thingTypeUIDs.removeAll(zigBeeThingTypeProvider.getThingTypeUIDs());
+        providers.remove(zigBeeThingTypeProvider);
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeHandlerFactory.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeHandlerFactory.java
@@ -9,6 +9,8 @@
 package org.openhab.binding.zigbee.internal;
 
 import java.util.Hashtable;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.eclipse.smarthome.config.core.ConfigDescriptionProvider;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -20,8 +22,11 @@ import org.eclipse.smarthome.core.thing.type.DynamicStateDescriptionProvider;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.openhab.binding.zigbee.internal.converter.ZigBeeChannelConverterFactory;
+import org.openhab.binding.zigbee.thingtype.ZigBeeThingTypeProvider;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 
 /**
  * The {@link ZigBeeHandlerFactory} is responsible for creating things and thing
@@ -36,7 +41,7 @@ public class ZigBeeHandlerFactory extends BaseThingHandlerFactory {
 
     private ZigBeeChannelConverterFactory zigbeeChannelConverterFactory;
 
-    private final ZigBeeThingTypeMatcher matcher = new ZigBeeThingTypeMatcher();
+    private final Set<ThingTypeUID> thingTypeUIDs = new CopyOnWriteArraySet<>();
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -45,7 +50,7 @@ public class ZigBeeHandlerFactory extends BaseThingHandlerFactory {
             return true;
         }
 
-        return matcher.getSupportedThingTypeUIDs().contains(thingTypeUID);
+        return thingTypeUIDs.contains(thingTypeUID);
     }
 
     @Override
@@ -70,5 +75,14 @@ public class ZigBeeHandlerFactory extends BaseThingHandlerFactory {
 
     protected void unsetZigBeeChannelConverterFactory(ZigBeeChannelConverterFactory zigbeeChannelConverterFactory) {
         this.zigbeeChannelConverterFactory = null;
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    public void addZigBeeThingTypeProvider(ZigBeeThingTypeProvider zigBeeThingTypeProvider) {
+        thingTypeUIDs.addAll(zigBeeThingTypeProvider.getThingTypeUIDs());
+    }
+
+    public void removeZigBeeThingTypeProvider(ZigBeeThingTypeProvider zigBeeThingTypeProvider) {
+        thingTypeUIDs.removeAll(zigBeeThingTypeProvider.getThingTypeUIDs());
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeThingTypeMatcher.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeThingTypeMatcher.java
@@ -50,14 +50,29 @@ import org.slf4j.LoggerFactory;
  * </ul>
  *
  * @author Chris Jackson - Initial Implementation
- *
+ * @author Thomas Höfer - Refactored class to provide only one single instance
  */
 public class ZigBeeThingTypeMatcher {
     private final Logger logger = LoggerFactory.getLogger(ZigBeeThingTypeMatcher.class);
 
     private final Map<String, List<RequiredProperty>> discoveryProperties = new HashMap<>();
 
-    private final static String DISCOVERY_PROPERTIES_FILE = "/discovery.txt";
+    private static final String DISCOVERY_PROPERTIES_FILE = "/discovery.txt";
+
+    private static final ZigBeeThingTypeMatcher MATCHER = new ZigBeeThingTypeMatcher();
+
+    private ZigBeeThingTypeMatcher() {
+        // use the getInstance operation to get the single instance of this class
+    }
+
+    /**
+     * Provides the instance of this thing type matcher.
+     *
+     * @return the instance of this matcher
+     */
+    public static synchronized ZigBeeThingTypeMatcher getInstance() {
+        return MATCHER;
+    }
 
     /**
      * Matches a set of properties to a single thing type. If no match is found, null is returned.

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeThingTypeProviderImpl.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeThingTypeProviderImpl.java
@@ -16,7 +16,7 @@ import org.openhab.binding.zigbee.thingtype.ZigBeeThingTypeProvider;
 import org.osgi.service.component.annotations.Component;
 
 /**
- * This class is the basic binding implementation to provide non generic thing types.
+ * This class is the basic binding implementation to provide non-generic thing types.
  *
  * @author Thomas Höfer - Initial Implementation
  */

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeThingTypeProviderImpl.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeThingTypeProviderImpl.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2010-2019 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zigbee.internal;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.openhab.binding.zigbee.thingtype.ZigBeeThingTypeProvider;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * This class is the basic binding implementation to provide non generic thing types.
+ *
+ * @author Thomas Höfer - Initial Implementation
+ */
+@Component(immediate = true)
+public final class ZigBeeThingTypeProviderImpl implements ZigBeeThingTypeProvider {
+
+    @Override
+    public Set<@NonNull ThingTypeUID> getThingTypeUIDs() {
+        return ZigBeeThingTypeMatcher.getInstance().getSupportedThingTypeUIDs();
+    }
+}

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/thingtype/ZigBeeThingTypeProvider.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/thingtype/ZigBeeThingTypeProvider.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2019 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zigbee.thingtype;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
+
+/**
+ * The {@link ZigBeeThingTypeProvider} can be registered as OSGi service in order to provide additional ZigBee
+ * {@link ThingTypeUID}s that are to be supported by the {@link ThingHandlerFactory} of this binding. These thing types
+ * are <b>not</b> tracked by the factories that are responsible to create the {@link ZigBeeCoordinatorHandler}s.
+ *
+ * @author Thomas Höfer - Initial contribution
+ */
+@NonNullByDefault
+public interface ZigBeeThingTypeProvider {
+
+    /**
+     * Provides the set of ZigBee thing types that are supported by this thing type provider.
+     *
+     * @return the set of ZigBee thing types supported by this thing type provider.
+     */
+    Set<ThingTypeUID> getThingTypeUIDs();
+}

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/ZigBeeThingTypeMatcherTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/ZigBeeThingTypeMatcherTest.java
@@ -27,7 +27,7 @@ public class ZigBeeThingTypeMatcherTest {
     @Test
     public void testMatcher()
             throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
-        ZigBeeThingTypeMatcher matcher = new ZigBeeThingTypeMatcher();
+        ZigBeeThingTypeMatcher matcher = ZigBeeThingTypeMatcher.getInstance();
         Map<String, Object> properties;
 
         properties = new HashMap<>();

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/thingtype/ZigBeeThingTypeProviderTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/thingtype/ZigBeeThingTypeProviderTest.java
@@ -15,7 +15,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.junit.Before;
 import org.junit.Test;
@@ -97,7 +96,7 @@ public class ZigBeeThingTypeProviderTest {
     private ZigBeeThingTypeProvider createProvider(final ThingTypeUID... thingTypeUIDs) {
         return new ZigBeeThingTypeProvider() {
             @Override
-            public @NonNull Set<@NonNull ThingTypeUID> getThingTypeUIDs() {
+            public Set<ThingTypeUID> getThingTypeUIDs() {
                 return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(thingTypeUIDs)));
             }
         };

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/thingtype/ZigBeeThingTypeProviderTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/thingtype/ZigBeeThingTypeProviderTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2010-2019 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zigbee.thingtype;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.openhab.binding.zigbee.internal.ZigBeeHandlerFactory;
+
+/**
+ * Testing the {@link ZigBeeThingTypeProvider} provisioning process.
+ *
+ * @author Thomas Höfer - Initial contribution
+ */
+public class ZigBeeThingTypeProviderTest {
+
+    private static final String BINDING = "zigbee";
+    private static final ThingTypeUID UID1 = new ThingTypeUID(BINDING, "tt1");
+    private static final ThingTypeUID UID2 = new ThingTypeUID(BINDING, "tt2");
+    private static final ThingTypeUID UID3 = new ThingTypeUID(BINDING, "tt3");
+
+    private final ZigBeeThingTypeProvider provider1 = createProvider(UID1, UID2);
+    private final ZigBeeThingTypeProvider provider2 = createProvider(UID3);
+
+    private ZigBeeHandlerFactory factory;
+
+    @Before
+    public void setup() {
+        factory = new ZigBeeHandlerFactory();
+    }
+
+    @Test
+    public void testNoProviders() {
+        assertFalse(factory.supportsThingType(UID1));
+    }
+
+    @Test
+    public void testAddThingTypes() {
+        factory.addZigBeeThingTypeProvider(provider1);
+
+        assertTrue(factory.supportsThingType(UID1));
+        assertTrue(factory.supportsThingType(UID2));
+        assertFalse(factory.supportsThingType(UID3));
+    }
+
+    @Test
+    public void testRemoveThingTypes() {
+        factory.addZigBeeThingTypeProvider(provider1);
+        factory.removeZigBeeThingTypeProvider(provider1);
+
+        assertFalse(factory.supportsThingType(UID1));
+        assertFalse(factory.supportsThingType(UID2));
+        assertFalse(factory.supportsThingType(UID3));
+    }
+
+    @Test
+    public void testSeveralProviders() {
+        factory.addZigBeeThingTypeProvider(provider1);
+
+        assertTrue(factory.supportsThingType(UID1));
+        assertTrue(factory.supportsThingType(UID2));
+        assertFalse(factory.supportsThingType(UID3));
+
+        factory.addZigBeeThingTypeProvider(provider2);
+
+        assertTrue(factory.supportsThingType(UID1));
+        assertTrue(factory.supportsThingType(UID2));
+        assertTrue(factory.supportsThingType(UID3));
+
+        factory.removeZigBeeThingTypeProvider(provider1);
+
+        assertFalse(factory.supportsThingType(UID1));
+        assertFalse(factory.supportsThingType(UID2));
+        assertTrue(factory.supportsThingType(UID3));
+
+        factory.removeZigBeeThingTypeProvider(provider2);
+
+        assertFalse(factory.supportsThingType(UID1));
+        assertFalse(factory.supportsThingType(UID2));
+        assertFalse(factory.supportsThingType(UID3));
+    }
+
+    private ZigBeeThingTypeProvider createProvider(final ThingTypeUID... thingTypeUIDs) {
+        return new ZigBeeThingTypeProvider() {
+            @Override
+            public @NonNull Set<@NonNull ThingTypeUID> getThingTypeUIDs() {
+                return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(thingTypeUIDs)));
+            }
+        };
+    }
+}


### PR DESCRIPTION
Having an osgified thing type matching approach we can get rid of the separate ```ZigBeeThingHandlerFactory``` implementation in our project. Since the thing handler created by that factory depends on the ```ZigBeeChannelConverterFactory``` which is not API we required an additional commit in our project to get the corresponding **internal** package of the binding exported. For this reason we decided to implement a mechanism to provide thing type matchers as OSGi services so that we can provide our project based thing types **and** that we can use the standar thing handler factory of the binding.

Signed-off-by: Thomas Höfer <thomas.hoefer@telekom.de>