### PR TITLE
Store BasicCluster.ApplicationVersion as Thing property

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -203,6 +203,7 @@ public class ZigBeeBindingConstants {
     public static final String ITEM_TYPE_SWITCH = "Switch";
     public static final String ITEM_TYPE_STRING = "String";
 
+    public static final String THING_PROPERTY_APPLICATIONVERSION = "zigbee_applicationVersion";
     public static final String THING_PROPERTY_STKVERSION = "zigbee_stkversion";
     public static final String THING_PROPERTY_ZCLVERSION = "zigbee_zclversion";
     public static final String THING_PROPERTY_DATECODE = "zigbee_datecode";

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeNodePropertyDiscoverer.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeNodePropertyDiscoverer.java
@@ -141,6 +141,15 @@ public class ZigBeeNodePropertyDiscoverer {
             }
         }
 
+        if (alwaysUpdate || properties.get(ZigBeeBindingConstants.THING_PROPERTY_APPLICATIONVERSION) == null) {
+            Integer appVersion = basicCluster.getApplicationVersion(Long.MAX_VALUE);
+            if (appVersion != null) {
+                properties.put(ZigBeeBindingConstants.THING_PROPERTY_APPLICATIONVERSION, appVersion.toString());
+            } else {
+                logger.debug("{}: Application version failed", node.getIeeeAddress());
+            }
+        }
+
         if (alwaysUpdate || properties.get(ZigBeeBindingConstants.THING_PROPERTY_STKVERSION) == null) {
             Integer stkVersion = basicCluster.getStackVersion(Long.MAX_VALUE);
             if (stkVersion != null) {


### PR DESCRIPTION
Currently the `ZigBeeNodePropertyDiscoverer` sets the thing properties as
defined in the `Thing` class:

PROPERTY_VENDOR
PROPERTY_MODEL_ID
PROPERTY_HARDWARE_VERSION

In addition it sets the following properties which are zigbee specific:

THING_PROPERTY_STKVERSION
THING_PROPERTY_ZCLVERSION
THING_PROPERTY_DATECODE

This PR also adds the applicationVersion as a property on the thing.

By definition it holds the "version number of the application software" of
the device and thus might be useful for certain devices.

For example, BitronHome stores their non upgradeable firmware version
(thus no ota cluster available) in this attribute on the 902010/24 smoke
detector.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>