### PR TITLE
Implemented IsAliveTracker to set Things to OFFLINE after a timeout

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigbeeIsAliveTracker.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigbeeIsAliveTracker.java
@@ -1,0 +1,83 @@
+package org.openhab.binding.zigbee.handler;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.smarthome.core.common.ThreadPoolManager;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Service which starts timeout tasks to set a Thing to OFFLINE if it doesn't reset the timer before it runs out
+ */
+@Component(immediate = true, service = ZigbeeIsAliveTracker.class)
+public class ZigbeeIsAliveTracker {
+
+    private final Logger logger = LoggerFactory.getLogger(ZigbeeIsAliveTracker.class);
+
+    private Map<ZigBeeThingHandler, Integer> handlerIntervalMapping = new ConcurrentHashMap<>();
+    private Map<ZigBeeThingHandler, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
+
+    protected final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool("ZigbeeIsAliveTracker");
+
+    /**
+     * Adds a mapping from {@link ZigBeeThingHandler} to the interval in which it should have communicated
+     *
+     * @param zigBeeThingHandler      the {@link ZigBeeThingHandler}
+     * @param expectedUpdateInterval the interval in which the device should have communicated with us
+     */
+    public void addHandler(ZigBeeThingHandler zigBeeThingHandler, int expectedUpdateInterval) {
+        handlerIntervalMapping.put(zigBeeThingHandler, expectedUpdateInterval);
+        resetTimer(zigBeeThingHandler);
+    }
+
+    /**
+     * Removes a {@link ZigBeeThingHandler} from the map so it is not tracked anymore
+     *
+     * @param zigBeeThingHandler the {@link ZigBeeThingHandler}
+     */
+    public void removeHandler(ZigBeeThingHandler zigBeeThingHandler) {
+        cancelTask(zigBeeThingHandler);
+        handlerIntervalMapping.remove(zigBeeThingHandler);
+    }
+
+    /**
+     * Reset the timer for a {@link ZigBeeThingHandler}, i.e. expressing that some communication has just occurred
+     *
+     * @param zigBeeThingHandler the {@link ZigBeeThingHandler}
+     */
+    public void resetTimer(ZigBeeThingHandler zigBeeThingHandler) {
+        logger.debug("Reset timeout for handler with thingUID={}", zigBeeThingHandler.getThing().getUID());
+        cancelTask(zigBeeThingHandler);
+        scheduleTask(zigBeeThingHandler);
+    }
+
+    private void scheduleTask(ZigBeeThingHandler handler) {
+        ScheduledFuture<?> existingTask = scheduledTasks.get(handler);
+        if (existingTask == null) {
+            int interval = handlerIntervalMapping.get(handler);
+            logger.debug("Scheduling timeout task for thingUID={} in {} seconds",
+                    handler.getThing().getUID().getAsString(), interval);
+            ScheduledFuture<?> task = scheduler.schedule(() -> {
+                logger.debug("Timeout has been reached for thingUID={}", handler.getThing().getUID().getAsString());
+                handler.aliveTimeoutReached();
+                scheduledTasks.remove(handler);
+            }, interval, TimeUnit.SECONDS);
+
+            scheduledTasks.put(handler, task);
+        }
+    }
+
+    private void cancelTask(ZigBeeThingHandler handler) {
+        ScheduledFuture<?> task = scheduledTasks.get(handler);
+        if (task != null) {
+            logger.debug("Canceling timeout task for thingUID={}", handler.getThing().getUID().getAsString());
+            task.cancel(true);
+            scheduledTasks.remove(handler);
+        }
+    }
+}

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeHandlerFactory.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeHandlerFactory.java
@@ -20,6 +20,7 @@ import org.eclipse.smarthome.core.thing.type.DynamicStateDescriptionProvider;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeChannelConverterFactory;
 import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
+import org.openhab.binding.zigbee.handler.ZigbeeIsAliveTracker;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -37,6 +38,7 @@ public class ZigBeeHandlerFactory extends BaseThingHandlerFactory {
     private final ZigBeeThingTypeMatcher matcher = new ZigBeeThingTypeMatcher();
 
     private ZigBeeChannelConverterFactory zigbeeChannelConverterFactory;
+    private ZigbeeIsAliveTracker zigbeeIsAliveTracker;
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -54,7 +56,7 @@ public class ZigBeeHandlerFactory extends BaseThingHandlerFactory {
             return null;
         }
 
-        ZigBeeThingHandler handler = new ZigBeeThingHandler(thing, zigbeeChannelConverterFactory);
+        ZigBeeThingHandler handler = new ZigBeeThingHandler(thing, zigbeeChannelConverterFactory, zigbeeIsAliveTracker);
         bundleContext.registerService(ConfigDescriptionProvider.class.getName(), handler,
                 new Hashtable<String, Object>());
         bundleContext.registerService(DynamicStateDescriptionProvider.class.getName(), handler,
@@ -72,4 +74,12 @@ public class ZigBeeHandlerFactory extends BaseThingHandlerFactory {
         this.zigbeeChannelConverterFactory = null;
     }
 
+    @Reference
+    protected void setZigbeeIsAliveTracker(ZigbeeIsAliveTracker zigbeeIsAliveTracker) {
+        this.zigbeeIsAliveTracker = zigbeeIsAliveTracker;
+    }
+
+    protected void unsetZigbeeIsAliveTracker(ZigbeeIsAliveTracker zigbeeIsAliveTracker) {
+        this.zigbeeIsAliveTracker = null;
+    }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
@@ -79,11 +79,8 @@ public class ZigBeeConverterBatteryAlarm extends ZigBeeBaseChannelConverter impl
             if (bindResponse.isSuccess()) {
                 CommandResult reportingResponse = cluster.setReporting(cluster.getAttribute(ATTR_BATTERYALARMSTATE),
                         ALARMSTATE_MIN_REPORTING_INTERVAL, ALARMSTATE_MAX_REPORTING_INTERVAL).get();
-                if (reportingResponse.isError()) {
-                    logger.debug("Could not configure reporting for the battery alarm state; polling every {} seconds",
-                            BATTERY_ALARM_POLLING_PERIOD);
-                    pollingPeriod = BATTERY_ALARM_POLLING_PERIOD;
-                }
+                handleReportingResponse(reportingResponse, BATTERY_ALARM_POLLING_PERIOD,
+                        ALARMSTATE_MAX_REPORTING_INTERVAL);
             } else {
                 pollingPeriod = BATTERY_ALARM_POLLING_PERIOD;
                 logger.debug(

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
@@ -51,7 +51,9 @@ public class ZigBeeConverterBatteryPercent extends ZigBeeBaseChannelConverter im
             CommandResult bindResponse = bind(cluster).get();
             if (bindResponse.isSuccess()) {
                 // Configure reporting - no faster than once per ten minutes - no slower than every 2 hours.
-                cluster.setBatteryPercentageRemainingReporting(600, 7200, 1).get();
+                CommandResult reportingResponse = cluster
+                        .setBatteryPercentageRemainingReporting(600, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
@@ -56,7 +56,9 @@ public class ZigBeeConverterBatteryVoltage extends ZigBeeBaseChannelConverter im
             if (bindResponse.isSuccess()) {
                 ZclAttribute attribute = cluster.getAttribute(ZclPowerConfigurationCluster.ATTR_BATTERYVOLTAGE);
                 // Configure reporting - no faster than once per ten minutes - no slower than every 2 hours.
-                cluster.setReporting(attribute, 600, 7200, 1).get();
+                CommandResult reportingResponse = cluster.setReporting(attribute, 600, REPORTING_PERIOD_DEFAULT_MAX, 1)
+                        .get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
@@ -136,20 +136,21 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
             if (!bindResponse.isSuccess()) {
                 pollingPeriod = POLLING_PERIOD_HIGH;
             }
+            CommandResult reportingResponse;
             if (supportsHue) {
-                CommandResult reportResponse = clusterColorControl
-                        .setCurrentHueReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
-                if (!reportResponse.isSuccess()) {
-                    pollingPeriod = POLLING_PERIOD_HIGH;
-                }
-                reportResponse = clusterColorControl.setCurrentSaturationReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 1)
+                reportingResponse = clusterColorControl.setCurrentHueReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 1)
                         .get();
-                if (!reportResponse.isSuccess()) {
-                    pollingPeriod = POLLING_PERIOD_HIGH;
-                }
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
+
+                reportingResponse = clusterColorControl
+                        .setCurrentSaturationReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
             } else {
-                clusterColorControl.setCurrentXReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
-                clusterColorControl.setCurrentYReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
+                reportingResponse = clusterColorControl.setCurrentXReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
+
+                reportingResponse = clusterColorControl.setCurrentYReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
             }
         } catch (ExecutionException | InterruptedException e) {
             logger.debug("{}: Exception configuring color reporting", endpoint.getIeeeAddress(), e);
@@ -162,11 +163,9 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                 if (!bindResponse.isSuccess()) {
                     pollingPeriod = POLLING_PERIOD_HIGH;
                 }
-                CommandResult reportResponse = clusterLevelControl
+                CommandResult reportingResponse = clusterLevelControl
                         .setCurrentLevelReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
-                if (!reportResponse.isSuccess()) {
-                    pollingPeriod = POLLING_PERIOD_HIGH;
-                }
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
             } catch (ExecutionException | InterruptedException e) {
                 logger.debug("{}: Exception configuring level reporting", endpoint.getIeeeAddress(), e);
             }
@@ -179,17 +178,21 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                 if (!bindResponse.isSuccess()) {
                     pollingPeriod = POLLING_PERIOD_HIGH;
                 }
-                CommandResult reportResponse = clusterOnOff.setOnOffReporting(1, REPORTING_PERIOD_DEFAULT_MAX).get();
-                if (!reportResponse.isSuccess()) {
-                    pollingPeriod = POLLING_PERIOD_HIGH;
-                }
+                CommandResult reportingResponse = clusterOnOff.setOnOffReporting(1, REPORTING_PERIOD_DEFAULT_MAX).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
             } catch (ExecutionException | InterruptedException e) {
                 logger.debug("{}: Exception configuring on/off reporting", endpoint.getIeeeAddress(), e);
             }
         }
 
-        ZclAttribute colorModeAttribute = clusterColorControl.getAttribute(ZclColorControlCluster.ATTR_COLORMODE);
-        clusterColorControl.setReporting(colorModeAttribute, 1, REPORTING_PERIOD_DEFAULT_MAX, 1);
+        try {
+            ZclAttribute colorModeAttribute = clusterColorControl.getAttribute(ZclColorControlCluster.ATTR_COLORMODE);
+            CommandResult reportingResponse = clusterColorControl
+                    .setReporting(colorModeAttribute, 1, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
+            handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
+        } catch (ExecutionException | InterruptedException e) {
+            logger.debug("{}: Exception configuring color mode reporting", endpoint.getIeeeAddress(), e);
+        }
 
         // Create a configuration handler and get the available options
         configLevelControl = new ZclLevelControlConfig();

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterDoorLock.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterDoorLock.java
@@ -50,11 +50,9 @@ public class ZigBeeConverterDoorLock extends ZigBeeBaseChannelConverter implemen
         try {
             CommandResult bindResponse = bind(cluster).get();
             if (bindResponse.isSuccess()) {
-                // Configure reporting - no faster than once per second - no slower than 10 minutes.
+                // Configure reporting - no faster than once per second - no slower than 2 hours.
                 CommandResult reportingResponse = cluster.setDoorStateReporting(1, REPORTING_PERIOD_DEFAULT_MAX).get();
-                if (reportingResponse.isError()) {
-                    pollingPeriod = POLLING_PERIOD_HIGH;
-                }
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
             } else {
                 pollingPeriod = POLLING_PERIOD_HIGH;
             }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
@@ -9,6 +9,7 @@
 package org.openhab.binding.zigbee.internal.converter;
 
 import java.math.BigDecimal;
+import java.util.concurrent.ExecutionException;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -19,6 +20,7 @@ import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.zcl.ZclAttribute;
 import com.zsmartsystems.zigbee.zcl.ZclAttributeListener;
@@ -50,8 +52,14 @@ public class ZigBeeConverterIlluminance extends ZigBeeBaseChannelConverter imple
         // Add a listener, then request the status
         cluster.addAttributeListener(this);
 
-        // Configure reporting - no faster than once per second - no slower than 10 minutes.
-        cluster.setMeasuredValueReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 1);
+        // Configure reporting - no faster than once per second - no slower than 2 hours.
+        try {
+            CommandResult reportingResponse = cluster.setMeasuredValueReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 1)
+                    .get();
+            handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
+        } catch (InterruptedException | ExecutionException e) {
+            logger.debug("{}: Exception configuring meassured value reporting", endpoint.getIeeeAddress(), e);
+        }
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
@@ -59,12 +59,10 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
             if (bindResponse.isSuccess()) {
                 ZclAttribute attribute = clusterMeasurement
                         .getAttribute(ZclElectricalMeasurementCluster.ATTR_ACTIVEPOWER);
-                // Configure reporting - no faster than once per second - no slower than 10 minutes.
+                // Configure reporting - no faster than once per second - no slower than 2 hours.
                 CommandResult reportingResponse = clusterMeasurement
                         .setReporting(attribute, 3, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
-                if (reportingResponse.isError()) {
-                    pollingPeriod = POLLING_PERIOD_HIGH;
-                }
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
             } else {
                 pollingPeriod = POLLING_PERIOD_HIGH;
             }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
@@ -60,12 +60,10 @@ public class ZigBeeConverterMeasurementRmsCurrent extends ZigBeeBaseChannelConve
             if (bindResponse.isSuccess()) {
                 ZclAttribute attribute = clusterMeasurement
                         .getAttribute(ZclElectricalMeasurementCluster.ATTR_RMSCURRENT);
-                // Configure reporting - no faster than once per second - no slower than 10 minutes.
+                // Configure reporting - no faster than once per second - no slower than 2 hours.
                 CommandResult reportingResponse = clusterMeasurement
                         .setReporting(attribute, 3, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
-                if (reportingResponse.isError()) {
-                    pollingPeriod = POLLING_PERIOD_HIGH;
-                }
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
             } else {
                 pollingPeriod = POLLING_PERIOD_HIGH;
             }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
@@ -60,12 +60,10 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
             if (bindResponse.isSuccess()) {
                 ZclAttribute attribute = clusterMeasurement
                         .getAttribute(ZclElectricalMeasurementCluster.ATTR_RMSVOLTAGE);
-                // Configure reporting - no faster than once per second - no slower than 10 minutes.
+                // Configure reporting - no faster than once per second - no slower than 2 hours.
                 CommandResult reportingResponse = clusterMeasurement
                         .setReporting(attribute, 3, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
-                if (reportingResponse.isError()) {
-                    pollingPeriod = POLLING_PERIOD_HIGH;
-                }
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
             } else {
                 pollingPeriod = POLLING_PERIOD_HIGH;
             }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -71,9 +71,7 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
                 // Configure reporting
                 CommandResult reportingResponse = clusterLevelControl
                         .setCurrentLevelReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
-                if (reportingResponse.isError()) {
-                    pollingPeriod = POLLING_PERIOD_HIGH;
-                }
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
             } else {
                 pollingPeriod = POLLING_PERIOD_HIGH;
                 logger.debug("{}: Failed to bind level control cluster", endpoint.getIeeeAddress());
@@ -90,9 +88,7 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
                     // Configure reporting
                     CommandResult reportingResponse = clusterOnOff.setOnOffReporting(1, REPORTING_PERIOD_DEFAULT_MAX)
                             .get();
-                    if (reportingResponse.isError()) {
-                        pollingPeriod = POLLING_PERIOD_HIGH;
-                    }
+                    handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
                 } else {
                     pollingPeriod = POLLING_PERIOD_HIGH;
                 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -67,9 +67,7 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
                     // Configure reporting
                     CommandResult reportingResponse = serverCluster
                             .setOnOffReporting(REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX).get();
-                    if (reportingResponse.isError()) {
-                        pollingPeriod = POLLING_PERIOD_HIGH;
-                    }
+                    handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
                 } else {
                     logger.debug("{}: Error 0x{} setting server binding", endpoint.getIeeeAddress(),
                             Integer.toHexString(bindResponse.getStatusCode()));

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
@@ -55,7 +55,9 @@ public class ZigBeeConverterTemperature extends ZigBeeBaseChannelConverter imple
                 logger.debug("{}: Failed to bind temperature measurement cluster", endpoint.getIeeeAddress());
             } else {
                 // Configure reporting
-                cluster.setMeasuredValueReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 0.1);
+                CommandResult reportingResponse = cluster
+                        .setMeasuredValueReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatLocalTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatLocalTemperature.java
@@ -57,7 +57,10 @@ public class ZigBeeConverterThermostatLocalTemperature extends ZigBeeBaseChannel
                 logger.debug("{}: Failed to bind thermostat cluster", endpoint.getIeeeAddress());
             } else {
                 // Configure reporting
-                cluster.setLocalTemperatureReporting(REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1);
+                CommandResult reportingResponse = cluster
+                        .setLocalTemperatureReporting(REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1)
+                        .get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
@@ -56,7 +56,9 @@ public class ZigBeeConverterThermostatOccupiedCooling extends ZigBeeBaseChannelC
             } else {
                 // Configure reporting
                 ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_OCCUPIEDCOOLINGSETPOINT);
-                cluster.setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1);
+                CommandResult reportingResponse = cluster
+                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedHeating.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedHeating.java
@@ -56,7 +56,9 @@ public class ZigBeeConverterThermostatOccupiedHeating extends ZigBeeBaseChannelC
             } else {
                 // Configure reporting
                 ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_OCCUPIEDHEATINGSETPOINT);
-                cluster.setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1);
+                CommandResult reportingResponse = cluster
+                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
@@ -56,7 +56,9 @@ public class ZigBeeConverterThermostatOutdoorTemperature extends ZigBeeBaseChann
             } else {
                 // Configure reporting
                 ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_OUTDOORTEMPERATURE);
-                cluster.setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1);
+                CommandResult reportingResponse = cluster
+                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
@@ -58,7 +58,9 @@ public class ZigBeeConverterThermostatRunningMode extends ZigBeeBaseChannelConve
             } else {
                 // Configure reporting
                 ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_THERMOSTATRUNNINGMODE);
-                cluster.setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX);
+                CommandResult reportingResponse = cluster
+                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
@@ -53,7 +53,9 @@ public class ZigBeeConverterThermostatSystemMode extends ZigBeeBaseChannelConver
             } else {
                 // Configure reporting
                 ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_SYSTEMMODE);
-                cluster.setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX);
+                CommandResult reportingResponse = cluster
+                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
@@ -56,7 +56,9 @@ public class ZigBeeConverterThermostatUnoccupiedCooling extends ZigBeeBaseChanne
             } else {
                 // Configure reporting
                 ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_UNOCCUPIEDCOOLINGSETPOINT);
-                cluster.setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1);
+                CommandResult reportingResponse = cluster
+                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
@@ -56,7 +56,9 @@ public class ZigBeeConverterThermostatUnoccupiedHeating extends ZigBeeBaseChanne
             } else {
                 // Configure reporting
                 ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_UNOCCUPIEDHEATINGSETPOINT);
-                cluster.setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1);
+                CommandResult reportingResponse = cluster
+                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandlerTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandlerTest.java
@@ -30,7 +30,7 @@ public class ZigBeeThingHandlerTest {
             SecurityException {
         Method privateMethod;
 
-        ZigBeeThingHandler handler = new ZigBeeThingHandler(null, null);
+        ZigBeeThingHandler handler = new ZigBeeThingHandler(null, null, null);
 
         privateMethod = ZigBeeThingHandler.class.getDeclaredMethod("processClusterList", Collection.class,
                 String.class);

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasTamperTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasTamperTest.java
@@ -1,11 +1,11 @@
 package org.openhab.binding.zigbee.internal.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -15,14 +15,16 @@ import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 
+import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.zcl.ZclAttribute;
 import com.zsmartsystems.zigbee.zcl.ZclCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclIasZoneCluster;
 
 /**
  * Unit tests for the {@link ZigBeeConverterIasTamper}.
- * 
+ *
  * @author Tommaso Travaglino - initial contribution
  */
 public class ZigBeeConverterIasTamperTest {
@@ -34,8 +36,9 @@ public class ZigBeeConverterIasTamperTest {
     private ZigBeeEndpoint endpoint;
     private ThingUID thingUID;
 
+    @SuppressWarnings("deprecation")
     @Before
-    public void setup() {
+    public void setup() throws InterruptedException, ExecutionException {
         IeeeAddress ieeeAddress = new IeeeAddress();
         int endpointId = 1;
 
@@ -47,6 +50,13 @@ public class ZigBeeConverterIasTamperTest {
         when(endpoint.getEndpointId()).thenReturn(endpointId);
         when(endpoint.getIeeeAddress()).thenReturn(ieeeAddress);
         when(endpoint.getInputCluster(ZclIasZoneCluster.CLUSTER_ID)).thenReturn(zclCluster);
+
+        @SuppressWarnings("unchecked")
+        Future<CommandResult> reportingFuture = mock(Future.class);
+        when(zclCluster.setReporting(isNull(ZclAttribute.class), anyInt(), anyInt())).thenReturn(reportingFuture);
+
+        CommandResult reportingResult = new CommandResult();
+        when(reportingFuture.get()).thenReturn(reportingResult);
 
         channel = mock(Channel.class);
         thingHandler = mock(ZigBeeThingHandler.class);
@@ -82,6 +92,5 @@ public class ZigBeeConverterIasTamperTest {
         Channel channel = converter.getChannel(thingUID, endpoint);
         assertNull(channel);
     }
-
 
 }


### PR DESCRIPTION
- Introduced a method in the ZigbeeBaseChannelConverter to obtain the minimum
of all configured max reporting intervals.
- Adjusted wrong comments with 10 minutes where code said 2 hours.
- Use pollingPeriod = POLLING_PERIOD_DEFAULT if there was no blocking get()
on the Future before this PR and POLLING_PERIOD_HIGH if it was previously
used in the case that the configuring of the reporting failed.
- Using !CommandResult.isSuccess() instead of sometimes isError() for
all converters.

Relates to #315

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>