### PR TITLE
Refactor ZigBeeConverterAtmosphericPressure

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
@@ -190,11 +190,11 @@ public abstract class ZigBeeBaseChannelConverter {
      * Configures the device. This method should perform the one off device configuration such as performing the bind
      * and reporting configuration.
      * <p>
-     * The binding should initialise reporting using one of the {@link ZclCluster#setReporting} commands. If this fails,
+     * The binding should initialize reporting using one of the {@link ZclCluster#setReporting} commands. If this fails,
      * the {@link #pollingPeriod} variable should be set to {@link #POLLING_PERIOD_HIGH}.
      * <p>
-     * Note that this method should be self contained, and may not make any assumptions about the initialisation of any
-     * internal fields of the converter other than those initialised in the {@link #initialize} method.
+     * Note that this method should be self contained, and may not make any assumptions about the initialization of any
+     * internal fields of the converter other than those initialized in the {@link #initialize} method.
      *
      * @return true if the device was configured correctly
      */

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
@@ -52,40 +52,56 @@ public class ZigBeeConverterAtmosphericPressure extends ZigBeeBaseChannelConvert
     private Integer enhancedScale = null;
 
     @Override
-    public synchronized boolean initializeConverter() {
+    public boolean initializeDevice() {
+        ZclPressureMeasurementCluster serverCluster = (ZclPressureMeasurementCluster) endpoint
+                .getInputCluster(ZclPressureMeasurementCluster.CLUSTER_ID);
+        if (serverCluster == null) {
+            logger.error("{}: Error opening device pressure measurement cluster", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        // Check if the enhanced attributes are supported
+        if (serverCluster.getScaledValue(Long.MAX_VALUE) != null) {
+            enhancedScale = serverCluster.getScale(Long.MAX_VALUE);
+            if (enhancedScale != null) {
+                enhancedScale *= -1;
+            }
+        }
+
+        try {
+            CommandResult bindResponse = bind(serverCluster).get();
+            if (bindResponse.isSuccess()) {
+                // Configure reporting - no faster than once per second - no slower than 2 hours.
+                CommandResult reportingResponse;
+                if (enhancedScale != null) {
+                    reportingResponse = serverCluster.setScaledValueReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 0.1)
+                            .get();
+                    handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
+                } else {
+                    reportingResponse = serverCluster.setMeasuredValueReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 0.1)
+                            .get();
+                    handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
+                }
+            } else {
+                logger.error("{}: Error 0x{} setting server binding", endpoint.getIeeeAddress(),
+                        Integer.toHexString(bindResponse.getStatusCode()));
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean initializeConverter() {
         cluster = (ZclPressureMeasurementCluster) endpoint.getInputCluster(ZclPressureMeasurementCluster.CLUSTER_ID);
         if (cluster == null) {
             logger.error("{}: Error opening device pressure measurement cluster", endpoint.getIeeeAddress());
             return false;
         }
 
-        // Check if the enhanced attributes are supported
-        if (cluster.getScaledValue(Long.MAX_VALUE) != null) {
-            enhancedScale = cluster.getScale(Long.MAX_VALUE);
-            if (enhancedScale != null) {
-                enhancedScale *= -1;
-            }
-        }
-
-        bind(cluster);
-
-        // Add a listener, then request the status
+        // Add a listener
         cluster.addAttributeListener(this);
-
-        // Configure reporting - no faster than once per second - no slower than 2 hours.
-        try {
-            CommandResult reportingResponse;
-            if (enhancedScale != null) {
-                reportingResponse = cluster.setScaledValueReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
-                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
-            } else {
-                reportingResponse = cluster.setMeasuredValueReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
-                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
-        }
-
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
@@ -85,6 +85,8 @@ public class ZigBeeConverterAtmosphericPressure extends ZigBeeBaseChannelConvert
             } else {
                 logger.error("{}: Error 0x{} setting server binding", endpoint.getIeeeAddress(),
                         Integer.toHexString(bindResponse.getStatusCode()));
+                pollingPeriod = POLLING_PERIOD_HIGH;
+                return false;
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);


### PR DESCRIPTION
Refactor ZigBeeConverterAtmosphericPressure to split the device and channel initialization
Initialization logic split in two methods similar `ZigBeeConverterSwitchOnoff` refactor done in [this commit](https://github.com/openhab/org.openhab.binding.zigbee/commit/45f74b9c7e7a7e5a59bb68c536f4a3ed64535bb5)
Signed-off-by: YordanDZhelev <zhelev.yordan@gmail.com>