### PR TITLE
Added missing thing type package

### DIFF
--- a/org.openhab.binding.zigbee/META-INF/MANIFEST.MF
+++ b/org.openhab.binding.zigbee/META-INF/MANIFEST.MF
@@ -55,6 +55,7 @@ Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.zigbee,
  org.openhab.binding.zigbee.converter,
  org.openhab.binding.zigbee.discovery,
- org.openhab.binding.zigbee.handler
+ org.openhab.binding.zigbee.handler,
+ org.openhab.binding.zigbee.thingtype
 Bundle-ClassPath: .
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
In #365 we have added the possibility to provide additional thing types. Unfortunately we forgot to add it as exported package so that 3rd party bundles can make use of it.