### PR TITLE
Refactor ZigBee binding channel converters

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
@@ -90,6 +90,8 @@ public class ZigBeeConverterAtmosphericPressure extends ZigBeeBaseChannelConvert
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            pollingPeriod = POLLING_PERIOD_HIGH;
+            return false;
         }
         return true;
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
@@ -89,6 +89,7 @@ public class ZigBeeConverterBatteryAlarm extends ZigBeeBaseChannelConverter impl
                 logger.debug(
                         "Could not bind to the power configuration cluster; polling battery alarm state every {} seconds",
                         BATTERY_ALARM_POLLING_PERIOD);
+                return false;
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting of battery alarm state ", endpoint.getIeeeAddress(), e);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
@@ -65,20 +65,23 @@ public class ZigBeeConverterBatteryAlarm extends ZigBeeBaseChannelConverter impl
     private ZclPowerConfigurationCluster cluster;
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeDevice() {
         logger.debug("{}: Initialising device battery alarm converter", endpoint.getIeeeAddress());
 
-        cluster = (ZclPowerConfigurationCluster) endpoint.getInputCluster(ZclPowerConfigurationCluster.CLUSTER_ID);
-        if (cluster == null) {
+        ZclPowerConfigurationCluster serverCluster = (ZclPowerConfigurationCluster) endpoint
+                .getInputCluster(ZclPowerConfigurationCluster.CLUSTER_ID);
+        if (serverCluster == null) {
             logger.error("{}: Error opening power configuration cluster", endpoint.getIeeeAddress());
             return false;
         }
 
         try {
-            CommandResult bindResponse = bind(cluster).get();
+            CommandResult bindResponse = bind(serverCluster).get();
             if (bindResponse.isSuccess()) {
-                CommandResult reportingResponse = cluster.setReporting(cluster.getAttribute(ATTR_BATTERYALARMSTATE),
-                        ALARMSTATE_MIN_REPORTING_INTERVAL, ALARMSTATE_MAX_REPORTING_INTERVAL).get();
+                CommandResult reportingResponse = serverCluster
+                        .setReporting(serverCluster.getAttribute(ATTR_BATTERYALARMSTATE),
+                                ALARMSTATE_MIN_REPORTING_INTERVAL, ALARMSTATE_MAX_REPORTING_INTERVAL)
+                        .get();
                 handleReportingResponse(reportingResponse, BATTERY_ALARM_POLLING_PERIOD,
                         ALARMSTATE_MAX_REPORTING_INTERVAL);
             } else {
@@ -91,7 +94,18 @@ public class ZigBeeConverterBatteryAlarm extends ZigBeeBaseChannelConverter impl
             logger.error("{}: Exception setting reporting of battery alarm state ", endpoint.getIeeeAddress(), e);
             return false;
         }
+        return true;
+    }
 
+    @Override
+    public boolean initializeConverter() {
+        cluster = (ZclPowerConfigurationCluster) endpoint.getInputCluster(ZclPowerConfigurationCluster.CLUSTER_ID);
+        if (cluster == null) {
+            logger.error("{}: Error opening power configuration cluster", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        // Add a listener
         cluster.addAttributeListener(this);
         return true;
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
@@ -38,30 +38,43 @@ public class ZigBeeConverterBatteryPercent extends ZigBeeBaseChannelConverter im
     private ZclPowerConfigurationCluster cluster;
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeDevice() {
         logger.debug("{}: Initialising device battery percent converter", endpoint.getIeeeAddress());
 
+        ZclPowerConfigurationCluster serverCluster = (ZclPowerConfigurationCluster) endpoint
+                .getInputCluster(ZclPowerConfigurationCluster.CLUSTER_ID);
+        if (serverCluster == null) {
+            logger.error("{}: Error opening power configuration cluster", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        try {
+            CommandResult bindResponse = bind(serverCluster).get();
+            if (bindResponse.isSuccess()) {
+                // Configure reporting - no faster than once per ten minutes - no slower than every 2 hours.
+                CommandResult reportingResponse = serverCluster
+                        .setBatteryPercentageRemainingReporting(600, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
+            } else {
+                logger.error("{}: Error 0x{} setting server binding", endpoint.getIeeeAddress(),
+                        Integer.toHexString(bindResponse.getStatusCode()));
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean initializeConverter() {
         cluster = (ZclPowerConfigurationCluster) endpoint.getInputCluster(ZclPowerConfigurationCluster.CLUSTER_ID);
         if (cluster == null) {
             logger.error("{}: Error opening power configuration cluster", endpoint.getIeeeAddress());
             return false;
         }
 
-        try {
-            CommandResult bindResponse = bind(cluster).get();
-            if (bindResponse.isSuccess()) {
-                // Configure reporting - no faster than once per ten minutes - no slower than every 2 hours.
-                CommandResult reportingResponse = cluster
-                        .setBatteryPercentageRemainingReporting(600, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
-                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
-        }
-
         // Add a listener, then request the status
         cluster.addAttributeListener(this);
-
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
@@ -61,6 +61,7 @@ public class ZigBeeConverterBatteryPercent extends ZigBeeBaseChannelConverter im
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            return false;
         }
         return true;
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
@@ -63,6 +63,7 @@ public class ZigBeeConverterBatteryVoltage extends ZigBeeBaseChannelConverter im
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            return false;
         }
         return true;
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
@@ -99,6 +99,7 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
         } catch (InterruptedException | ExecutionException e) {
             logger.debug("{}: Exception configuring color temperature or color mode reporting",
                     endpoint.getIeeeAddress(), e);
+            return false;
         }
         return true;
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterDoorLock.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterDoorLock.java
@@ -59,8 +59,8 @@ public class ZigBeeConverterDoorLock extends ZigBeeBaseChannelConverter implemen
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            return false;
         }
-
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
@@ -78,6 +78,7 @@ public abstract class ZigBeeConverterIas extends ZigBeeBaseChannelConverter
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.debug("{}: Exception configuring ias zone status reporting", endpoint.getIeeeAddress(), e);
+            return false;
         }
         return true;
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
@@ -56,6 +56,33 @@ public abstract class ZigBeeConverterIas extends ZigBeeBaseChannelConverter
     protected static final int CIE_BATTERYDEFECT = 0x0200;
 
     @Override
+    public boolean initializeDevice() {
+        logger.debug("{}: Initialising device IAS Zone cluster for {}", endpoint.getIeeeAddress(),
+                channel.getChannelTypeUID());
+
+        ZclIasZoneCluster serverClusterIasZone = (ZclIasZoneCluster) endpoint
+                .getInputCluster(ZclIasZoneCluster.CLUSTER_ID);
+        if (serverClusterIasZone == null) {
+            logger.error("{}: Error opening IAS zone cluster", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        try {
+            CommandResult bindResponse = bind(serverClusterIasZone).get();
+            if (bindResponse.isSuccess()) {
+                // Configure reporting - no faster than once per second - no slower than 2 hours.
+                ZclAttribute attribute = serverClusterIasZone.getAttribute(ZclIasZoneCluster.ATTR_ZONESTATUS);
+                CommandResult reportingResponse = serverClusterIasZone
+                        .setReporting(attribute, 3, REPORTING_PERIOD_DEFAULT_MAX).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.debug("{}: Exception configuring ias zone status reporting", endpoint.getIeeeAddress(), e);
+        }
+        return true;
+    }
+
+    @Override
     public boolean initializeConverter() {
         logger.debug("{}: Initialising device IAS Zone cluster for {}", endpoint.getIeeeAddress(),
                 channel.getChannelTypeUID());
@@ -65,22 +92,10 @@ public abstract class ZigBeeConverterIas extends ZigBeeBaseChannelConverter
             logger.error("{}: Error opening IAS zone cluster", endpoint.getIeeeAddress());
             return false;
         }
-
-        bind(clusterIasZone);
-
         // Add a listener, then request the status
         clusterIasZone.addCommandListener(this);
         clusterIasZone.addAttributeListener(this);
 
-        // Configure reporting - no faster than once per second - no slower than 2 hours.
-        ZclAttribute attribute = clusterIasZone.getAttribute(ZclIasZoneCluster.ATTR_ZONESTATUS);
-        try {
-            CommandResult reportingResponse = clusterIasZone.setReporting(attribute, 3, REPORTING_PERIOD_DEFAULT_MAX)
-                    .get();
-            handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
-        } catch (InterruptedException | ExecutionException e) {
-            logger.debug("{}: Exception configuring ias zone status reporting", endpoint.getIeeeAddress(), e);
-        }
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
@@ -57,6 +57,7 @@ public class ZigBeeConverterIlluminance extends ZigBeeBaseChannelConverter imple
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.debug("{}: Exception configuring meassured value reporting", endpoint.getIeeeAddress(), e);
+            return false;
         }
         return true;
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
@@ -44,23 +44,23 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
     private Integer multiplier;
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeDevice() {
         logger.debug("{}: Initialising electrical measurement cluster", endpoint.getIeeeAddress());
 
-        clusterMeasurement = (ZclElectricalMeasurementCluster) endpoint
+        ZclElectricalMeasurementCluster serverClusterMeasurement = (ZclElectricalMeasurementCluster) endpoint
                 .getInputCluster(ZclElectricalMeasurementCluster.CLUSTER_ID);
-        if (clusterMeasurement == null) {
+        if (serverClusterMeasurement == null) {
             logger.error("{}: Error opening electrical measurement cluster", endpoint.getIeeeAddress());
             return false;
         }
 
         try {
-            CommandResult bindResponse = bind(clusterMeasurement).get();
+            CommandResult bindResponse = bind(serverClusterMeasurement).get();
             if (bindResponse.isSuccess()) {
-                ZclAttribute attribute = clusterMeasurement
+                ZclAttribute attribute = serverClusterMeasurement
                         .getAttribute(ZclElectricalMeasurementCluster.ATTR_ACTIVEPOWER);
                 // Configure reporting - no faster than once per second - no slower than 2 hours.
-                CommandResult reportingResponse = clusterMeasurement
+                CommandResult reportingResponse = serverClusterMeasurement
                         .setReporting(attribute, 3, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
                 handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
             } else {
@@ -70,16 +70,26 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
         }
 
-        divisor = clusterMeasurement.getAcPowerDivisor(Long.MAX_VALUE);
-        multiplier = clusterMeasurement.getAcPowerMultiplier(Long.MAX_VALUE);
+        divisor = serverClusterMeasurement.getAcPowerDivisor(Long.MAX_VALUE);
+        multiplier = serverClusterMeasurement.getAcPowerMultiplier(Long.MAX_VALUE);
         if (divisor == null || multiplier == null) {
             divisor = 1;
             multiplier = 1;
         }
+        return true;
+    }
+
+    @Override
+    public boolean initializeConverter() {
+        clusterMeasurement = (ZclElectricalMeasurementCluster) endpoint
+                .getInputCluster(ZclElectricalMeasurementCluster.CLUSTER_ID);
+        if (clusterMeasurement == null) {
+            logger.error("{}: Error opening electrical measurement cluster", endpoint.getIeeeAddress());
+            return false;
+        }
 
         // Add a listener, then request the status
         clusterMeasurement.addAttributeListener(this);
-
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
@@ -68,6 +68,7 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            return false;
         }
 
         divisor = serverClusterMeasurement.getAcPowerDivisor(Long.MAX_VALUE);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
@@ -69,6 +69,7 @@ public class ZigBeeConverterMeasurementRmsCurrent extends ZigBeeBaseChannelConve
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            return false;
         }
 
         divisor = serviceClusterMeasurement.getAcCurrentDivisor(Long.MAX_VALUE);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
@@ -45,23 +45,23 @@ public class ZigBeeConverterMeasurementRmsCurrent extends ZigBeeBaseChannelConve
     private Integer multiplier;
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeDevice() {
         logger.debug("{}: Initialising electrical measurement cluster", endpoint.getIeeeAddress());
 
-        clusterMeasurement = (ZclElectricalMeasurementCluster) endpoint
+        ZclElectricalMeasurementCluster serviceClusterMeasurement = (ZclElectricalMeasurementCluster) endpoint
                 .getInputCluster(ZclElectricalMeasurementCluster.CLUSTER_ID);
-        if (clusterMeasurement == null) {
+        if (serviceClusterMeasurement == null) {
             logger.error("{}: Error opening electrical measurement cluster", endpoint.getIeeeAddress());
             return false;
         }
 
         try {
-            CommandResult bindResponse = bind(clusterMeasurement).get();
+            CommandResult bindResponse = bind(serviceClusterMeasurement).get();
             if (bindResponse.isSuccess()) {
-                ZclAttribute attribute = clusterMeasurement
+                ZclAttribute attribute = serviceClusterMeasurement
                         .getAttribute(ZclElectricalMeasurementCluster.ATTR_RMSCURRENT);
                 // Configure reporting - no faster than once per second - no slower than 2 hours.
-                CommandResult reportingResponse = clusterMeasurement
+                CommandResult reportingResponse = serviceClusterMeasurement
                         .setReporting(attribute, 3, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
                 handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
             } else {
@@ -71,16 +71,26 @@ public class ZigBeeConverterMeasurementRmsCurrent extends ZigBeeBaseChannelConve
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
         }
 
-        divisor = clusterMeasurement.getAcCurrentDivisor(Long.MAX_VALUE);
-        multiplier = clusterMeasurement.getAcCurrentMultiplier(Long.MAX_VALUE);
+        divisor = serviceClusterMeasurement.getAcCurrentDivisor(Long.MAX_VALUE);
+        multiplier = serviceClusterMeasurement.getAcCurrentMultiplier(Long.MAX_VALUE);
         if (divisor == null || multiplier == null) {
             divisor = 1;
             multiplier = 1;
         }
+        return true;
+    }
+
+    @Override
+    public boolean initializeConverter() {
+        clusterMeasurement = (ZclElectricalMeasurementCluster) endpoint
+                .getInputCluster(ZclElectricalMeasurementCluster.CLUSTER_ID);
+        if (clusterMeasurement == null) {
+            logger.error("{}: Error opening electrical measurement cluster", endpoint.getIeeeAddress());
+            return false;
+        }
 
         // Add a listener
         clusterMeasurement.addAttributeListener(this);
-
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
@@ -69,6 +69,7 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            return false;
         }
 
         divisor = serverClusterMeasurement.getAcVoltageDivisor(Long.MAX_VALUE);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
@@ -38,28 +38,40 @@ public class ZigBeeConverterOccupancy extends ZigBeeBaseChannelConverter impleme
     private ZclOccupancySensingCluster clusterOccupancy;
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeDevice() {
         logger.debug("{}: Initialising device occupancy cluster", endpoint.getIeeeAddress());
 
+        ZclOccupancySensingCluster serverClusterOccupancy = (ZclOccupancySensingCluster) endpoint
+                .getInputCluster(ZclOccupancySensingCluster.CLUSTER_ID);
+        if (serverClusterOccupancy == null) {
+            logger.error("{}: Error opening occupancy cluster", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        try {
+            CommandResult bindResponse = bind(serverClusterOccupancy).get();
+            if (bindResponse.isSuccess()) {
+                // Configure reporting - no faster than once per second - no slower than 2 hours.
+                CommandResult reportingResponse = serverClusterOccupancy
+                        .setOccupancyReporting(1, REPORTING_PERIOD_DEFAULT_MAX).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean initializeConverter() {
         clusterOccupancy = (ZclOccupancySensingCluster) endpoint.getInputCluster(ZclOccupancySensingCluster.CLUSTER_ID);
         if (clusterOccupancy == null) {
             logger.error("{}: Error opening occupancy cluster", endpoint.getIeeeAddress());
             return false;
         }
 
-        bind(clusterOccupancy);
-
         // Add a listener, then request the status
         clusterOccupancy.addAttributeListener(this);
-
-        // Configure reporting - no faster than once per second - no slower than 2 hours.
-        try {
-            CommandResult reportingResponse = clusterOccupancy.setOccupancyReporting(1, REPORTING_PERIOD_DEFAULT_MAX)
-                    .get();
-            handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
-        } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
-        }
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
@@ -58,6 +58,7 @@ public class ZigBeeConverterOccupancy extends ZigBeeBaseChannelConverter impleme
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            return false;
         }
         return true;
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
@@ -58,6 +58,7 @@ public class ZigBeeConverterRelativeHumidity extends ZigBeeBaseChannelConverter 
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
             pollingPeriod = POLLING_PERIOD_HIGH;
+            return false;
         }
         return true;
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
@@ -39,6 +39,30 @@ public class ZigBeeConverterRelativeHumidity extends ZigBeeBaseChannelConverter 
     private ZclRelativeHumidityMeasurementCluster cluster;
 
     @Override
+    public boolean initializeDevice() {
+        ZclRelativeHumidityMeasurementCluster serverCluster = (ZclRelativeHumidityMeasurementCluster) endpoint
+                .getInputCluster(ZclRelativeHumidityMeasurementCluster.CLUSTER_ID);
+        if (serverCluster == null) {
+            logger.error("{}: Error opening device relative humidity measurement cluster", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        try {
+            CommandResult bindResponse = bind(serverCluster).get();
+            if (bindResponse.isSuccess()) {
+                // Configure reporting - no faster than once per second - no slower than 2 hours.
+                CommandResult response = serverCluster.setMeasuredValueReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 0.1)
+                        .get();
+                handleReportingResponse(response, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            pollingPeriod = POLLING_PERIOD_HIGH;
+        }
+        return true;
+    }
+
+    @Override
     public boolean initializeConverter() {
         cluster = (ZclRelativeHumidityMeasurementCluster) endpoint
                 .getInputCluster(ZclRelativeHumidityMeasurementCluster.CLUSTER_ID);
@@ -47,19 +71,8 @@ public class ZigBeeConverterRelativeHumidity extends ZigBeeBaseChannelConverter 
             return false;
         }
 
-        bind(cluster);
-
         // Add a listener, then request the status
         cluster.addAttributeListener(this);
-
-        // Configure reporting - no faster than once per second - no slower than 2 hours.
-        try {
-            CommandResult response = cluster.setMeasuredValueReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
-            handleReportingResponse(response, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
-        } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
-            pollingPeriod = POLLING_PERIOD_HIGH;
-        }
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -85,6 +85,7 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error(String.format("%s: Exception setting level control reporting ", endpoint.getIeeeAddress()), e);
+            return false;
         }
 
         try {
@@ -96,9 +97,12 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
                 handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
             } else {
                 pollingPeriod = POLLING_PERIOD_HIGH;
+                logger.debug("{}: Failed to bind on off control cluster", endpoint.getIeeeAddress());
+                return false;
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error(String.format("%s: Exception setting on off reporting ", endpoint.getIeeeAddress()), e);
+            return false;
         }
 
         // Set the currentOnOffState to ON. This will ensure that we only ignore levelControl reports AFTER we have

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -58,18 +58,25 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
     private PercentType lastLevel = PercentType.HUNDRED;
 
     @Override
-    public synchronized boolean initializeConverter() {
-        clusterLevelControl = (ZclLevelControlCluster) endpoint.getInputCluster(ZclLevelControlCluster.CLUSTER_ID);
-        if (clusterLevelControl == null) {
+    public boolean initializeDevice() {
+        ZclLevelControlCluster serverClusterLevelControl = (ZclLevelControlCluster) endpoint
+                .getInputCluster(ZclLevelControlCluster.CLUSTER_ID);
+        if (serverClusterLevelControl == null) {
+            logger.error("{}: Error opening device level controls", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        ZclOnOffCluster serverClusterOnOff = (ZclOnOffCluster) endpoint.getInputCluster(ZclOnOffCluster.CLUSTER_ID);
+        if (serverClusterOnOff == null) {
             logger.error("{}: Error opening device level controls", endpoint.getIeeeAddress());
             return false;
         }
 
         try {
-            CommandResult bindResponse = bind(clusterLevelControl).get();
+            CommandResult bindResponse = bind(serverClusterLevelControl).get();
             if (bindResponse.isSuccess()) {
                 // Configure reporting
-                CommandResult reportingResponse = clusterLevelControl
+                CommandResult reportingResponse = serverClusterLevelControl
                         .setCurrentLevelReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
                 handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
             } else {
@@ -80,42 +87,53 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
             logger.error(String.format("%s: Exception setting level control reporting ", endpoint.getIeeeAddress()), e);
         }
 
-        clusterOnOff = (ZclOnOffCluster) endpoint.getInputCluster(ZclOnOffCluster.CLUSTER_ID);
-        if (clusterOnOff != null) {
-            try {
-                CommandResult bindResponse = bind(clusterOnOff).get();
-                if (bindResponse.isSuccess()) {
-                    // Configure reporting
-                    CommandResult reportingResponse = clusterOnOff.setOnOffReporting(1, REPORTING_PERIOD_DEFAULT_MAX)
-                            .get();
-                    handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
-                } else {
-                    pollingPeriod = POLLING_PERIOD_HIGH;
-                }
-            } catch (InterruptedException | ExecutionException e) {
-                logger.error(String.format("%s: Exception setting on off reporting ", endpoint.getIeeeAddress()), e);
+        try {
+            CommandResult bindResponse = bind(serverClusterOnOff).get();
+            if (bindResponse.isSuccess()) {
+                // Configure reporting
+                CommandResult reportingResponse = serverClusterOnOff.setOnOffReporting(1, REPORTING_PERIOD_DEFAULT_MAX)
+                        .get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
+            } else {
+                pollingPeriod = POLLING_PERIOD_HIGH;
             }
-
-            // Set the currentOnOffState to ON. This will ensure that we only ignore levelControl reports AFTER we have
-            // really received an OFF report, thus confirming ON_OFF reporting is working
-            currentOnOffState.set(true);
-
-            // Add a listener
-            clusterOnOff.addAttributeListener(this);
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error(String.format("%s: Exception setting on off reporting ", endpoint.getIeeeAddress()), e);
         }
 
-        // Add a listener
-        clusterLevelControl.addAttributeListener(this);
+        // Set the currentOnOffState to ON. This will ensure that we only ignore levelControl reports AFTER we have
+        // really received an OFF report, thus confirming ON_OFF reporting is working
+        currentOnOffState.set(true);
 
         // Create a configuration handler and get the available options
         configReporting = new ZclReportingConfig();
         configLevelControl = new ZclLevelControlConfig();
-        configLevelControl.initialize(clusterLevelControl);
+        configLevelControl.initialize(serverClusterLevelControl);
 
         configOptions = new ArrayList<>();
         configOptions.addAll(configReporting.getConfiguration());
         configOptions.addAll(configLevelControl.getConfiguration());
 
+        return true;
+    }
+
+    @Override
+    public synchronized boolean initializeConverter() {
+        clusterLevelControl = (ZclLevelControlCluster) endpoint.getInputCluster(ZclLevelControlCluster.CLUSTER_ID);
+        if (clusterLevelControl == null) {
+            logger.error("{}: Error opening device level controls", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        clusterOnOff = (ZclOnOffCluster) endpoint.getInputCluster(ZclOnOffCluster.CLUSTER_ID);
+        if (clusterOnOff == null) {
+            logger.error("{}: Error opening device level controls", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        // Add a listeners
+        clusterOnOff.addAttributeListener(this);
+        clusterLevelControl.addAttributeListener(this);
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
@@ -40,6 +40,32 @@ public class ZigBeeConverterTemperature extends ZigBeeBaseChannelConverter imple
     private ZclTemperatureMeasurementCluster cluster;
 
     @Override
+    public boolean initializeDevice() {
+        ZclTemperatureMeasurementCluster serverCluster = (ZclTemperatureMeasurementCluster) endpoint
+                .getInputCluster(ZclTemperatureMeasurementCluster.CLUSTER_ID);
+        if (serverCluster == null) {
+            logger.error("{}: Error opening device temperature measurement cluster", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        try {
+            CommandResult bindResponse = bind(serverCluster).get();
+            if (bindResponse.isSuccess()) {
+                // Configure reporting
+                CommandResult reportingResponse = serverCluster
+                        .setMeasuredValueReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
+            } else {
+                logger.debug("{}: Failed to bind temperature measurement cluster", endpoint.getIeeeAddress());
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+        }
+
+        return true;
+    }
+
+    @Override
     public boolean initializeConverter() {
         cluster = (ZclTemperatureMeasurementCluster) endpoint
                 .getInputCluster(ZclTemperatureMeasurementCluster.CLUSTER_ID);
@@ -48,24 +74,8 @@ public class ZigBeeConverterTemperature extends ZigBeeBaseChannelConverter imple
             return false;
         }
 
-        CommandResult bindResponse;
-        try {
-            bindResponse = bind(cluster).get();
-            if (!bindResponse.isSuccess()) {
-                logger.debug("{}: Failed to bind temperature measurement cluster", endpoint.getIeeeAddress());
-            } else {
-                // Configure reporting
-                CommandResult reportingResponse = cluster
-                        .setMeasuredValueReporting(1, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
-                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
-        }
-
         // Add a listener, then request the status
         cluster.addAttributeListener(this);
-
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
@@ -60,6 +60,7 @@ public class ZigBeeConverterTemperature extends ZigBeeBaseChannelConverter imple
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            return false;
         }
 
         return true;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatLocalTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatLocalTemperature.java
@@ -64,6 +64,7 @@ public class ZigBeeConverterThermostatLocalTemperature extends ZigBeeBaseChannel
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            return false;
         }
 
         return true;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
@@ -62,6 +62,7 @@ public class ZigBeeConverterThermostatOccupiedCooling extends ZigBeeBaseChannelC
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+            return false;
         }
 
         return true;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedHeating.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedHeating.java
@@ -41,6 +41,32 @@ public class ZigBeeConverterThermostatOccupiedHeating extends ZigBeeBaseChannelC
     private ZclThermostatCluster cluster;
 
     @Override
+    public boolean initializeDevice() {
+        ZclThermostatCluster serverCluster = (ZclThermostatCluster) endpoint
+                .getInputCluster(ZclThermostatCluster.CLUSTER_ID);
+        if (serverCluster == null) {
+            logger.error("{}: Error opening device thermostat cluster", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        try {
+            CommandResult bindResponse = bind(serverCluster).get();
+            if (bindResponse.isSuccess()) {
+                // Configure reporting
+                ZclAttribute attribute = serverCluster.getAttribute(ZclThermostatCluster.ATTR_OCCUPIEDHEATINGSETPOINT);
+                CommandResult reportingResponse = serverCluster
+                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
+            } else {
+                logger.debug("{}: Failed to bind thermostat cluster", endpoint.getIeeeAddress());
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+        }
+        return true;
+    }
+
+    @Override
     public boolean initializeConverter() {
         cluster = (ZclThermostatCluster) endpoint.getInputCluster(ZclThermostatCluster.CLUSTER_ID);
         if (cluster == null) {
@@ -48,25 +74,8 @@ public class ZigBeeConverterThermostatOccupiedHeating extends ZigBeeBaseChannelC
             return false;
         }
 
-        CommandResult bindResponse;
-        try {
-            bindResponse = bind(cluster).get();
-            if (!bindResponse.isSuccess()) {
-                logger.debug("{}: Failed to bind thermostat cluster", endpoint.getIeeeAddress());
-            } else {
-                // Configure reporting
-                ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_OCCUPIEDHEATINGSETPOINT);
-                CommandResult reportingResponse = cluster
-                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
-                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
-        }
-
         // Add a listener, then request the status
         cluster.addAttributeListener(this);
-
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
@@ -41,6 +41,33 @@ public class ZigBeeConverterThermostatOutdoorTemperature extends ZigBeeBaseChann
     private ZclThermostatCluster cluster;
 
     @Override
+    public boolean initializeDevice() {
+        ZclThermostatCluster serverCluster = (ZclThermostatCluster) endpoint
+                .getInputCluster(ZclThermostatCluster.CLUSTER_ID);
+        if (serverCluster == null) {
+            logger.error("{}: Error opening device thermostat cluster", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        try {
+            CommandResult bindResponse = bind(serverCluster).get();
+            if (bindResponse.isSuccess()) {
+                // Configure reporting
+                ZclAttribute attribute = serverCluster.getAttribute(ZclThermostatCluster.ATTR_OUTDOORTEMPERATURE);
+                CommandResult reportingResponse = serverCluster
+                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
+            } else {
+                logger.debug("{}: Failed to bind thermostat cluster", endpoint.getIeeeAddress());
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+        }
+
+        return true;
+    }
+
+    @Override
     public boolean initializeConverter() {
         cluster = (ZclThermostatCluster) endpoint.getInputCluster(ZclThermostatCluster.CLUSTER_ID);
         if (cluster == null) {
@@ -48,25 +75,8 @@ public class ZigBeeConverterThermostatOutdoorTemperature extends ZigBeeBaseChann
             return false;
         }
 
-        CommandResult bindResponse;
-        try {
-            bindResponse = bind(cluster).get();
-            if (!bindResponse.isSuccess()) {
-                logger.debug("{}: Failed to bind thermostat cluster", endpoint.getIeeeAddress());
-            } else {
-                // Configure reporting
-                ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_OUTDOORTEMPERATURE);
-                CommandResult reportingResponse = cluster
-                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
-                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
-        }
-
         // Add a listener, then request the status
         cluster.addAttributeListener(this);
-
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
@@ -43,6 +43,34 @@ public class ZigBeeConverterThermostatRunningMode extends ZigBeeBaseChannelConve
     private ZclThermostatCluster cluster;
 
     @Override
+    public boolean initializeDevice() {
+        ZclThermostatCluster serverCluster = (ZclThermostatCluster) endpoint
+                .getInputCluster(ZclThermostatCluster.CLUSTER_ID);
+        if (serverCluster == null) {
+            logger.error("{}: Error opening device thermostat cluster", endpoint.getIeeeAddress());
+            pollingPeriod = POLLING_PERIOD_HIGH;
+            return false;
+        }
+
+        try {
+            CommandResult bindResponse = bind(serverCluster).get();
+            if (bindResponse.isSuccess()) {
+                // Configure reporting
+                ZclAttribute attribute = serverCluster.getAttribute(ZclThermostatCluster.ATTR_THERMOSTATRUNNINGMODE);
+                CommandResult reportingResponse = serverCluster
+                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
+            } else {
+                logger.debug("{}: Failed to bind thermostat cluster", endpoint.getIeeeAddress());
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+        }
+
+        return true;
+    }
+
+    @Override
     public boolean initializeConverter() {
         cluster = (ZclThermostatCluster) endpoint.getInputCluster(ZclThermostatCluster.CLUSTER_ID);
         if (cluster == null) {
@@ -50,25 +78,8 @@ public class ZigBeeConverterThermostatRunningMode extends ZigBeeBaseChannelConve
             return false;
         }
 
-        CommandResult bindResponse;
-        try {
-            bindResponse = bind(cluster).get();
-            if (!bindResponse.isSuccess()) {
-                logger.debug("{}: Failed to bind thermostat cluster", endpoint.getIeeeAddress());
-            } else {
-                // Configure reporting
-                ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_THERMOSTATRUNNINGMODE);
-                CommandResult reportingResponse = cluster
-                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX).get();
-                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
-        }
-
         // Add a listener, then request the status
         cluster.addAttributeListener(this);
-
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
@@ -38,6 +38,33 @@ public class ZigBeeConverterThermostatSystemMode extends ZigBeeBaseChannelConver
     private ZclThermostatCluster cluster;
 
     @Override
+    public boolean initializeDevice() {
+        ZclThermostatCluster serverCluster = (ZclThermostatCluster) endpoint
+                .getInputCluster(ZclThermostatCluster.CLUSTER_ID);
+        if (serverCluster == null) {
+            logger.error("{}: Error opening device thermostat cluster", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        try {
+            CommandResult bindResponse = bind(serverCluster).get();
+            if (bindResponse.isSuccess()) {
+                // Configure reporting
+                ZclAttribute attribute = serverCluster.getAttribute(ZclThermostatCluster.ATTR_SYSTEMMODE);
+                CommandResult reportingResponse = serverCluster
+                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
+            } else {
+                logger.debug("{}: Failed to bind thermostat cluster", endpoint.getIeeeAddress());
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+        }
+
+        return true;
+    }
+
+    @Override
     public boolean initializeConverter() {
         cluster = (ZclThermostatCluster) endpoint.getInputCluster(ZclThermostatCluster.CLUSTER_ID);
         if (cluster == null) {
@@ -45,25 +72,8 @@ public class ZigBeeConverterThermostatSystemMode extends ZigBeeBaseChannelConver
             return false;
         }
 
-        CommandResult bindResponse;
-        try {
-            bindResponse = bind(cluster).get();
-            if (!bindResponse.isSuccess()) {
-                logger.debug("{}: Failed to bind thermostat cluster", endpoint.getIeeeAddress());
-            } else {
-                // Configure reporting
-                ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_SYSTEMMODE);
-                CommandResult reportingResponse = cluster
-                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX).get();
-                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
-        }
-
         // Add a listener, then request the status
         cluster.addAttributeListener(this);
-
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
@@ -41,6 +41,33 @@ public class ZigBeeConverterThermostatUnoccupiedCooling extends ZigBeeBaseChanne
     private ZclThermostatCluster cluster;
 
     @Override
+    public boolean initializeDevice() {
+        ZclThermostatCluster serverCluster = (ZclThermostatCluster) endpoint
+                .getInputCluster(ZclThermostatCluster.CLUSTER_ID);
+        if (serverCluster == null) {
+            logger.error("{}: Error opening device thermostat cluster", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        try {
+            CommandResult bindResponse = bind(serverCluster).get();
+            // Configure reporting
+            ZclAttribute attribute = serverCluster.getAttribute(ZclThermostatCluster.ATTR_UNOCCUPIEDCOOLINGSETPOINT);
+            CommandResult reportingResponse = serverCluster
+                    .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
+            handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
+            if (!bindResponse.isSuccess()) {
+            } else {
+                logger.debug("{}: Failed to bind thermostat cluster", endpoint.getIeeeAddress());
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+        }
+
+        return true;
+    }
+
+    @Override
     public boolean initializeConverter() {
         cluster = (ZclThermostatCluster) endpoint.getInputCluster(ZclThermostatCluster.CLUSTER_ID);
         if (cluster == null) {
@@ -48,25 +75,8 @@ public class ZigBeeConverterThermostatUnoccupiedCooling extends ZigBeeBaseChanne
             return false;
         }
 
-        CommandResult bindResponse;
-        try {
-            bindResponse = bind(cluster).get();
-            if (!bindResponse.isSuccess()) {
-                logger.debug("{}: Failed to bind thermostat cluster", endpoint.getIeeeAddress());
-            } else {
-                // Configure reporting
-                ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_UNOCCUPIEDCOOLINGSETPOINT);
-                CommandResult reportingResponse = cluster
-                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
-                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
-        }
-
         // Add a listener, then request the status
         cluster.addAttributeListener(this);
-
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
@@ -41,6 +41,35 @@ public class ZigBeeConverterThermostatUnoccupiedHeating extends ZigBeeBaseChanne
     private ZclThermostatCluster cluster;
 
     @Override
+    public boolean initializeDevice() {
+        ZclThermostatCluster serverCluster = (ZclThermostatCluster) endpoint
+                .getInputCluster(ZclThermostatCluster.CLUSTER_ID);
+        if (serverCluster == null) {
+            logger.error("{}: Error opening device thermostat cluster", endpoint.getIeeeAddress());
+            return false;
+        }
+
+        try {
+            CommandResult bindResponse = bind(serverCluster).get();
+            if (bindResponse.isSuccess()) {
+                // Configure reporting
+                ZclAttribute attribute = serverCluster
+                        .getAttribute(ZclThermostatCluster.ATTR_UNOCCUPIEDHEATINGSETPOINT);
+                CommandResult reportingResponse = serverCluster
+                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
+            } else {
+                logger.debug("{}: Failed to bind thermostat cluster", endpoint.getIeeeAddress());
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
+        }
+
+        return true;
+
+    }
+
+    @Override
     public boolean initializeConverter() {
         cluster = (ZclThermostatCluster) endpoint.getInputCluster(ZclThermostatCluster.CLUSTER_ID);
         if (cluster == null) {
@@ -48,25 +77,8 @@ public class ZigBeeConverterThermostatUnoccupiedHeating extends ZigBeeBaseChanne
             return false;
         }
 
-        CommandResult bindResponse;
-        try {
-            bindResponse = bind(cluster).get();
-            if (!bindResponse.isSuccess()) {
-                logger.debug("{}: Failed to bind thermostat cluster", endpoint.getIeeeAddress());
-            } else {
-                // Configure reporting
-                ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_UNOCCUPIEDHEATINGSETPOINT);
-                CommandResult reportingResponse = cluster
-                        .setReporting(attribute, REPORTING_PERIOD_DEFAULT_MIN, REPORTING_PERIOD_DEFAULT_MAX, 0.1).get();
-                handleReportingResponse(reportingResponse, POLLING_PERIOD_DEFAULT, REPORTING_PERIOD_DEFAULT_MAX);
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.error("{}: Exception setting reporting ", endpoint.getIeeeAddress(), e);
-        }
-
         // Add a listener, then request the status
         cluster.addAttributeListener(this);
-
         return true;
     }
 


### PR DESCRIPTION
Extract device initialization from `initializeConverter()` method to `initializeDevice()`.
This PR only split the existing functionality without changing the logic. If any refactoring is needed e.g. additional setting of the polling interval, or returning `false` during device initialization in case of an exception, it can be done in a separate PR.
Signed-off-by: YordanDZhelev <zhelev.yordan@gmail.com>