### PR TITLE
Add Xiaomi Lumi motion sensor

### DIFF
--- a/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensor-motion.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensor-motion.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zigbee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="xiaomi_lumisensor-motion">
+		<label>Xiaomi Lumi Motion Sensor</label>
+		<description>Xiaomi Motion Sensor</description>
+
+		<channels>
+			<channel id="occupancy" typeId="sensor_occupancy">
+				<properties>
+					<property name="zigbee_endpoint">1</property>
+					<property name="zigbee_inputclusters">1030</property>
+				</properties>
+			</channel>
+		</channels>
+
+		<properties>
+			<property name="vendor">Xiaomi</property>
+			<property name="modelId">lumi.sensor_motion</property>
+			<property name="zigbee_logicaltype">END_DEVICE</property>
+		</properties>
+
+		<representation-property>zigbee_macaddress</representation-property>
+
+		<config-description>
+			<parameter name="zigbee_macaddress" type="text" readOnly="true" required="true">
+				<label>MAC Address</label>
+			</parameter>
+		</config-description>
+	</thing-type>
+</thing:thing-descriptions>

--- a/org.openhab.binding.zigbee/src/main/resources/discovery.txt
+++ b/org.openhab.binding.zigbee/src/main/resources/discovery.txt
@@ -4,4 +4,5 @@ smartthings_motionv4,vendor=SmartThings,modelId=motionv4
 bitron-video-902010-23,vendor=Bitron Home,modelId=902010/23
 bitron-video-av2010-34,vendor=Bitron Video,modelId=AV2010/34
 xiaomi_lumisensorht,modelId=lumi.sensor_ht
+xiaomi_lumisensor-motion,modelId=lumi.sensor_motion
 innr-rc-110,vendor=innr,modelId=RC 110


### PR DESCRIPTION
Thanks to @puzzle-star suggestion [on the forums](https://community.openhab.org/t/zigbee-binding/15763/1885?u=jonny0stars) I've added an override for the Xiaomi Lumi motion sensor.


Before - 
```
21:39:42.891 [DEBUG] [531.network.impl.CommandInterfaceImpl] - <-- AF_INCOMING_MSG (FE 1B 44 81 00 00 06 04 D2 C1 01 01 00 7E 00 11 E1 4C 00 00 07 18 04 0A 00 00 18 01 D2 C1 1D 0B)
21:39:42.891 [DEBUG] [531.network.impl.CommandInterfaceImpl] - Received Async Cmd: Packet: subsystem=null, length=27, apiId=44 81, data=FE 1B 44 81 00 00 06 04 D2 C1 01 01 00 7E 00 11 E1 4C 00 00 07 18 04 0A 00 00 18 01 D2 C1 1D 0B, checksum=0B, error=false
21:39:42.891 [DEBUG] [rtsystems.zigbee.ZigBeeNetworkManager] - RX APS: ZigBeeApsFrame [sourceAddress=49618/1, destinationAddress=0/1, profile=0104, cluster=1030, addressMode=null, radius=0, apsSecurity=false, apsCounter=0, payload=18 04 0A 00 00 18 01]
21:39:42.891 [DEBUG] [rtsystems.zigbee.ZigBeeNetworkManager] - RX ZCL: ZclHeader [frameType=ENTIRE_PROFILE_COMMAND, manufacturerSpecific=false, direction=SERVER_TO_CLIENT, disableDefaultResponse=true, manufacturerCode=0, sequenceNumber=4, commandId=10]
21:39:42.892 [DEBUG] [rtsystems.zigbee.ZigBeeNetworkManager] - RX CMD: ReportAttributesCommand [Occupancy sensing: 49618/1 -> 0/1, cluster=0406, TID=04, reports=[Attribute Report: attributeDataType=BITMAP_8_BIT, attributeIdentifier=0, attributeValue=1]]
21:39:42.892 [DEBUG] [m.zsmartsystems.zigbee.ZigBeeEndpoint] - 49618/1: Cluster 1030 not found for attribute response
```
After 
```
21:05:04.505 [DEBUG] [al.converter.ZigBeeConverterOccupancy] - 00158D00020B3D32: ZigBee attribute reports ZclAttribute [cluster=OCCUPANCY_SENSING, id=0, name=Occupancy, dataType=BITMAP_8_BIT, lastValue=1, lastReportTime=Sat Jan 19 21:05:04 GMT 2019]
21:05:04.505 [DEBUG] [.converter.ZigBeeBaseChannelConverter] - 00158D00020B3D32: Channel zigbee:xiaomi_lumisensor-motion:686111d4:00158d00020b3d32:occupancy updated to ON
21:05:04.505 [DEBUG] [ing.zigbee.handler.ZigBeeThingHandler] - 00158D00020B3D32: Updating ZigBee channel state zigbee:xiaomi_lumisensor-motion:686111d4:00158d00020b3d32:occupancy to ON
```

The only thing i think is confusing is it sticks on the ``ON`` state, there is no method to set a timeout on the ZED AFIK so it only ever triggers on motion, it does not report lack of motion, so its not treating motion as a toggle, I can work around this with a rule that fires on change but i suspect it should probably return to the ``OFF`` state?