### PR TITLE
Add support for IAS movement and vibration alarms

### DIFF
--- a/org.openhab.binding.zigbee/ESH-INF/thing/channels.xml
+++ b/org.openhab.binding.zigbee/ESH-INF/thing/channels.xml
@@ -136,6 +136,24 @@
         <category>Sensor</category>
         <state readOnly="true" />
     </channel-type>
+    
+    <!-- IAS Movement Sensor Channel -->
+    <channel-type id="ias_movement">
+        <item-type>Switch</item-type>
+        <label>Movement Sensor</label>
+        <description>Movement Sensor Alarm</description>
+        <category>Sensor</category>
+        <state readOnly="true" />
+    </channel-type>
+    
+    <!-- IAS Vibration Sensor Channel -->
+    <channel-type id="ias_vibration">
+        <item-type>Switch</item-type>
+        <label>Vibration Sensor</label>
+        <description>Vibration Sensor Alarm</description>
+        <category>Sensor</category>
+        <state readOnly="true" />
+    </channel-type>
 
     <!-- IAS Tamper Channel -->
     <channel-type id="ias_tamper">

--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -216,6 +216,8 @@ The following channels are supported -:
 | ias_motionpresence | ```IAS_ZONE``` (0x0500) | Switch |  |
 | ias_standard_system | ```IAS_ZONE``` (0x0500) | Switch |  |
 | ias_water | ```IAS_ZONE``` (0x0500) | Switch |  |
+| ias_movement | ```IAS_ZONE``` (0x0500) | Switch |  |
+| ias_vibration | ```IAS_ZONE``` (0x0500) | Switch |  |
 | ias_tamper | ```IAS_ZONE``` (0x0500) | Switch |  |
 | measurement_illuminance | ```ILLUMINANCE_MEASUREMENT``` (0x0400) | Number |   |
 | measurement_pressure | ```PRESSURE_MEASUREMENT``` (0x0403) | Number:Pressure |   |

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -110,6 +110,14 @@ public class ZigBeeBindingConstants {
     public static final String CHANNEL_LABEL_IAS_WATERSENSOR = "Water Alarm";
     public static final ChannelTypeUID CHANNEL_IAS_WATERSENSOR = new ChannelTypeUID("zigbee:ias_water");
 
+    public static final String CHANNEL_NAME_IAS_MOVEMENTSENSOR = "movement";
+    public static final String CHANNEL_LABEL_IAS_MOVEMENTSENSOR = "Movement Alarm";
+    public static final ChannelTypeUID CHANNEL_IAS_MOVEMENTSENSOR = new ChannelTypeUID("zigbee:ias_movement");
+
+    public static final String CHANNEL_NAME_IAS_VIBRATIONSENSOR = "vibration";
+    public static final String CHANNEL_LABEL_IAS_VIBRATIONSENSOR = "Vibration Alarm";
+    public static final ChannelTypeUID CHANNEL_IAS_VIBRATIONSENSOR = new ChannelTypeUID("zigbee:ias_vibration");
+
     public static final String CHANNEL_NAME_IAS_LOWBATTERY = "iaslowbattery";
     public static final String CHANNEL_LABEL_IAS_LOWBATTERY = "Low Battery";
     public static final ChannelTypeUID CHANNEL_IAS_LOWBATTERY = SYSTEM_CHANNEL_LOW_BATTERY.getUID();

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasMovement.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasMovement.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zigbee.internal.converter;
+
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
+import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
+
+/**
+ * Converter for the IAS movement sensor.
+ *
+ * @author Henning Sudbrock - Initial Contribution
+ */
+public class ZigBeeConverterIasMovement extends ZigBeeConverterIas {
+
+    @Override
+    public boolean initializeConverter() {
+        bitTest = CIE_ALARM1;
+        return super.initializeConverter();
+    }
+
+    @Override
+    public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
+        if (!supportsIasChannel(endpoint, ZoneTypeEnum.VIBRATION_MOVEMENT_SENSOR)) {
+            return null;
+        }
+
+        return ChannelBuilder
+                .create(createChannelUID(thingUID, endpoint, ZigBeeBindingConstants.CHANNEL_NAME_IAS_MOVEMENTSENSOR),
+                        ZigBeeBindingConstants.ITEM_TYPE_SWITCH)
+                .withType(ZigBeeBindingConstants.CHANNEL_IAS_MOVEMENTSENSOR)
+                .withLabel(ZigBeeBindingConstants.CHANNEL_LABEL_IAS_MOVEMENTSENSOR)
+                .withProperties(createProperties(endpoint)).build();
+    }
+}

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasVibration.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasVibration.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zigbee.internal.converter;
+
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
+import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
+
+/**
+ * Converter for the IAS vibration sensor.
+ *
+ * @author Henning Sudbrock - Initial Contribution
+ */
+public class ZigBeeConverterIasVibration extends ZigBeeConverterIas {
+
+    @Override
+    public boolean initializeConverter() {
+        bitTest = CIE_ALARM2;
+        return super.initializeConverter();
+    }
+
+    @Override
+    public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
+        if (!supportsIasChannel(endpoint, ZoneTypeEnum.VIBRATION_MOVEMENT_SENSOR)) {
+            return null;
+        }
+
+        return ChannelBuilder
+                .create(createChannelUID(thingUID, endpoint, ZigBeeBindingConstants.CHANNEL_NAME_IAS_VIBRATIONSENSOR),
+                        ZigBeeBindingConstants.ITEM_TYPE_SWITCH)
+                .withType(ZigBeeBindingConstants.CHANNEL_IAS_VIBRATIONSENSOR)
+                .withLabel(ZigBeeBindingConstants.CHANNEL_LABEL_IAS_VIBRATIONSENSOR)
+                .withProperties(createProperties(endpoint)).build();
+    }
+}

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeDefaultChannelConverterProvider.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeDefaultChannelConverterProvider.java
@@ -45,6 +45,8 @@ public final class ZigBeeDefaultChannelConverterProvider implements ZigBeeChanne
         channelMap.put(ZigBeeBindingConstants.CHANNEL_IAS_MOTIONPRESENCE, ZigBeeConverterIasMotionPresence.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_IAS_STANDARDCIESYSTEM, ZigBeeConverterIasCieSystem.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_IAS_WATERSENSOR, ZigBeeConverterIasWaterSensor.class);
+        channelMap.put(ZigBeeBindingConstants.CHANNEL_IAS_MOVEMENTSENSOR, ZigBeeConverterIasMovement.class);
+        channelMap.put(ZigBeeBindingConstants.CHANNEL_IAS_VIBRATIONSENSOR, ZigBeeConverterIasVibration.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_IAS_LOWBATTERY, ZigBeeConverterIasLowBattery.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_IAS_TAMPER, ZigBeeConverterIasTamper.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_ILLUMINANCE_VALUE, ZigBeeConverterIlluminance.class);


### PR DESCRIPTION
This resolves #417 

Here's a screenshot of how an IAS device with zonetype `0x002d` looks like in paper UI with the two new converters (after shaking the device, and, hence, with vibration alarm shown):

![image](https://user-images.githubusercontent.com/5314568/54821410-5706ff00-4ca2-11e9-9be3-7b6ee1579d0f.png)

