### PR TITLE
More Osram smart+ switch support

### DIFF
--- a/org.openhab.binding.zigbee/ESH-INF/thing/osram/osram-switch-4x-eu.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/osram/osram-switch-4x-eu.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0" bindingId="zigbee"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+	<thing-type id="osram-switch-4x-eu">
+		<label>Osram Smart+ Switch</label>
+		<channels>
+			<channel id="buttonBottomRight" typeId="system.button">
+				<label>Button bottom right</label>
+				<description>The button in the bottom right corner (LED pointing down wards).</description>
+				<properties>
+					<property name="zigbee_endpoint">1</property>
+					<property name="zigbee_shortpress_cluster_id">0x0006</property>
+					<property name="zigbee_shortpress_command_id">0x01</property>
+					<property name="zigbee_longpress_cluster_id">0x0008</property>
+					<property name="zigbee_longpress_command_id">0x05</property>
+				</properties>
+			</channel>
+			<channel id="buttonBottomRightLongpressRelease" typeId="system.button">
+				<label>Button bottom right long press release</label>
+				<description>This channel gets an event when a long press on the bottom right button is released.</description>
+				<properties>
+					<property name="zigbee_endpoint">1</property>
+					<property name="zigbee_shortpress_cluster_id">0x0008</property>
+					<property name="zigbee_shortpress_command_id">0x03</property>
+				</properties>
+			</channel>
+			<channel id="buttonBottomLeft" typeId="system.button">
+				<label>Button bottom left</label>
+				<description>The button in the bottom left corner (LED pointing down wards).</description>
+				<properties>
+					<property name="zigbee_endpoint">2</property>
+					<!-- short press is not working yet -->
+					<!-- <property name="zigbee_shortpress_cluster_id">0x0300</property> -->
+					<!-- <property name="zigbee_shortpress_command_id">0x4C</property> -->
+					<property name="zigbee_longpress_cluster_id">0x0300</property>
+					<property name="zigbee_longpress_command_id">0x03</property>
+				</properties>
+			</channel>
+			<channel id="buttonBottomLeftLongpressRelease" typeId="system.button">
+				<label>Button bottom left long press release</label>
+				<description>This channel gets an event when a long press on the bottom left button is released.</description>
+				<properties>
+					<property name="zigbee_endpoint">2</property>
+					<property name="zigbee_shortpress_cluster_id">0x0300</property>
+					<property name="zigbee_shortpress_command_id">0x01</property>
+                    <property name="zigbee_shortpress_parameter_name">moveMode</property>
+                    <property name="zigbee_shortpress_parameter_value">0</property>
+				</properties>
+			</channel>
+			<channel id="buttonTopRight" typeId="system.button">
+				<label>Button top right</label>
+				<description>The button in the top right corner (LED pointing down wards).</description>
+				<properties>
+					<property name="zigbee_endpoint">3</property>
+					<property name="zigbee_shortpress_cluster_id">0x0006</property>
+					<property name="zigbee_shortpress_command_id">0x00</property>
+					<property name="zigbee_longpress_cluster_id">0x0008</property>
+					<property name="zigbee_longpress_command_id">0x01</property>
+				</properties>
+			</channel>
+			<channel id="buttonTopRightLongpressRelease" typeId="system.button">
+				<label>Button top right long press release</label>
+				<description>This channel gets an event when a long press on the top right button is released.</description>
+				<properties>
+					<property name="zigbee_endpoint">3</property>
+					<property name="zigbee_shortpress_cluster_id">0x0008</property>
+					<property name="zigbee_shortpress_command_id">0x03</property>
+				</properties>
+			</channel>
+			<channel id="buttonTopLeft" typeId="system.button">
+				<label>Button top left</label>
+				<description>The button in the top left corner (LED pointing down wards).</description>
+				<properties>
+					<property name="zigbee_endpoint">4</property>
+					<!-- short press is not working yet -->
+					<!-- <property name="zigbee_shortpress_cluster_id">0x0300</property> -->
+					<!-- <property name="zigbee_shortpress_command_id">0x4C</property> -->
+					<property name="zigbee_longpress_cluster_id">0x0300</property>
+					<property name="zigbee_longpress_command_id">0x03</property>
+				</properties>
+			</channel>
+			<channel id="buttonTopLeftLongpressRelease" typeId="system.button">
+				<label>Button top left long press release</label>
+				<description>This channel gets an event when a long press on the top left button is released.</description>
+				<properties>
+					<property name="zigbee_endpoint">4</property>
+					<property name="zigbee_shortpress_cluster_id">0x0300</property>
+					<property name="zigbee_shortpress_command_id">0x01</property>
+					<property name="zigbee_shortpress_parameter_name">moveMode</property>
+					<property name="zigbee_shortpress_parameter_value">0</property>
+				</properties>
+			</channel>
+			<channel id="batteryVoltage" typeId="battery_voltage">
+				<properties>
+					<property name="zigbee_endpoint">2</property>
+				</properties>
+			</channel>
+		</channels>
+		<config-description>
+			<parameter name="zigbee_macaddress" type="text" readOnly="true" required="true">
+				<label>MAC Address</label>
+			</parameter>
+		</config-description>
+	</thing-type>
+</thing:thing-descriptions>

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButton.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButton.java
@@ -237,10 +237,8 @@ public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter imp
 
         public boolean matchesCommand(ZclCommand command) {
             boolean commandIdMatches = command.getCommandId().intValue() == commandId;
-            boolean commandParameterMatches = commandParameterName == null || commandParameterValue == null
-                    || matchesParameter(command);
-
-            return commandIdMatches && commandParameterMatches;
+            return commandIdMatches
+                    && (commandParameterName == null || commandParameterValue == null || matchesParameter(command));
         }
 
         private boolean matchesParameter(ZclCommand command) {

--- a/org.openhab.binding.zigbee/src/main/resources/discovery.txt
+++ b/org.openhab.binding.zigbee/src/main/resources/discovery.txt
@@ -5,3 +5,4 @@ bitron-video-902010-23,vendor=Bitron Home,modelId=902010/23
 bitron-video-av2010-34,vendor=Bitron Video,modelId=AV2010/34
 xiaomi_lumisensorht,modelId=lumi.sensor_ht
 innr-rc-110,vendor=innr,modelId=RC 110
+osram-switch-4x-eu,vendor=OSRAM,modelId=Switch 4x EU-LIGHTIFY


### PR DESCRIPTION
With this pull request long press and long press release work for all 4 buttons. Short press work only for the right buttons at the moments because the library can not map the required cluster/commandId combination. I guess that is fixed with https://github.com/openhab/org.openhab.binding.zigbee/pull/363 ?

The switch reports voltage but now battery percentage. I added a mapping for the voltage too.

While creating the definition I got the following exception

~~~
2019-01-17 19:16:12.122 [WARN ] [c.ZigBeeConverterGenericButton:255  ] - 000D6F000FE4C49A: Could not read parameter moveMode for command MoveToSaturationCommand [Color Control: 28320/2 -> 0/1, cluster=0300, TID=17, saturation=254, transitionTime=2]java.lang.NoSuchMethodException: com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.MoveToSaturationCommand.getMoveMode()
	at java.lang.Class.getMethod(Class.java:1786)
	at org.openhab.binding.zigbee.internal.converter.ZigBeeConverterGenericButton$CommandSpec.matchesParameter(ZigBeeConverterGenericButton.java:250)
	at org.openhab.binding.zigbee.internal.converter.ZigBeeConverterGenericButton$CommandSpec.matchesCommand(ZigBeeConverterGenericButton.java:241)
	at org.openhab.binding.zigbee.internal.converter.ZigBeeConverterGenericButton.getButtonPressType(ZigBeeConverterGenericButton.java:152)
	at org.openhab.binding.zigbee.internal.converter.ZigBeeConverterGenericButton.commandReceived(ZigBeeConverterGenericButton.java:128)
	at com.zsmartsystems.zigbee.zcl.ZclCluster$5.run(ZclCluster.java:845)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
~~~

I fixed it in the second commit.