### PR TITLE
Fix typo in WarningTypeCommandDescriptionProvider API

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/warningdevice/WarningTypeCommandDescriptionProvider.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/warningdevice/WarningTypeCommandDescriptionProvider.java
@@ -24,6 +24,6 @@ public interface WarningTypeCommandDescriptionProvider {
      * @return A map mapping labels for warning/squawk command descriptions (to be used by UIs) to the serializes
      *         warning/squawk commands.
      */
-    List<CommandOption> getWarningAndSquawCommandOptions();
+    List<CommandOption> getWarningAndSquawkCommandOptions();
 
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/warningdevice/DynamicWarningCommandDescriptionProvider.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/warningdevice/DynamicWarningCommandDescriptionProvider.java
@@ -79,7 +79,7 @@ public class DynamicWarningCommandDescriptionProvider implements DynamicCommandD
     }
 
     private List<CommandOption> getProvidedWarningTypes() {
-        return providers.stream().map(WarningTypeCommandDescriptionProvider::getWarningAndSquawCommandOptions)
+        return providers.stream().map(WarningTypeCommandDescriptionProvider::getWarningAndSquawkCommandOptions)
                 .flatMap(List::stream).collect(toList());
     }
 

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/warningdevice/DynamicWarningCommandDescriptionProviderTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/warningdevice/DynamicWarningCommandDescriptionProviderTest.java
@@ -88,7 +88,7 @@ public class DynamicWarningCommandDescriptionProviderTest {
         return new WarningTypeCommandDescriptionProvider() {
 
             @Override
-            public List<CommandOption> getWarningAndSquawCommandOptions() {
+            public List<CommandOption> getWarningAndSquawkCommandOptions() {
                 return Collections.singletonList(new CommandOption(warningType.serializeToCommand(), label));
             }
         };


### PR DESCRIPTION
This PR fixes a typo in the method signature of the `WarningTypeCommandDescriptionProvider` API and thus, the PR is a breaking change. However, it is unlikely that someone already makes use of the newly introduced API.

Signed-off-by: Hannes Hofmann <hannes.hofmann@telekom.de>