### PR TITLE
Refactoring of some converters to always initialize variables

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
@@ -61,12 +61,7 @@ public class ZigBeeConverterAtmosphericPressure extends ZigBeeBaseChannelConvert
         }
 
         // Check if the enhanced attributes are supported
-        if (serverCluster.getScaledValue(Long.MAX_VALUE) != null) {
-            enhancedScale = serverCluster.getScale(Long.MAX_VALUE);
-            if (enhancedScale != null) {
-                enhancedScale *= -1;
-            }
-        }
+        determineEnhancedScale(serverCluster);
 
         try {
             CommandResult bindResponse = bind(serverCluster).get();
@@ -103,6 +98,9 @@ public class ZigBeeConverterAtmosphericPressure extends ZigBeeBaseChannelConvert
             logger.error("{}: Error opening device pressure measurement cluster", endpoint.getIeeeAddress());
             return false;
         }
+
+        // Check if the enhanced attributes are supported
+        determineEnhancedScale(cluster);
 
         // Add a listener
         cluster.addAttributeListener(this);
@@ -171,4 +169,14 @@ public class ZigBeeConverterAtmosphericPressure extends ZigBeeBaseChannelConvert
             return;
         }
     }
+
+    private void determineEnhancedScale(ZclPressureMeasurementCluster cluster) {
+        if (cluster.getScaledValue(Long.MAX_VALUE) != null) {
+            enhancedScale = cluster.getScale(Long.MAX_VALUE);
+            if (enhancedScale != null) {
+                enhancedScale *= -1;
+            }
+        }
+    }
+
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
@@ -62,8 +62,6 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
             return false;
         }
 
-        determineMinMaxTemperature(serverClusterColorControl);
-
         try {
             CommandResult bindResponse = bind(serverClusterColorControl).get();
             if (bindResponse.isSuccess()) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
@@ -62,24 +62,7 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
             return false;
         }
 
-        Integer minTemperatureInMired = serverClusterColorControl.getColorTemperatureMin(Long.MAX_VALUE);
-        Integer maxTemperatureInMired = serverClusterColorControl.getColorTemperatureMax(Long.MAX_VALUE);
-
-        // High Mired values correspond to low Kelvin values, hence the max Mired value yields the min Kelvin value
-        if (maxTemperatureInMired == null) {
-            kelvinMin = DEFAULT_MIN_TEMPERATURE_IN_KELVIN;
-        } else {
-            kelvinMin = miredToKelvin(maxTemperatureInMired);
-        }
-
-        // Low Mired values correspond to high Kelvin values, hence the min Mired value yields the max Kelvin value
-        if (minTemperatureInMired == null) {
-            kelvinMax = DEFAULT_MAX_TEMPERATURE_IN_KELVIN;
-        } else {
-            kelvinMax = miredToKelvin(minTemperatureInMired);
-        }
-
-        kelvinRange = kelvinMax - kelvinMin;
+        determineMinMaxTemperature(serverClusterColorControl);
 
         try {
             CommandResult bindResponse = bind(serverClusterColorControl).get();
@@ -112,6 +95,8 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
                     endpoint.getEndpointId());
             return false;
         }
+
+        determineMinMaxTemperature(clusterColorControl);
 
         clusterColorControl.addAttributeListener(this);
         return true;
@@ -267,6 +252,27 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
             return null;
         }
         return kelvinToPercent(miredToKelvin(temperatureInMired));
+    }
+
+    private void determineMinMaxTemperature(ZclColorControlCluster serverClusterColorControl) {
+        Integer minTemperatureInMired = serverClusterColorControl.getColorTemperatureMin(Long.MAX_VALUE);
+        Integer maxTemperatureInMired = serverClusterColorControl.getColorTemperatureMax(Long.MAX_VALUE);
+
+        // High Mired values correspond to low Kelvin values, hence the max Mired value yields the min Kelvin value
+        if (maxTemperatureInMired == null) {
+            kelvinMin = DEFAULT_MIN_TEMPERATURE_IN_KELVIN;
+        } else {
+            kelvinMin = miredToKelvin(maxTemperatureInMired);
+        }
+
+        // Low Mired values correspond to high Kelvin values, hence the min Mired value yields the max Kelvin value
+        if (minTemperatureInMired == null) {
+            kelvinMax = DEFAULT_MAX_TEMPERATURE_IN_KELVIN;
+        } else {
+            kelvinMax = miredToKelvin(minTemperatureInMired);
+        }
+
+        kelvinRange = kelvinMax - kelvinMin;
     }
 
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
@@ -71,8 +71,6 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
             return false;
         }
 
-        determineDivisorAndMultiplier(serverClusterMeasurement);
-
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
@@ -71,12 +71,8 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
             return false;
         }
 
-        divisor = serverClusterMeasurement.getAcPowerDivisor(Long.MAX_VALUE);
-        multiplier = serverClusterMeasurement.getAcPowerMultiplier(Long.MAX_VALUE);
-        if (divisor == null || multiplier == null) {
-            divisor = 1;
-            multiplier = 1;
-        }
+        determineDivisorAndMultiplier(serverClusterMeasurement);
+
         return true;
     }
 
@@ -88,6 +84,8 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
             logger.error("{}: Error opening electrical measurement cluster", endpoint.getIeeeAddress());
             return false;
         }
+
+        determineDivisorAndMultiplier(clusterMeasurement);
 
         // Add a listener, then request the status
         clusterMeasurement.addAttributeListener(this);
@@ -154,4 +152,14 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
             }
         }
     }
+
+    private void determineDivisorAndMultiplier(ZclElectricalMeasurementCluster serverClusterMeasurement) {
+        divisor = serverClusterMeasurement.getAcPowerDivisor(Long.MAX_VALUE);
+        multiplier = serverClusterMeasurement.getAcPowerMultiplier(Long.MAX_VALUE);
+        if (divisor == null || multiplier == null) {
+            divisor = 1;
+            multiplier = 1;
+        }
+    }
+
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
@@ -72,8 +72,6 @@ public class ZigBeeConverterMeasurementRmsCurrent extends ZigBeeBaseChannelConve
             return false;
         }
 
-        determineDivisorAndMultiplier(serverClusterMeasurement);
-
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
@@ -72,8 +72,6 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
             return false;
         }
 
-        determineDivisorAndMultiplier(serverClusterMeasurement);
-
         return true;
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
@@ -72,12 +72,7 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
             return false;
         }
 
-        divisor = serverClusterMeasurement.getAcVoltageDivisor(Long.MAX_VALUE);
-        multiplier = serverClusterMeasurement.getAcVoltageMultiplier(Long.MAX_VALUE);
-        if (divisor == null || multiplier == null) {
-            divisor = 1;
-            multiplier = 1;
-        }
+        determineDivisorAndMultiplier(serverClusterMeasurement);
 
         return true;
     }
@@ -90,6 +85,8 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
             logger.error("{}: Error opening electrical measurement cluster", endpoint.getIeeeAddress());
             return false;
         }
+
+        determineDivisorAndMultiplier(clusterMeasurement);
 
         // Add a listener
         clusterMeasurement.addAttributeListener(this);
@@ -153,4 +150,14 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
             }
         }
     }
+
+    private void determineDivisorAndMultiplier(ZclElectricalMeasurementCluster serverClusterMeasurement) {
+        divisor = serverClusterMeasurement.getAcPowerDivisor(Long.MAX_VALUE);
+        multiplier = serverClusterMeasurement.getAcPowerMultiplier(Long.MAX_VALUE);
+        if (divisor == null || multiplier == null) {
+            divisor = 1;
+            multiplier = 1;
+        }
+    }
+
 }


### PR DESCRIPTION
Resolves #432 

Some converters used to initialize variables on device initialization in
order to handle attributes updates. After the initilization has been
been split into a device and a converter initialization these variables
were no longer initialized when only the converter was initialized. This
made the initialization run into NPEs. This commit ensures that the
initialization is properly done when only the converter is initialized.

Signed-off-by: Tommaso Travaglino <tommaso.travaglino@telekom.de>