### PR TITLE
Add checkstyle configuration to fix the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,52 @@
 	</distributionManagement>
 
     <build>
-        <testSourceDirectory>src/test</testSourceDirectory>
-        
+      <testSourceDirectory>src/test</testSourceDirectory>
+
+      <pluginManagement>
         <plugins>
+	  
+          <plugin>
+            <groupId>org.commonjava.maven.plugins</groupId>
+            <artifactId>directory-maven-plugin</artifactId>
+            <version>0.3.1</version>
+            <executions>
+              <execution>
+                <id>zigbee-binding-dir</id>
+                <goals>
+                  <goal>directory-of</goal>
+                </goals>
+                <phase>initialize</phase>
+                <configuration>
+                  <property>zigbeeBindingRoot</property>
+                  <project>
+                    <groupId>org.openhab.binding</groupId>
+                    <artifactId>org.openhab.binding.zigbee.pom</artifactId>
+                  </project>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.openhab.tools.sat</groupId>
+            <artifactId>sat-plugin</artifactId>
+            <version>{sat.version}</version>
+            <configuration>
+              <checkstyleProperties>${zigbeeBindingRoot}/static-code-analysis/checkstyle/ruleset.properties</checkstyleProperties>
+              <checkstyleFilter>${zigbeeBindingRoot}/static-code-analysis/checkstyle/suppressions.xml</checkstyleFilter>
+            </configuration>
+          </plugin>
+	  
+        </plugins>
+      </pluginManagement>
+        
+      <plugins>
+            <plugin>
+                <groupId>org.commonjava.maven.plugins</groupId>
+                <artifactId>directory-maven-plugin</artifactId>
+            </plugin>
+	
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/static-code-analysis/checkstyle/ruleset.properties
+++ b/static-code-analysis/checkstyle/ruleset.properties
@@ -1,0 +1,6 @@
+checkstyle.headerCheck.content=^/\\*\\*$\\n^ \\* Copyright \\(c\\) {0}-{1} by the respective copyright holders.$\\n^ \\*$\\n^ \\* All rights reserved. This program and the accompanying materials$\\n^ \\* are made available under the terms of the Eclipse Public License v1\\.0$\\n^ \\* which accompanies this distribution, and is available at$\\n^ \\* http://www.eclipse.org/legal/epl\\-v10\\.html$
+checkstyle.headerCheck.values=2010,2019
+checkstyle.pomXmlCheck.currentVersionRegex=^2\.5\.0
+checkstyle.forbiddenPackageUsageCheck.forbiddenPackages=com.google.common
+checkstyle.forbiddenPackageUsageCheck.exceptions=
+checkstyle.requiredFilesCheck.files=pom.xml

--- a/static-code-analysis/checkstyle/suppressions.xml
+++ b/static-code-analysis/checkstyle/suppressions.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN" "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+<suppressions>
+    <suppress files=".classpath" checks="MavenPomderivedInClasspathCheck" />
+    <!-- These suppressions define which files to be suppressed for which checks. -->
+    <suppress files=".+[\\/]internal[\\/].+\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck|NullAnnotationsCheck"/>
+    <suppress files=".+DTO\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck" />
+    <suppress files=".+Impl\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck"/>
+
+    <!-- Some checks will be supressed for test bundles -->
+    <suppress files=".+.test[\\/].+" checks="RequireBundleCheck"/>
+
+    <suppress files=".+[\\/]pom\.xml" checks="OnlyTabIndentationCheck|OnlyTabIndentationInXmlFilesCheck"/>
+</suppressions>


### PR DESCRIPTION
This resolves #420.

As in the `openhab-addons2` project, I use the [`directory-maven-plugin`](https://github.com/openhab/openhab2-addons/blob/54eaec83e34604321075554c5bd6f7b2981cc227/poms/tycho/pom.xml#L132) to capture the directory with the checkstyle configuration.

The checkstyle configuration is like for the Z-Wave binding (see https://github.com/openhab/org.openhab.binding.zwave/pull/1158, but with the check for the copyright header adapted to match https://github.com/openhab/org.openhab.binding.zigbee/blob/master/src/etc/header.txt.

Maybe the checkstyle configuration could be tailored more towards the specifics of the ZigBee binding, but I leave this for other PRs.