### PR TITLE
Make interface WarningTypeCommandDescriptionProvider and related enums API

### DIFF
--- a/org.openhab.binding.zigbee/META-INF/MANIFEST.MF
+++ b/org.openhab.binding.zigbee/META-INF/MANIFEST.MF
@@ -55,6 +55,7 @@ Import-Package: com.thoughtworks.xstream,
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.zigbee,
  org.openhab.binding.zigbee.converter,
+ org.openhab.binding.zigbee.converter.warningdevice,
  org.openhab.binding.zigbee.discovery,
  org.openhab.binding.zigbee.handler
 Bundle-ClassPath: .

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/warningdevice/SoundLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/warningdevice/SoundLevel.java
@@ -6,29 +6,28 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.openhab.binding.zigbee.internal.converter.warningdevice;
+package org.openhab.binding.zigbee.converter.warningdevice;
 
 /**
- * Possible values for the warning mode in a warning type.
+ * Possible siren level values (for both warning and squawk commands).
  *
  * @author Henning Sudbrock - initial contribution
  */
-public enum WarningMode {
-    STOP(0),
-    BURGLAR(1),
-    FIRE(2),
-    EMERGENCY(3),
-    POLICE_PANIC(4),
-    FIRE_PANIC(5),
-    EMERGENCY_PANIC(6);
+public enum SoundLevel {
+
+    LOW(0),
+    MEDIUM(1),
+    HIGH(2),
+    VERY_HIGH(3);
 
     private int value;
 
-    WarningMode(int value) {
+    SoundLevel(int value) {
         this.value = value;
     }
 
     public int getValue() {
         return value;
     }
+
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/warningdevice/SquawkMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/warningdevice/SquawkMode.java
@@ -6,7 +6,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.openhab.binding.zigbee.internal.converter.warningdevice;
+package org.openhab.binding.zigbee.converter.warningdevice;
 
 /**
  * Possible values for the squawk mode in a squawk type.

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/warningdevice/SquawkType.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/warningdevice/SquawkType.java
@@ -6,11 +6,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.openhab.binding.zigbee.internal.converter.warningdevice;
+package org.openhab.binding.zigbee.converter.warningdevice;
 
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toMap;
-import static org.openhab.binding.zigbee.internal.converter.warningdevice.SoundLevel.HIGH;
+import static org.openhab.binding.zigbee.converter.warningdevice.SoundLevel.HIGH;
 
 import java.util.Map;
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/warningdevice/WarningMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/warningdevice/WarningMode.java
@@ -6,28 +6,29 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.openhab.binding.zigbee.internal.converter.warningdevice;
+package org.openhab.binding.zigbee.converter.warningdevice;
 
 /**
- * Possible siren level values (for both warning and squawk commands).
+ * Possible values for the warning mode in a warning type.
  *
  * @author Henning Sudbrock - initial contribution
  */
-public enum SoundLevel {
-
-    LOW(0),
-    MEDIUM(1),
-    HIGH(2),
-    VERY_HIGH(3);
+public enum WarningMode {
+    STOP(0),
+    BURGLAR(1),
+    FIRE(2),
+    EMERGENCY(3),
+    POLICE_PANIC(4),
+    FIRE_PANIC(5),
+    EMERGENCY_PANIC(6);
 
     private int value;
 
-    SoundLevel(int value) {
+    WarningMode(int value) {
         this.value = value;
     }
 
     public int getValue() {
         return value;
     }
-
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/warningdevice/WarningType.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/warningdevice/WarningType.java
@@ -6,13 +6,13 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.openhab.binding.zigbee.internal.converter.warningdevice;
+package org.openhab.binding.zigbee.converter.warningdevice;
 
 import static java.util.Arrays.stream;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
-import static org.openhab.binding.zigbee.internal.converter.warningdevice.SoundLevel.HIGH;
-import static org.openhab.binding.zigbee.internal.converter.warningdevice.WarningMode.BURGLAR;
+import static org.openhab.binding.zigbee.converter.warningdevice.SoundLevel.HIGH;
+import static org.openhab.binding.zigbee.converter.warningdevice.WarningMode.BURGLAR;
 
 import java.time.Duration;
 import java.util.Map;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/warningdevice/WarningTypeCommandDescriptionProvider.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/warningdevice/WarningTypeCommandDescriptionProvider.java
@@ -6,7 +6,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.openhab.binding.zigbee.internal.converter.warningdevice;
+package org.openhab.binding.zigbee.converter.warningdevice;
 
 import java.util.List;
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/warningdevice/DynamicWarningCommandDescriptionProvider.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/warningdevice/DynamicWarningCommandDescriptionProvider.java
@@ -26,6 +26,7 @@ import org.eclipse.smarthome.core.thing.type.DynamicCommandDescriptionProvider;
 import org.eclipse.smarthome.core.types.CommandDescription;
 import org.eclipse.smarthome.core.types.CommandDescriptionBuilder;
 import org.eclipse.smarthome.core.types.CommandOption;
+import org.openhab.binding.zigbee.converter.warningdevice.WarningTypeCommandDescriptionProvider;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/warningdevice/DynamicWarningCommandDescriptionProvider.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/warningdevice/DynamicWarningCommandDescriptionProvider.java
@@ -26,6 +26,7 @@ import org.eclipse.smarthome.core.thing.type.DynamicCommandDescriptionProvider;
 import org.eclipse.smarthome.core.types.CommandDescription;
 import org.eclipse.smarthome.core.types.CommandDescriptionBuilder;
 import org.eclipse.smarthome.core.types.CommandOption;
+import org.openhab.binding.zigbee.converter.warningdevice.WarningType;
 import org.openhab.binding.zigbee.converter.warningdevice.WarningTypeCommandDescriptionProvider;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/warningdevice/ZigBeeConverterWarningDevice.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/warningdevice/ZigBeeConverterWarningDevice.java
@@ -23,6 +23,8 @@ import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.converter.warningdevice.SquawkType;
+import org.openhab.binding.zigbee.converter.warningdevice.WarningType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/warningdevice/DynamicWarningCommandDescriptionProviderTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/warningdevice/DynamicWarningCommandDescriptionProviderTest.java
@@ -23,6 +23,7 @@ import org.eclipse.smarthome.core.types.CommandDescription;
 import org.eclipse.smarthome.core.types.CommandOption;
 import org.junit.Before;
 import org.junit.Test;
+import org.openhab.binding.zigbee.converter.warningdevice.WarningType;
 import org.openhab.binding.zigbee.converter.warningdevice.WarningTypeCommandDescriptionProvider;
 
 /**

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/warningdevice/DynamicWarningCommandDescriptionProviderTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/warningdevice/DynamicWarningCommandDescriptionProviderTest.java
@@ -23,6 +23,7 @@ import org.eclipse.smarthome.core.types.CommandDescription;
 import org.eclipse.smarthome.core.types.CommandOption;
 import org.junit.Before;
 import org.junit.Test;
+import org.openhab.binding.zigbee.converter.warningdevice.WarningTypeCommandDescriptionProvider;
 
 /**
  * Unit tests for the {@link DynamicWarningCommandDescriptionProvider}.

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/warningdevice/SquawkTypeTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/warningdevice/SquawkTypeTest.java
@@ -11,6 +11,9 @@ package org.openhab.binding.zigbee.internal.converter.warningdevice;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
+import org.openhab.binding.zigbee.converter.warningdevice.SoundLevel;
+import org.openhab.binding.zigbee.converter.warningdevice.SquawkMode;
+import org.openhab.binding.zigbee.converter.warningdevice.SquawkType;
 
 /**
  * Unit tests for {@link SquawkType}.

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/warningdevice/WarningTypeTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/warningdevice/WarningTypeTest.java
@@ -13,6 +13,9 @@ import static org.junit.Assert.*;
 import java.time.Duration;
 
 import org.junit.Test;
+import org.openhab.binding.zigbee.converter.warningdevice.SoundLevel;
+import org.openhab.binding.zigbee.converter.warningdevice.WarningMode;
+import org.openhab.binding.zigbee.converter.warningdevice.WarningType;
 
 /**
  * Unit tests for {@link WarningType}.

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/warningdevice/ZigBeeConverterWarningDeviceTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/warningdevice/ZigBeeConverterWarningDeviceTest.java
@@ -19,6 +19,11 @@ import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.junit.Before;
 import org.junit.Test;
+import org.openhab.binding.zigbee.converter.warningdevice.SoundLevel;
+import org.openhab.binding.zigbee.converter.warningdevice.SquawkMode;
+import org.openhab.binding.zigbee.converter.warningdevice.SquawkType;
+import org.openhab.binding.zigbee.converter.warningdevice.WarningMode;
+import org.openhab.binding.zigbee.converter.warningdevice.WarningType;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 


### PR DESCRIPTION
Currently, the interface `WarningTypeCommandDescriptionProvider` is not exported. The interface should, however, be exported, because it is intended to be implemented by providers that might be in other bundles.

For this reason, I have moved the interface to the subpackage `warningdevice` of the non-internal `converter` package. Likewise, I have added related enums into the exported subpackage, as they can be used to create warning type command options in a type-safe way.