### PR TITLE
add support for xiaomi wireless mini switch

### DIFF
--- a/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/xiaomi_lumisensor-switchaq2.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/xiaomi/xiaomi_lumisensor-switchaq2.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zigbee"
+                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                          xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+                          xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="xiaomi_lumisensor-switchaq2" listed="false">
+        <label>Xiaomi Wireless Mini Switch</label>
+        <description>Xiaomi Wireless Mini Switch</description>
+        <category>WallSwitch</category>
+
+        <channels>
+            <channel id="center" typeId="system.button">
+                <label>Center</label>
+                <properties>
+                    <property name="zigbee_endpoint">1</property>
+                    <property name="zigbee_shortpress_cluster_id">0x06</property>
+                    <property name="zigbee_shortpress_attribute_id">0</property>
+                    <property name="zigbee_shortpress_attribute_value">true</property>
+                    <property name="zigbee_doublepress_cluster_id">0x06</property>
+                    <property name="zigbee_doublepress_attribute_id">32768</property>
+                    <property name="zigbee_doublepress_attribute_value">2</property>
+                </properties>
+            </channel>
+            <channel id="range-check" typeId="system.button">
+                <label>Range Check</label>
+                <properties>
+                    <property name="zigbee_endpoint">1</property>
+                    <property name="zigbee_shortpress_cluster_id">0x00</property>
+                    <property name="zigbee_shortpress_attribute_id">5</property>
+                    <property name="zigbee_shortpress_attribute_value">lumi.sensor_switch.aq2</property>
+                </properties>
+            </channel>
+        </channels>
+
+        <properties>
+            <property name="vendor">Xiaomi</property>
+            <property name="modelId">lumi.sensor_switch.aq2</property>
+            <property name="zigbee_logicaltype">END_DEVICE</property>
+        </properties>
+
+        <representation-property>zigbee_macaddress</representation-property>
+
+        <config-description>
+            <parameter name="zigbee_macaddress" type="text" readOnly="true" required="true">
+                <label>MAC Address</label>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -121,28 +121,32 @@ The thing type is ```coordinator_xbee```. Other XBee S2C devices should also be 
 
 The following devices have been tested with the binding
 
-| Device                     | Description                                       |
-|----------------------------|---------------------------------------------------|
-| Busch-Jaeger 6711 U        | Relay Insert                                      |
-| Busch-Jaeger 6715 U        | LED-Dimmer Insert                                 |
-| Busch-Jaeger 6735          | Control Element (1-channel)                       |
-| Busch-Jaeger 6735/01       | Control Element (1-channel, battery-operated)     |
-| Busch-Jaeger 6736          | Control Element (2-channel)                       |
-| GE Bulbs                   |                                                   |
-| GE Tapt Wall Switch        | On/Off Switch                                     |
-| Hue Bulbs                  | Color LED Bulb                                    |
-| Hue Dimmer                 | Hue Dimmer Switch Remote *note2*                  |
-| Hue Motion Sensor          | Motion and Luminance sensor                       |
-| Innr Bulbs                 | *note1*                                           |
-| Osram Bulbs                |                                                   |
-| Osram Motion Sensor        | Osram Smart+ Motion Sensor                        |
-| SmartThings Plug           | Metered Plug                                      |
-| SmartThings Motion Sensor  | CentraLite 3325-S Motion and Temperature sensor   |
-| SmartThings Contact Sensor | Contact and Temperature sensor                    |
-| Tradfri Bulbs              |                                                   |
-| Tradfri Motion Sensor      |                                                   |
-| Trust Bulbs                | *note1*                                           |
-| Ubisys modules             | D1 Dimmer, S1/S2 Switch modules                   |
+| Device                                       | Description                                       |
+|----------------------------------------------|---------------------------------------------------|
+| Busch-Jaeger 6711 U                          | Relay Insert                                      |
+| Busch-Jaeger 6715 U                          | LED-Dimmer Insert                                 |
+| Busch-Jaeger 6735                            | Control Element (1-channel)                       |
+| Busch-Jaeger 6735/01                         | Control Element (1-channel, battery-operated)     |
+| Busch-Jaeger 6736                            | Control Element (2-channel)                       |
+| GE Bulbs                                     |                                                   |
+| GE Tapt Wall Switch                          | On/Off Switch                                     |
+| Hue Bulbs                                    | Color LED Bulb                                    |
+| Hue Dimmer                                   | Hue Dimmer Switch Remote *note2*                  |
+| Hue Motion Sensor                            | Motion and Luminance sensor                       |
+| Innr Bulbs                                   | *note1*                                           |
+| Osram Bulbs                                  |                                                   |
+| Osram Motion Sensor                          | Osram Smart+ Motion Sensor                        |
+| SmartThings Plug                             | Metered Plug                                      |
+| SmartThings Motion Sensor                    | CentraLite 3325-S Motion and Temperature sensor   |
+| SmartThings Contact Sensor                   | Contact and Temperature sensor                    |
+| Tradfri Bulbs                                |                                                   |
+| Tradfri Motion Sensor                        |                                                   |
+| Trust Bulbs                                  | *note1*                                           |
+| Ubisys modules                               | D1 Dimmer, S1/S2 Switch modules                   |
+| Xiaomi Aqara Door and Window Sensor          |                                                   |
+| Xiaomi Aqara Temperature and Humidity Sensor |                                                   |
+| Xiaomi Aqara Wireless Mini Switch            |                                                   |
+| Xiaomi Aqara Wireless Remote Switch          | Double Rocker variant                             |
 
 Note 1: Some bulbs may not work with the Telegesis dongle.
 

--- a/org.openhab.binding.zigbee/src/main/resources/discovery.txt
+++ b/org.openhab.binding.zigbee/src/main/resources/discovery.txt
@@ -7,5 +7,6 @@ xiaomi_lumisensorht,modelId=lumi.sensor_ht
 xiaomi_lumisensor-motion,modelId=lumi.sensor_motion
 xiaomi_lumiremoteb286acn01,modelId=lumi.remote.b286acn01
 xiaomi_lumisensor86sw2,modelId=lumi.sensor_86sw2
+xiaomi_lumisensor-switchaq2,modelId=lumi.sensor_switch.aq2
 innr-rc-110,vendor=innr,modelId=RC 110
 osram-switch-4x-eu,vendor=OSRAM,modelId=Switch 4x EU-LIGHTIFY


### PR DESCRIPTION
https://www.aqara.com/en/wireless_mini_switch.html

shortpress requires https://github.com/zsmartsystems/com.zsmartsystems.zigbee/pull/556
doublepress requires support for proprietary attributes.