### PR TITLE
Add static definition for Xiaomi Wireless 2-Button Switch

### DIFF
--- a/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensor86sw2.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensor86sw2.xml
@@ -17,13 +17,13 @@
 			</channel>
 			<channel id="switch_2" typeId="switch_onoff">
 				<properties>
-					<property name="zigbee_endpoint">1</property>
+					<property name="zigbee_endpoint">2</property>
 					<property name="zigbee_inputclusters">6</property>
 				</properties>
 			</channel>
 			<channel id="switch_3" typeId="switch_onoff">
 				<properties>
-					<property name="zigbee_endpoint">1</property>
+					<property name="zigbee_endpoint">3</property>
 					<property name="zigbee_inputclusters">6</property>
 				</properties>
 			</channel>

--- a/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensor86sw2.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensor86sw2.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zigbee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="xiaomi_lumisensor86sw2">
+		<label>Xiaomi Wireless 2-Button Switch</label>
+		<description>Xiaomi Wireless 2-Button Switch</description>
+
+		<channels>
+			<channel id="switch_1" typeId="switch_onoff">
+				<properties>
+					<property name="zigbee_endpoint">1</property>
+					<property name="zigbee_inputclusters">6</property>
+				</properties>
+			</channel>
+			<channel id="switch_2" typeId="switch_onoff">
+				<properties>
+					<property name="zigbee_endpoint">1</property>
+					<property name="zigbee_inputclusters">6</property>
+				</properties>
+			</channel>
+			<channel id="switch_3" typeId="switch_onoff">
+				<properties>
+					<property name="zigbee_endpoint">1</property>
+					<property name="zigbee_inputclusters">6</property>
+				</properties>
+			</channel>
+		</channels>
+
+		<properties>
+			<property name="vendor">Xiaomi</property>
+			<property name="modelId">lumi.sensor_86sw2</property>
+			<property name="zigbee_logicaltype">END_DEVICE</property>
+		</properties>
+
+		<representation-property>zigbee_macaddress</representation-property>
+
+		<config-description>
+			<parameter name="zigbee_macaddress" type="text" readOnly="true" required="true">
+				<label>MAC Address</label>
+			</parameter>
+		</config-description>
+	</thing-type>
+</thing:thing-descriptions>

--- a/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensor86sw2.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensor86sw2.xml
@@ -4,9 +4,11 @@
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-	<thing-type id="xiaomi_lumisensor86sw2">
+	<!-- These devices do not correctly report their clusters, so they need a static thing definition for the binding to inject the correct clusters into the ZigBeeNode -->
+
+	<thing-type id="xiaomi_lumisensor86sw2" listed="false">
 		<label>Xiaomi Wireless 2-Button Switch</label>
-		<description>Xiaomi Wireless 2-Button Switch. This specific Thing Type is needed because these devices do not correctly report their clusters.</description>
+		<description>Xiaomi Wireless 2-Button Switch</description>
 
 		<channels>
 			<channel id="switch_1" typeId="switch_onoff">

--- a/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensor86sw2.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensor86sw2.xml
@@ -6,7 +6,7 @@
 
 	<thing-type id="xiaomi_lumisensor86sw2">
 		<label>Xiaomi Wireless 2-Button Switch</label>
-		<description>Xiaomi Wireless 2-Button Switch</description>
+		<description>Xiaomi Wireless 2-Button Switch. These devices do not correctly report their clusters, so these need to be injected by the binding.</description>
 
 		<channels>
 			<channel id="switch_1" typeId="switch_onoff">

--- a/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensor86sw2.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensor86sw2.xml
@@ -6,7 +6,7 @@
 
 	<thing-type id="xiaomi_lumisensor86sw2">
 		<label>Xiaomi Wireless 2-Button Switch</label>
-		<description>Xiaomi Wireless 2-Button Switch. These devices do not correctly report their clusters, so these need to be injected by the binding.</description>
+		<description>Xiaomi Wireless 2-Button Switch. This specific Thing Type is needed because these devices do not correctly report their clusters.</description>
 
 		<channels>
 			<channel id="switch_1" typeId="switch_onoff">

--- a/org.openhab.binding.zigbee/src/main/resources/discovery.txt
+++ b/org.openhab.binding.zigbee/src/main/resources/discovery.txt
@@ -5,4 +5,5 @@ bitron-video-902010-23,vendor=Bitron Home,modelId=902010/23
 bitron-video-av2010-34,vendor=Bitron Video,modelId=AV2010/34
 xiaomi_lumisensorht,modelId=lumi.sensor_ht
 xiaomi_lumisensor-motion,modelId=lumi.sensor_motion
+xiaomi_lumisensor86sw2,modelId=lumi.sensor_86sw2
 innr-rc-110,vendor=innr,modelId=RC 110


### PR DESCRIPTION
This adds support for the non-standard Xiaomi lumi.sensor_86sw2, the two button wireless (battery powered) switches.

It adds three channels (switch_onoff cluster at endpoints 1, 2 and 3), for left button (switch_1), right button (switch_2) and both buttons at the same time (switch_3)