### PR TITLE
Set thing status to offline/gone if there is no node for a thing

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -219,7 +219,7 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
         ZigBeeNode node = coordinatorHandler.getNode(nodeIeeeAddress);
         if (node == null) {
             logger.debug("{}: Node not found - deferring handler initialisation", nodeIeeeAddress);
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, ZigBeeBindingConstants.OFFLINE_NODE_NOT_FOUND);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.GONE, ZigBeeBindingConstants.OFFLINE_NODE_NOT_FOUND);
             return;
         }
 
@@ -765,7 +765,7 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
         updateProperties(properties);
 
         if (getThing().getStatus() != ThingStatus.REMOVING) {
-            updateStatus(ThingStatus.OFFLINE);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.GONE);
         }
     }
 


### PR DESCRIPTION
This resolves #380 

As discussed in #380 , this changes the thing status to `OFFLINE` with detail `GONE` if (a) there is no node for the thing on node initialization in the thing handler, and (b) if the thing handler learns that the node was removed (and removal was not triggered by the openHAB core, in which case the thing status would be `REMOVING`).

As you mentioned [here](https://github.com/openhab/org.openhab.binding.zigbee/issues/380#issuecomment-468263410), Chris, case (b) should not happen currently, as the ZSS library will not remove nodes unless the binding explicitly requests that the device leaves the network. But in case that this changes in the future, I think it's good to correctly set the status detail to `GONE` in case (b) as well.
