### PR TITLE
Prevent coordinator handler from starting reconnect job when bridge is being removed

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -881,13 +881,18 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
                     break;
                 }
                 
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
                 
-                // try to reconnect (unless the bridge is being removed or uninitialized)
-                if (!Arrays.asList(ThingStatus.UNINITIALIZED, ThingStatus.REMOVING, ThingStatus.REMOVED)
+                // - Do not set the status to OFFLINE when the bridge is in one of these statuses. According to the
+                // documentation https://www.eclipse.org/smarthome/documentation/concepts/things.html#status-transitions
+                // the thing must not change from these statuses to OFFLINE
+                // - Do not try to reconnect if the bridge is being removed.
+                if (Arrays.asList(ThingStatus.UNINITIALIZED, ThingStatus.REMOVING, ThingStatus.REMOVED)
                         .contains(bridge.getStatus())) {
-                    startReconnectJobIfNotRunning();
+                    break;
                 }
+                
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
+                startReconnectJobIfNotRunning();
 
                 break;
             default:

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -11,6 +11,7 @@ package org.openhab.binding.zigbee.handler;
 import static org.openhab.binding.zigbee.ZigBeeBindingConstants.*;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -873,13 +874,21 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
                 break;
             case OFFLINE:
                 Bridge bridge = getThing();
+
                 // do not try to reconnect if there is a firmware update in progress
                 if (bridge.getStatus() == ThingStatus.OFFLINE
                         && bridge.getStatusInfo().getStatusDetail() == ThingStatusDetail.FIRMWARE_UPDATING) {
                     break;
                 }
+                
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
-                startReconnectJobIfNotRunning();
+                
+                // try to reconnect (unless the bridge is being removed or uninitialized)
+                if (!Arrays.asList(ThingStatus.UNINITIALIZED, ThingStatus.REMOVING, ThingStatus.REMOVED)
+                        .contains(bridge.getStatus())) {
+                    startReconnectJobIfNotRunning();
+                }
+
                 break;
             default:
                 break;


### PR DESCRIPTION
Fixes #200 

In the method 'networkStateUpdated' the reconnect job was restarted when
the removal of the bridge was in progress. This lead to frame handler
activity although the node didn't exist anymore. Now the restart of the
reconnect job is skipped when the thing status is 'UNINITIALIZED',
'REMOVING' or 'REMOVED'.

Signed-off-by: Tommaso Travaglino <tommaso.travaglino@telekom.de>