### PR TITLE
Do not list statically defined devices when manually adding things

### DIFF
--- a/org.openhab.binding.zigbee/ESH-INF/thing/bitron/bitron-video-902010-23.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/bitron/bitron-video-902010-23.xml
@@ -3,7 +3,7 @@
                           xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
                           bindingId="zigbee"
                           xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
-   <thing-type id="bitron-video-902010-23">
+   <thing-type id="bitron-video-902010-23" listed="false">
       <label>BitronVideo 4-button Remote Control</label>
       <channels>
          <channel id="key1" typeId="system.button">

--- a/org.openhab.binding.zigbee/ESH-INF/thing/bitron/bitron-video-av2010-34.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/bitron/bitron-video-av2010-34.xml
@@ -3,7 +3,7 @@
                           xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
                           bindingId="zigbee"
                           xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
-   <thing-type id="bitron-video-av2010-34">
+   <thing-type id="bitron-video-av2010-34" listed="false">
       <label>Bitron Video Wall Switch AV2010/34</label>
       <channels>
          <channel id="button1" typeId="system.button">

--- a/org.openhab.binding.zigbee/ESH-INF/thing/innr/rc-110.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/innr/rc-110.xml
@@ -3,7 +3,7 @@
                           xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
                           bindingId="zigbee"
                           xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
-   <thing-type id="innr-rc-110">
+   <thing-type id="innr-rc-110" listed="false">
       <label>Innr RC 110 Remote Control</label>
       <channels>
          <channel id="scenesOn" typeId="system.button">

--- a/org.openhab.binding.zigbee/ESH-INF/thing/osram/osram-switch-4x-eu.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/osram/osram-switch-4x-eu.xml
@@ -2,7 +2,7 @@
 <thing:thing-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0" bindingId="zigbee"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
-	<thing-type id="osram-switch-4x-eu">
+	<thing-type id="osram-switch-4x-eu" listed="false">
 		<label>Osram Smart+ Switch</label>
 		<channels>
 			<channel id="buttonBottomRight" typeId="system.button">

--- a/org.openhab.binding.zigbee/ESH-INF/thing/philips/rwl021.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/philips/rwl021.xml
@@ -3,7 +3,7 @@
                           xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
                           bindingId="zigbee"
                           xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
-   <thing-type id="philips_rwl021">
+   <thing-type id="philips_rwl021" listed="false">
       <label>Hue Dimmer Switch</label>
       <channels>
          <channel id="buttonI" typeId="system.button">

--- a/org.openhab.binding.zigbee/ESH-INF/thing/philips/sml001.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/philips/sml001.xml
@@ -4,7 +4,7 @@
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-	<thing-type id="philips_sml001">
+	<thing-type id="philips_sml001" listed="false">
 		<label>Hue Motion Sensor</label>
 		<description>Hue Motion Illuminance and Temperature Sensor</description>
 

--- a/org.openhab.binding.zigbee/ESH-INF/thing/smartthings/motionv4.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/smartthings/motionv4.xml
@@ -3,7 +3,7 @@
     xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
     xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-    <thing-type id="smartthings_motionv4">
+    <thing-type id="smartthings_motionv4" listed="false">
         <label>SmartThings Motion Sensor V4</label>
         <description>SmartThings Motion and Temperature Sensor</description>
 

--- a/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumiremoteb286acn01.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumiremoteb286acn01.xml
@@ -4,7 +4,7 @@
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-	<thing-type id="xiaomi_lumiremoteb286acn01">
+	<thing-type id="xiaomi_lumiremoteb286acn01" listed="false">
 		<label>Xiaomi Wall Switch</label>
 		<description>Xiaomi Wall Switch</description>
 		<category>WallSwitch</category>

--- a/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensor-motion.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensor-motion.xml
@@ -4,7 +4,7 @@
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-	<thing-type id="xiaomi_lumisensor-motion">
+	<thing-type id="xiaomi_lumisensor-motion" listed="false">
 		<label>Xiaomi Lumi Motion Sensor</label>
 		<description>Xiaomi Motion Sensor</description>
 

--- a/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensorht.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/lumisensorht.xml
@@ -4,7 +4,7 @@
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-	<thing-type id="xiaomi_lumisensorht">
+	<thing-type id="xiaomi_lumisensorht" listed="false">
 		<label>Xiaomi Temperature and Humidity Sensor</label>
 		<description>Xiaomi Temperature and Humidity Sensor</description>
 


### PR DESCRIPTION
Statically defined things cannot be added manually, so marking them "not listable" for them not to be shown when adding devices manually

@cdjackson, as discussed :-)