### PR TITLE
Adapt the binding to the changes in the ZSS core framework coming with release 1.2.0

### DIFF
--- a/org.openhab.binding.zigbee.cc2531/pom.xml
+++ b/org.openhab.binding.zigbee.cc2531/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>com.zsmartsystems.zigbee</groupId>
       <artifactId>com.zsmartsystems.zigbee.dongle.cc2531</artifactId>
-      <version>1.1.6</version>
+      <version>1.2.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/org.openhab.binding.zigbee.console.ember/pom.xml
+++ b/org.openhab.binding.zigbee.console.ember/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.zsmartsystems.zigbee</groupId>
       <artifactId>com.zsmartsystems.zigbee.console.ember</artifactId>
-      <version>1.1.6</version>
+      <version>1.2.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/org.openhab.binding.zigbee.console.telegesis/pom.xml
+++ b/org.openhab.binding.zigbee.console.telegesis/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.zsmartsystems.zigbee</groupId>
       <artifactId>com.zsmartsystems.zigbee.console.telegesis</artifactId>
-      <version>1.1.6</version>
+      <version>1.2.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/org.openhab.binding.zigbee.console/pom.xml
+++ b/org.openhab.binding.zigbee.console/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>com.zsmartsystems.zigbee</groupId>
       <artifactId>com.zsmartsystems.zigbee.console</artifactId>
-      <version>1.1.6</version>
+      <version>1.2.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/org.openhab.binding.zigbee.ember/pom.xml
+++ b/org.openhab.binding.zigbee.ember/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>com.zsmartsystems.zigbee</groupId>
       <artifactId>com.zsmartsystems.zigbee.dongle.ember</artifactId>
-      <version>1.1.6</version>
+      <version>1.2.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/org.openhab.binding.zigbee.telegesis/pom.xml
+++ b/org.openhab.binding.zigbee.telegesis/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>com.zsmartsystems.zigbee</groupId>
       <artifactId>com.zsmartsystems.zigbee.dongle.telegesis</artifactId>
-      <version>1.1.6</version>
+      <version>1.2.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/org.openhab.binding.zigbee.xbee/pom.xml
+++ b/org.openhab.binding.zigbee.xbee/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>com.zsmartsystems.zigbee</groupId>
       <artifactId>com.zsmartsystems.zigbee.dongle.xbee</artifactId>
-      <version>1.1.6</version>
+      <version>1.2.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/org.openhab.binding.zigbee/pom.xml
+++ b/org.openhab.binding.zigbee/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.zsmartsystems.zigbee</groupId>
       <artifactId>com.zsmartsystems.zigbee</artifactId>
-      <version>1.1.6</version>
+      <version>1.2.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeNodePropertyDiscoverer.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeNodePropertyDiscoverer.java
@@ -23,8 +23,8 @@ import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.zcl.ZclAttribute;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclBasicCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclOtaUpgradeCluster;
 import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor;
@@ -196,7 +196,12 @@ public class ZigBeeNodePropertyDiscoverer {
         }
 
         if (otaCluster != null) {
-            Integer fileVersion = otaCluster.getCurrentFileVersion(Long.MAX_VALUE);
+            logger.debug("{}: ZigBee node property discovery using OTA cluster on endpoint {}", node.getIeeeAddress(),
+                    otaCluster.getZigBeeAddress());
+
+            ZclAttribute attribute = otaCluster.getAttribute(ZclOtaUpgradeCluster.ATTR_CURRENTFILEVERSION);
+            Object fileVersion = attribute.readValue(Long.MAX_VALUE);
+
             if (fileVersion != null) {
                 properties.put(Thing.PROPERTY_FIRMWARE_VERSION,
                         String.format("%s%08X", ZigBeeBindingConstants.FIRMWARE_VERSION_HEX_PREFIX, fileVersion));

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -77,6 +77,7 @@ import com.zsmartsystems.zigbee.ZigBeeNetworkNodeListener;
 import com.zsmartsystems.zigbee.ZigBeeNode;
 import com.zsmartsystems.zigbee.ZigBeeNodeStatus;
 import com.zsmartsystems.zigbee.ZigBeeProfileType;
+import com.zsmartsystems.zigbee.ZigBeeStatus;
 import com.zsmartsystems.zigbee.app.otaserver.ZclOtaUpgradeServer;
 import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaFile;
 import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaServerStatus;
@@ -166,10 +167,10 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
     /**
      * Creates a ZigBee thing.
      *
-     * @param zigbeeDevice         the {@link Thing}
-     * @param channelFactory       the {@link ZigBeeChannelConverterFactory} to be used to create the channels
+     * @param zigbeeDevice the {@link Thing}
+     * @param channelFactory the {@link ZigBeeChannelConverterFactory} to be used to create the channels
      * @param zigbeeIsAliveTracker the tracker which sets the {@link Thing} to OFFLINE after a period without
-     *                                 communication
+     *            communication
      */
     public ZigBeeThingHandler(Thing zigbeeDevice, ZigBeeChannelConverterFactory channelFactory,
             ZigbeeIsAliveTracker zigbeeIsAliveTracker) {
@@ -432,7 +433,7 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
         // Update the binding table.
         // We're not doing anything with the information here, but we want it up to date so it's ready for use later.
         try {
-            if (node.updateBindingTable().get() == false) {
+            if (node.updateBindingTable().get() != ZigBeeStatus.SUCCESS) {
                 logger.debug("{}: Error getting binding table", nodeIeeeAddress);
             }
         } catch (InterruptedException | ExecutionException e) {
@@ -503,7 +504,7 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
      * Process a static cluster list and add it to the existing list
      *
      * @param initialClusters a collection of existing clusters
-     * @param newClusters     a string containing a comma separated list of clusters
+     * @param newClusters a string containing a comma separated list of clusters
      * @return a list of clusters if the list is updated, or an empty list if it has not changed
      */
     private List<Integer> processClusterList(Collection<Integer> initialClusters, String newClusters) {
@@ -738,7 +739,7 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
      * changes.
      *
      * @param channel the {@link ChannelUID} to be updated
-     * @param state   the new {link State}
+     * @param state the new {link State}
      */
     public void setChannelState(ChannelUID channel, State state) {
         if (firmwareUpdateInProgress) {
@@ -757,7 +758,7 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
      * received.
      *
      * @param channel the {@link ChannelUID} to be triggered
-     * @param event   the event to be emitted
+     * @param event the event to be emitted
      */
     @Override
     public void triggerChannel(ChannelUID channel, String event) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
@@ -158,20 +158,16 @@ public class ZigBeeConverterAtmosphericPressure extends ZigBeeBaseChannelConvert
         }
 
         if (attribute.getId() == ZclPressureMeasurementCluster.ATTR_SCALEDVALUE && enhancedScale != null) {
-            if (value instanceof Integer) {
-                updateChannelState(new QuantityType<Pressure>(BigDecimal.valueOf((Integer) value, enhancedScale),
-                        HECTO(SIUnits.PASCAL)));
-            }
+            updateChannelState(new QuantityType<Pressure>(BigDecimal.valueOf((Integer) value, enhancedScale),
+                    HECTO(SIUnits.PASCAL)));
             return;
         }
 
         if (attribute.getId() == ZclPressureMeasurementCluster.ATTR_MEASUREDVALUE && enhancedScale == null) {
-            if (value instanceof Integer) {
-                updateChannelState(
-                        new QuantityType<Pressure>(BigDecimal.valueOf((Integer) value, 0), HECTO(SIUnits.PASCAL)));
-            }
-            return;
+            updateChannelState(
+                    new QuantityType<Pressure>(BigDecimal.valueOf((Integer) value, 0), HECTO(SIUnits.PASCAL)));
         }
+        return;
     }
 
     private void determineEnhancedScale(ZclPressureMeasurementCluster cluster) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
@@ -158,17 +158,17 @@ public class ZigBeeConverterBatteryAlarm extends ZigBeeBaseChannelConverter impl
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         if (attribute.getCluster() == ZclClusterType.POWER_CONFIGURATION
                 && attribute.getId() == ZclPowerConfigurationCluster.ATTR_BATTERYALARMSTATE) {
 
             logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
 
-            // The value is a 32-bit bitmap, represented by an Integer
-            Integer value = (Integer) attribute.getLastValue();
-            if (value == null) {
+            if (!(val instanceof Integer)) {
                 return;
             }
+            // The value is a 32-bit bitmap, represented by an Integer
+            Integer value = (Integer) val;
 
             if ((value & MIN_THRESHOLD_BITMASK) != 0) {
                 updateChannelState(new StringType(STATE_OPTION_BATTERY_MIN_THRESHOLD));

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
@@ -164,9 +164,6 @@ public class ZigBeeConverterBatteryAlarm extends ZigBeeBaseChannelConverter impl
 
             logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
 
-            if (!(val instanceof Integer)) {
-                return;
-            }
             // The value is a 32-bit bitmap, represented by an Integer
             Integer value = (Integer) val;
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import static com.zsmartsystems.zigbee.zcl.clusters.ZclPowerConfigurationCluster.ATTR_BATTERYPERCENTAGEREMAINING;
+
 import java.util.concurrent.ExecutionException;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -57,7 +59,10 @@ public class ZigBeeConverterBatteryPercent extends ZigBeeBaseChannelConverter im
             if (bindResponse.isSuccess()) {
                 // Configure reporting - no faster than once per ten minutes - no slower than every 2 hours.
                 CommandResult reportingResponse = serverCluster
-                        .setBatteryPercentageRemainingReporting(600, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
+                        .setReporting(serverCluster.getAttribute(ATTR_BATTERYPERCENTAGEREMAINING), 600,
+                                REPORTING_PERIOD_DEFAULT_MAX, 1)
+                        .get();
+
                 handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
             } else {
                 logger.error("{}: Error 0x{} setting server binding", endpoint.getIeeeAddress(),
@@ -131,14 +136,14 @@ public class ZigBeeConverterBatteryPercent extends ZigBeeBaseChannelConverter im
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.POWER_CONFIGURATION
                 && attribute.getId() == ZclPowerConfigurationCluster.ATTR_BATTERYPERCENTAGEREMAINING) {
-            Integer value = (Integer) attribute.getLastValue();
-            if (value == null) {
+            if (!(val instanceof Integer)) {
                 return;
             }
+            Integer value = (Integer) val;
 
             updateChannelState(new DecimalType(value / 2));
         }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
@@ -140,9 +140,6 @@ public class ZigBeeConverterBatteryPercent extends ZigBeeBaseChannelConverter im
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.POWER_CONFIGURATION
                 && attribute.getId() == ZclPowerConfigurationCluster.ATTR_BATTERYPERCENTAGEREMAINING) {
-            if (!(val instanceof Integer)) {
-                return;
-            }
             Integer value = (Integer) val;
 
             updateChannelState(new DecimalType(value / 2));

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
@@ -137,9 +137,6 @@ public class ZigBeeConverterBatteryVoltage extends ZigBeeBaseChannelConverter im
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.POWER_CONFIGURATION
                 && attribute.getId() == ZclPowerConfigurationCluster.ATTR_BATTERYVOLTAGE) {
-            if (!(val instanceof Integer)) {
-                return;
-            }
             Integer value = (Integer) val;
             if (value == 0xFF) {
                 // The value 0xFF indicates an invalid or unknown reading.

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
@@ -133,12 +133,15 @@ public class ZigBeeConverterBatteryVoltage extends ZigBeeBaseChannelConverter im
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.POWER_CONFIGURATION
                 && attribute.getId() == ZclPowerConfigurationCluster.ATTR_BATTERYVOLTAGE) {
-            Integer value = (Integer) attribute.getLastValue();
-            if (value == null || value == 0xFF) {
+            if (!(val instanceof Integer)) {
+                return;
+            }
+            Integer value = (Integer) val;
+            if (value == 0xFF) {
                 // The value 0xFF indicates an invalid or unknown reading.
                 return;
             }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterDoorLock.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterDoorLock.java
@@ -119,11 +119,11 @@ public class ZigBeeConverterDoorLock extends ZigBeeBaseChannelConverter implemen
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.DOOR_LOCK
                 && attribute.getId() == ZclDoorLockCluster.ATTR_LOCKSTATE) {
-            Integer value = (Integer) attribute.getLastValue();
+            Integer value = (Integer) val;
             if (value != null && value == 1) {
                 updateChannelState(OnOffType.ON);
             } else {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButton.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButton.java
@@ -16,14 +16,18 @@ import static java.lang.Integer.*;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import com.zsmartsystems.zigbee.zcl.*;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -33,6 +37,11 @@ import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.zcl.ZclAttribute;
+import com.zsmartsystems.zigbee.zcl.ZclAttributeListener;
+import com.zsmartsystems.zigbee.zcl.ZclCluster;
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+import com.zsmartsystems.zigbee.zcl.ZclCommandListener;
 
 /**
  * Generic converter for buttons (e.g., from remote controls).
@@ -45,7 +54,8 @@ import com.zsmartsystems.zigbee.ZigBeeEndpoint;
  * @author Henning Sudbrock - initial contribution
  * @author Thomas Weißschuh - support for attribute-based buttons
  */
-public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter implements ZclCommandListener, ZclAttributeListener {
+public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter
+        implements ZclCommandListener, ZclAttributeListener {
 
     private Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -77,13 +87,12 @@ public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter imp
 
         boolean allBindsSucceeded = true;
 
-        for (EventSpec eventSpec: handledEvents.values()) {
+        for (EventSpec eventSpec : handledEvents.values()) {
             allBindsSucceeded &= eventSpec.bindCluster();
         }
 
         return allBindsSucceeded;
     }
-
 
     @Override
     public void disposeConverter() {
@@ -121,7 +130,7 @@ public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter imp
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         ButtonPressType buttonPressType = getButtonPressType(attribute);
         if (buttonPressType != null) {
             logger.debug("{}: Matching ZigBee attribute for press type {} received: {}", endpoint.getIeeeAddress(),
@@ -192,7 +201,8 @@ public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter imp
         }
     }
 
-    private AttributeReportSpec parseAttributeReportSpec(int clusterId, Map<String, String> properties, ButtonPressType pressType) {
+    private AttributeReportSpec parseAttributeReportSpec(int clusterId, Map<String, String> properties,
+            ButtonPressType pressType) {
         String attributeIdProperty = properties.get(getParameterName(ATTRIBUTE_ID, pressType));
         String attributeValue = properties.get(getParameterName(ATTRIBUTE_VALUE, pressType));
 
@@ -244,7 +254,6 @@ public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter imp
             return null;
         }
 
-
         return new CommandSpec(clusterId, commandId, commandParameterName, commandParameterValue);
     }
 
@@ -289,13 +298,13 @@ public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter imp
         }
 
         abstract boolean matches(ZclCommand command);
+
         abstract boolean matches(ZclAttribute attribute);
+
         abstract boolean bindCluster();
 
         boolean bindCluster(String clusterType, Collection<ZclCluster> existingClusters, int clusterId,
-                            Function<Integer, ZclCluster> getClusterById,
-                            Consumer<ZclCluster> registrationFunction
-        ) {
+                Function<Integer, ZclCluster> getClusterById, Consumer<ZclCluster> registrationFunction) {
             if (existingClusters.stream().anyMatch(c -> c.getClusterId().intValue() == clusterId)) {
                 // bind to each output cluster only once
                 return true;
@@ -303,8 +312,8 @@ public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter imp
 
             ZclCluster cluster = getClusterById.apply(clusterId);
             if (cluster == null) {
-                logger.error("{}: Error opening {} cluster {} on endpoint {}", endpoint.getIeeeAddress(), clusterType, clusterId,
-                        endpoint.getEndpointId());
+                logger.error("{}: Error opening {} cluster {} on endpoint {}", endpoint.getIeeeAddress(), clusterType,
+                        clusterId, endpoint.getEndpointId());
                 return false;
             }
 
@@ -315,7 +324,8 @@ public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter imp
                             toHexString(bindResponse.getStatusCode()), clusterType, clusterId);
                 }
             } catch (InterruptedException | ExecutionException e) {
-                logger.error("{}: Exception setting {} binding to cluster {}", endpoint.getIeeeAddress(), clusterType, clusterId, e);
+                logger.error("{}: Exception setting {} binding to cluster {}", endpoint.getIeeeAddress(), clusterType,
+                        clusterId, e);
             }
 
             registrationFunction.accept(cluster);
@@ -345,17 +355,13 @@ public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter imp
                 return false;
             }
             boolean attributeIdMatches = attribute.getId() == attributeId;
-            boolean attributeValueMatches = Objects.equals(
-                    Objects.toString(attribute.getLastValue()),
-                    attributeValue
-            );
+            boolean attributeValueMatches = Objects.equals(Objects.toString(attribute.getLastValue()), attributeValue);
             return attributeIdMatches && attributeValueMatches;
         }
 
         @Override
         boolean bindCluster() {
-            return bindCluster(
-                    "server", serverClusters, getClusterId(), endpoint::getInputCluster,
+            return bindCluster("server", serverClusters, getClusterId(), endpoint::getInputCluster,
                     cluster -> cluster.addAttributeListener(ZigBeeConverterGenericButton.this));
         }
     }
@@ -365,7 +371,8 @@ public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter imp
         private final String commandParameterName;
         private final String commandParameterValue;
 
-        private CommandSpec(int clusterId, Integer commandId, String commandParameterName, String commandParameterValue) {
+        private CommandSpec(int clusterId, Integer commandId, String commandParameterName,
+                String commandParameterValue) {
             super(clusterId);
             this.commandId = commandId;
             this.commandParameterName = commandParameterName;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButton.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButton.java
@@ -130,8 +130,8 @@ public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute, Object val) {
-        ButtonPressType buttonPressType = getButtonPressType(attribute);
+    public void attributeUpdated(ZclAttribute attribute, Object value) {
+        ButtonPressType buttonPressType = getButtonPressType(attribute, value);
         if (buttonPressType != null) {
             logger.debug("{}: Matching ZigBee attribute for press type {} received: {}", endpoint.getIeeeAddress(),
                     buttonPressType, attribute);
@@ -153,8 +153,8 @@ public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter
         }
     }
 
-    private ButtonPressType getButtonPressType(ZclAttribute attribute) {
-        return getButtonPressType(cs -> cs.matches(attribute));
+    private ButtonPressType getButtonPressType(ZclAttribute attribute, Object value) {
+        return getButtonPressType(cs -> cs.matches(attribute, value));
     }
 
     private ButtonPressType getButtonPressType(ZclCommand command) {
@@ -299,7 +299,7 @@ public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter
 
         abstract boolean matches(ZclCommand command);
 
-        abstract boolean matches(ZclAttribute attribute);
+        abstract boolean matches(ZclAttribute attribute, Object value);
 
         abstract boolean bindCluster();
 
@@ -350,12 +350,12 @@ public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter
         }
 
         @Override
-        boolean matches(ZclAttribute attribute) {
+        boolean matches(ZclAttribute attribute, Object value) {
             if (attributeId == null) {
                 return false;
             }
             boolean attributeIdMatches = attribute.getId() == attributeId;
-            boolean attributeValueMatches = Objects.equals(Objects.toString(attribute.getLastValue()), attributeValue);
+            boolean attributeValueMatches = Objects.equals(Objects.toString(value), attributeValue);
             return attributeIdMatches && attributeValueMatches;
         }
 
@@ -405,7 +405,7 @@ public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter
         }
 
         @Override
-        boolean matches(ZclAttribute attribute) {
+        boolean matches(ZclAttribute attribute, Object value) {
             return false;
         }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
@@ -158,11 +158,11 @@ public abstract class ZigBeeConverterIas extends ZigBeeBaseChannelConverter
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.IAS_ZONE
                 && attribute.getId() == ZclIasZoneCluster.ATTR_ZONESTATUS) {
-            updateChannelState((Integer) attribute.getLastValue());
+            updateChannelState((Integer) val);
         }
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
@@ -105,11 +105,11 @@ public class ZigBeeConverterIlluminance extends ZigBeeBaseChannelConverter imple
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.ILLUMINANCE_MEASUREMENT
                 && attribute.getId() == ZclIlluminanceMeasurementCluster.ATTR_MEASUREDVALUE) {
-            Integer value = (Integer) attribute.getLastValue();
+            Integer value = (Integer) val;
             if (value != null) {
                 updateChannelState(new DecimalType(BigDecimal.valueOf(value, 2)));
             }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
@@ -110,9 +110,7 @@ public class ZigBeeConverterIlluminance extends ZigBeeBaseChannelConverter imple
         if (attribute.getCluster() == ZclClusterType.ILLUMINANCE_MEASUREMENT
                 && attribute.getId() == ZclIlluminanceMeasurementCluster.ATTR_MEASUREDVALUE) {
             Integer value = (Integer) val;
-            if (value != null) {
-                updateChannelState(new DecimalType(BigDecimal.valueOf(value, 2)));
-            }
+            updateChannelState(new DecimalType(BigDecimal.valueOf(value, 2)));
         }
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
@@ -143,11 +143,11 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.ELECTRICAL_MEASUREMENT
                 && attribute.getId() == ZclElectricalMeasurementCluster.ATTR_ACTIVEPOWER) {
-            Integer value = (Integer) attribute.getLastValue();
+            Integer value = (Integer) val;
             if (value != null) {
                 BigDecimal valueInWatt = BigDecimal.valueOf(value * multiplier / divisor);
                 updateChannelState(new QuantityType<Power>(valueInWatt, SmartHomeUnits.WATT));

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
@@ -148,10 +148,8 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
         if (attribute.getCluster() == ZclClusterType.ELECTRICAL_MEASUREMENT
                 && attribute.getId() == ZclElectricalMeasurementCluster.ATTR_ACTIVEPOWER) {
             Integer value = (Integer) val;
-            if (value != null) {
-                BigDecimal valueInWatt = BigDecimal.valueOf(value * multiplier / divisor);
-                updateChannelState(new QuantityType<Power>(valueInWatt, SmartHomeUnits.WATT));
-            }
+            BigDecimal valueInWatt = BigDecimal.valueOf(value * multiplier / divisor);
+            updateChannelState(new QuantityType<Power>(valueInWatt, SmartHomeUnits.WATT));
         }
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
@@ -146,10 +146,8 @@ public class ZigBeeConverterMeasurementRmsCurrent extends ZigBeeBaseChannelConve
         if (attribute.getCluster() == ZclClusterType.ELECTRICAL_MEASUREMENT
                 && attribute.getId() == ZclElectricalMeasurementCluster.ATTR_RMSCURRENT) {
             Integer value = (Integer) val;
-            if (value != null) {
-                BigDecimal valueInAmpere = BigDecimal.valueOf(value * multiplier / divisor);
-                updateChannelState(new QuantityType<ElectricCurrent>(valueInAmpere, SmartHomeUnits.AMPERE));
-            }
+            BigDecimal valueInAmpere = BigDecimal.valueOf(value * multiplier / divisor);
+            updateChannelState(new QuantityType<ElectricCurrent>(valueInAmpere, SmartHomeUnits.AMPERE));
         }
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
@@ -141,11 +141,11 @@ public class ZigBeeConverterMeasurementRmsCurrent extends ZigBeeBaseChannelConve
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.ELECTRICAL_MEASUREMENT
                 && attribute.getId() == ZclElectricalMeasurementCluster.ATTR_RMSCURRENT) {
-            Integer value = (Integer) attribute.getLastValue();
+            Integer value = (Integer) val;
             if (value != null) {
                 BigDecimal valueInAmpere = BigDecimal.valueOf(value * multiplier / divisor);
                 updateChannelState(new QuantityType<ElectricCurrent>(valueInAmpere, SmartHomeUnits.AMPERE));

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
@@ -146,10 +146,8 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
         if (attribute.getCluster() == ZclClusterType.ELECTRICAL_MEASUREMENT
                 && attribute.getId() == ZclElectricalMeasurementCluster.ATTR_RMSVOLTAGE) {
             Integer value = (Integer) val;
-            if (value != null) {
-                BigDecimal valueInVolts = BigDecimal.valueOf(value * multiplier / divisor);
-                updateChannelState(new QuantityType<ElectricPotential>(valueInVolts, SmartHomeUnits.VOLT));
-            }
+            BigDecimal valueInVolts = BigDecimal.valueOf(value * multiplier / divisor);
+            updateChannelState(new QuantityType<ElectricPotential>(valueInVolts, SmartHomeUnits.VOLT));
         }
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
@@ -141,11 +141,11 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.ELECTRICAL_MEASUREMENT
                 && attribute.getId() == ZclElectricalMeasurementCluster.ATTR_RMSVOLTAGE) {
-            Integer value = (Integer) attribute.getLastValue();
+            Integer value = (Integer) val;
             if (value != null) {
                 BigDecimal valueInVolts = BigDecimal.valueOf(value * multiplier / divisor);
                 updateChannelState(new QuantityType<ElectricPotential>(valueInVolts, SmartHomeUnits.VOLT));

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
@@ -108,11 +108,11 @@ public class ZigBeeConverterOccupancy extends ZigBeeBaseChannelConverter impleme
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.OCCUPANCY_SENSING
                 && attribute.getId() == ZclOccupancySensingCluster.ATTR_OCCUPANCY) {
-            Integer value = (Integer) attribute.getLastValue();
+            Integer value = (Integer) val;
             if (value != null && value == 1) {
                 updateChannelState(OnOffType.ON);
             } else {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
@@ -112,9 +112,7 @@ public class ZigBeeConverterRelativeHumidity extends ZigBeeBaseChannelConverter 
         if (attribute.getCluster() == ZclClusterType.RELATIVE_HUMIDITY_MEASUREMENT
                 && attribute.getId() == ZclRelativeHumidityMeasurementCluster.ATTR_MEASUREDVALUE) {
             Integer value = (Integer) val;
-            if (value != null) {
-                updateChannelState(new DecimalType(BigDecimal.valueOf(value, 2)));
-            }
+            updateChannelState(new DecimalType(BigDecimal.valueOf(value, 2)));
         }
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
@@ -107,11 +107,11 @@ public class ZigBeeConverterRelativeHumidity extends ZigBeeBaseChannelConverter 
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.RELATIVE_HUMIDITY_MEASUREMENT
                 && attribute.getId() == ZclRelativeHumidityMeasurementCluster.ATTR_MEASUREDVALUE) {
-            Integer value = (Integer) attribute.getLastValue();
+            Integer value = (Integer) val;
             if (value != null) {
                 updateChannelState(new DecimalType(BigDecimal.valueOf(value, 2)));
             }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -240,18 +240,18 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
     }
 
     @Override
-    public synchronized void attributeUpdated(ZclAttribute attribute) {
+    public synchronized void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.LEVEL_CONTROL
                 && attribute.getId() == ZclLevelControlCluster.ATTR_CURRENTLEVEL) {
-            lastLevel = levelToPercent((Integer) attribute.getLastValue());
+            lastLevel = levelToPercent((Integer) val);
             if (currentOnOffState.get()) {
                 // Note that state is only updated if the current On/Off state is TRUE (ie ON)
                 updateChannelState(lastLevel);
             }
         } else if (attribute.getCluster() == ZclClusterType.ON_OFF && attribute.getId() == ZclOnOffCluster.ATTR_ONOFF) {
             if (attribute.getLastValue() != null) {
-                currentOnOffState.set((Boolean) attribute.getLastValue());
+                currentOnOffState.set((Boolean) val);
                 updateChannelState(currentOnOffState.get() ? lastLevel : OnOffType.OFF);
             }
         }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -195,10 +195,10 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.ON_OFF && attribute.getId() == ZclOnOffCluster.ATTR_ONOFF) {
-            Boolean value = (Boolean) attribute.getLastValue();
+            Boolean value = (Boolean) val;
             if (value != null && value) {
                 updateChannelState(OnOffType.ON);
             } else {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
@@ -115,9 +115,7 @@ public class ZigBeeConverterTemperature extends ZigBeeBaseChannelConverter imple
         if (attribute.getCluster() == ZclClusterType.TEMPERATURE_MEASUREMENT
                 && attribute.getId() == ZclTemperatureMeasurementCluster.ATTR_MEASUREDVALUE) {
             Integer value = (Integer) val;
-            if (value != null) {
-                updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
-            }
+            updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
         }
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
@@ -110,11 +110,11 @@ public class ZigBeeConverterTemperature extends ZigBeeBaseChannelConverter imple
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.TEMPERATURE_MEASUREMENT
                 && attribute.getId() == ZclTemperatureMeasurementCluster.ATTR_MEASUREDVALUE) {
-            Integer value = (Integer) attribute.getLastValue();
+            Integer value = (Integer) val;
             if (value != null) {
                 updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
             }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatLocalTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatLocalTemperature.java
@@ -131,11 +131,11 @@ public class ZigBeeConverterThermostatLocalTemperature extends ZigBeeBaseChannel
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_LOCALTEMPERATURE) {
-            Integer value = (Integer) attribute.getLastValue();
+            Integer value = (Integer) val;
             if (value != null && value != INVALID_TEMPERATURE) {
                 updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
             }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
@@ -129,11 +129,11 @@ public class ZigBeeConverterThermostatOccupiedCooling extends ZigBeeBaseChannelC
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_OCCUPIEDCOOLINGSETPOINT) {
-            Integer value = (Integer) attribute.getLastValue();
+            Integer value = (Integer) val;
             if (value != null) {
                 updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
             }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
@@ -134,9 +134,7 @@ public class ZigBeeConverterThermostatOccupiedCooling extends ZigBeeBaseChannelC
         if (attribute.getCluster() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_OCCUPIEDCOOLINGSETPOINT) {
             Integer value = (Integer) val;
-            if (value != null) {
-                updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
-            }
+            updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
         }
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedHeating.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedHeating.java
@@ -127,11 +127,11 @@ public class ZigBeeConverterThermostatOccupiedHeating extends ZigBeeBaseChannelC
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_OCCUPIEDHEATINGSETPOINT) {
-            Integer value = (Integer) attribute.getLastValue();
+            Integer value = (Integer) val;
             if (value != null) {
                 updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
             }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedHeating.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedHeating.java
@@ -132,9 +132,7 @@ public class ZigBeeConverterThermostatOccupiedHeating extends ZigBeeBaseChannelC
         if (attribute.getCluster() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_OCCUPIEDHEATINGSETPOINT) {
             Integer value = (Integer) val;
-            if (value != null) {
-                updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
-            }
+            updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
         }
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
@@ -128,11 +128,11 @@ public class ZigBeeConverterThermostatOutdoorTemperature extends ZigBeeBaseChann
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_OUTDOORTEMPERATURE) {
-            Integer value = (Integer) attribute.getLastValue();
+            Integer value = (Integer) val;
             if (value != null) {
                 updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
             }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
@@ -133,9 +133,7 @@ public class ZigBeeConverterThermostatOutdoorTemperature extends ZigBeeBaseChann
         if (attribute.getCluster() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_OUTDOORTEMPERATURE) {
             Integer value = (Integer) val;
-            if (value != null) {
-                updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
-            }
+            updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
         }
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
@@ -158,9 +158,7 @@ public class ZigBeeConverterThermostatRunningMode extends ZigBeeBaseChannelConve
         if (attribute.getCluster() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_THERMOSTATRUNNINGMODE) {
             Integer value = (Integer) val;
-            if (value != null) {
-                updateChannelState(new DecimalType(value));
-            }
+            updateChannelState(new DecimalType(value));
         }
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
@@ -153,11 +153,11 @@ public class ZigBeeConverterThermostatRunningMode extends ZigBeeBaseChannelConve
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_THERMOSTATRUNNINGMODE) {
-            Integer value = (Integer) attribute.getLastValue();
+            Integer value = (Integer) val;
             if (value != null) {
                 updateChannelState(new DecimalType(value));
             }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
@@ -132,9 +132,7 @@ public class ZigBeeConverterThermostatSystemMode extends ZigBeeBaseChannelConver
         if (attribute.getCluster() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_SYSTEMMODE) {
             Integer value = (Integer) val;
-            if (value != null) {
-                updateChannelState(new DecimalType(value));
-            }
+            updateChannelState(new DecimalType(value));
         }
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
@@ -127,11 +127,11 @@ public class ZigBeeConverterThermostatSystemMode extends ZigBeeBaseChannelConver
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_SYSTEMMODE) {
-            Integer value = (Integer) attribute.getLastValue();
+            Integer value = (Integer) val;
             if (value != null) {
                 updateChannelState(new DecimalType(value));
             }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
@@ -128,11 +128,11 @@ public class ZigBeeConverterThermostatUnoccupiedCooling extends ZigBeeBaseChanne
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_UNOCCUPIEDCOOLINGSETPOINT) {
-            Integer value = (Integer) attribute.getLastValue();
+            Integer value = (Integer) val;
             if (value != null) {
                 updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
             }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
@@ -133,9 +133,7 @@ public class ZigBeeConverterThermostatUnoccupiedCooling extends ZigBeeBaseChanne
         if (attribute.getCluster() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_UNOCCUPIEDCOOLINGSETPOINT) {
             Integer value = (Integer) val;
-            if (value != null) {
-                updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
-            }
+            updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
         }
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
@@ -135,9 +135,7 @@ public class ZigBeeConverterThermostatUnoccupiedHeating extends ZigBeeBaseChanne
         if (attribute.getCluster() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_UNOCCUPIEDHEATINGSETPOINT) {
             Integer value = (Integer) val;
-            if (value != null) {
-                updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
-            }
+            updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
         }
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
@@ -130,11 +130,11 @@ public class ZigBeeConverterThermostatUnoccupiedHeating extends ZigBeeBaseChanne
     }
 
     @Override
-    public void attributeUpdated(ZclAttribute attribute) {
+    public void attributeUpdated(ZclAttribute attribute, Object val) {
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_UNOCCUPIEDHEATINGSETPOINT) {
-            Integer value = (Integer) attribute.getLastValue();
+            Integer value = (Integer) val;
             if (value != null) {
                 updateChannelState(new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS));
             }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/warningdevice/ZigBeeConverterWarningDevice.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/warningdevice/ZigBeeConverterWarningDevice.java
@@ -156,7 +156,7 @@ public class ZigBeeConverterWarningDevice extends ZigBeeBaseChannelConverter {
     }
 
     private void squawk(SquawkType squawkType) {
-        iasWdCluster.squawkCommand(
+        iasWdCluster.squawk(
                 makeSquawkHeader(squawkType.getSquawkMode(), squawkType.isUseStrobe(), squawkType.getSquawkLevel()));
     }
 

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandlerTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandlerTest.java
@@ -45,6 +45,7 @@ import org.openhab.binding.zigbee.converter.ZigBeeChannelConverterFactory;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.ZigBeeStatus;
 
 /**
  * Test of the ZigBeeThingHandler
@@ -232,8 +233,8 @@ public class ZigBeeThingHandlerTest {
             throws InterruptedException, ExecutionException {
 
         ZigBeeEndpoint zigbeeEndpoint = mock(ZigBeeEndpoint.class);
-        Future<Boolean> updateBindingTableFuture = mock(Future.class);
-        when(updateBindingTableFuture.get()).thenReturn(Boolean.TRUE);
+        Future<ZigBeeStatus> updateBindingTableFuture = mock(Future.class);
+        when(updateBindingTableFuture.get()).thenReturn(ZigBeeStatus.SUCCESS);
 
         ZigBeeNode zigBeeNode = mock(ZigBeeNode.class);
         when(zigBeeNode.isDiscovered()).thenReturn(true);

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressureTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressureTest.java
@@ -61,17 +61,14 @@ public class ZigBeeConverterAtmosphericPressureTest {
         ZclAttribute attributeMeasuredVal = Mockito.mock(ZclAttribute.class);
         Mockito.when(attributeMeasuredVal.getCluster()).thenReturn(ZclClusterType.PRESSURE_MEASUREMENT);
         Mockito.when(attributeMeasuredVal.getId()).thenReturn(ZclPressureMeasurementCluster.ATTR_MEASUREDVALUE);
-        Mockito.when(attributeMeasuredVal.getLastValue()).thenReturn(Integer.valueOf(1234));
 
         ZclAttribute attributeScaledVal = Mockito.mock(ZclAttribute.class);
         Mockito.when(attributeScaledVal.getCluster()).thenReturn(ZclClusterType.PRESSURE_MEASUREMENT);
         Mockito.when(attributeScaledVal.getId()).thenReturn(ZclPressureMeasurementCluster.ATTR_SCALEDVALUE);
-        Mockito.when(attributeScaledVal.getLastValue()).thenReturn(Integer.valueOf(12456));
 
         ZclAttribute attributeScaledVal2 = Mockito.mock(ZclAttribute.class);
         Mockito.when(attributeScaledVal2.getCluster()).thenReturn(ZclClusterType.PRESSURE_MEASUREMENT);
         Mockito.when(attributeScaledVal2.getId()).thenReturn(ZclPressureMeasurementCluster.ATTR_SCALEDVALUE);
-        Mockito.when(attributeScaledVal2.getLastValue()).thenReturn(Integer.valueOf(12556));
 
         ZclAttribute attributeScale = Mockito.mock(ZclAttribute.class);
         Mockito.when(attributeScale.getCluster()).thenReturn(ZclClusterType.PRESSURE_MEASUREMENT);
@@ -79,7 +76,7 @@ public class ZigBeeConverterAtmosphericPressureTest {
         Mockito.when(attributeScale.getLastValue()).thenReturn(Integer.valueOf(-1));
 
         // Unscaled value, so it's updated
-        converter.attributeUpdated(attributeMeasuredVal);
+        converter.attributeUpdated(attributeMeasuredVal, Integer.valueOf(1234));
         Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(new ChannelUID("a:b:c:d"), channelCapture.getValue());
@@ -89,13 +86,13 @@ public class ZigBeeConverterAtmosphericPressureTest {
         assertEquals(1234, value.doubleValue(), 0.01);
 
         // Scaled value, but no scale yet, so no update
-        converter.attributeUpdated(attributeScaledVal);
+        converter.attributeUpdated(attributeScaledVal, Integer.valueOf(12456));
         Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
 
         // Scaled value, with scale, so updated
-        converter.attributeUpdated(attributeScale);
-        converter.attributeUpdated(attributeScaledVal);
+        converter.attributeUpdated(attributeScale, Integer.valueOf(-1));
+        converter.attributeUpdated(attributeScaledVal, Integer.valueOf(12456));
         Mockito.verify(thingHandler, Mockito.times(2)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(new ChannelUID("a:b:c:d"), channelCapture.getValue());
@@ -105,13 +102,13 @@ public class ZigBeeConverterAtmosphericPressureTest {
         assertEquals(1245.6, value.doubleValue(), 0.01);
 
         // Measured value, but after we received the scale, so no update
-        converter.attributeUpdated(attributeMeasuredVal);
+        converter.attributeUpdated(attributeMeasuredVal, Integer.valueOf(1234));
         Mockito.verify(thingHandler, Mockito.times(2)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
 
         // Scaled value, with scale, so updated
-        converter.attributeUpdated(attributeScale);
-        converter.attributeUpdated(attributeScaledVal);
+        converter.attributeUpdated(attributeScale, Integer.valueOf(-1));
+        converter.attributeUpdated(attributeScaledVal, Integer.valueOf(12456));
         Mockito.verify(thingHandler, Mockito.times(3)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(new ChannelUID("a:b:c:d"), channelCapture.getValue());
@@ -121,18 +118,18 @@ public class ZigBeeConverterAtmosphericPressureTest {
         assertEquals(1245.6, value.doubleValue(), 0.01);
 
         //
-        converter.attributeUpdated(attributeScale);
-        converter.attributeUpdated(attributeMeasuredVal);
-        converter.attributeUpdated(attributeScaledVal2);
+        converter.attributeUpdated(attributeScale, Integer.valueOf(-1));
+        converter.attributeUpdated(attributeMeasuredVal, Integer.valueOf(1234));
+        converter.attributeUpdated(attributeScaledVal2, Integer.valueOf(12556));
         Mockito.verify(thingHandler, Mockito.times(4)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         value = (QuantityType<Pressure>) stateCapture.getValue();
         assertEquals(1255.6, value.doubleValue(), 0.01);
 
         //
-        converter.attributeUpdated(attributeMeasuredVal);
-        converter.attributeUpdated(attributeScaledVal);
-        converter.attributeUpdated(attributeScale);
+        converter.attributeUpdated(attributeMeasuredVal, Integer.valueOf(1234));
+        converter.attributeUpdated(attributeScaledVal, Integer.valueOf(12456));
+        converter.attributeUpdated(attributeScale, Integer.valueOf(-1));
         Mockito.verify(thingHandler, Mockito.times(5)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         value = (QuantityType<Pressure>) stateCapture.getValue();

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarmTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarmTest.java
@@ -13,7 +13,6 @@
 package org.openhab.binding.zigbee.internal.converter;
 
 import static com.zsmartsystems.zigbee.zcl.clusters.ZclPowerConfigurationCluster.*;
-import static com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.openhab.binding.zigbee.ZigBeeBindingConstants.*;
@@ -30,6 +29,8 @@ import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.zcl.ZclAttribute;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclFanControlCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclPowerConfigurationCluster;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -65,66 +66,68 @@ public class ZigBeeConverterBatteryAlarmTest {
     @Test
     public void testAttributeUpdateForMinThreshold() {
         // Bit 0 indicates BatteryMinThreshold
-        converter.attributeUpdated(makeAlarmState(0b0001));
-        verify(thingHandler).setChannelState(channel.getUID(),
-                new StringType(STATE_OPTION_BATTERY_MIN_THRESHOLD));
+        ZclAttribute attribute = makeAlarmState(0b0001);
+        converter.attributeUpdated(attribute, attribute.getLastValue());
+        verify(thingHandler).setChannelState(channel.getUID(), new StringType(STATE_OPTION_BATTERY_MIN_THRESHOLD));
     }
 
     @Test
     public void testAttributeUpdateForThreshold1() {
         // Bit 1 indicates threshold 1
-        converter.attributeUpdated(makeAlarmState(0b0010));
-        verify(thingHandler).setChannelState(channel.getUID(),
-                new StringType(STATE_OPTION_BATTERY_THRESHOLD_1));
+        ZclAttribute attribute = makeAlarmState(0b0010);
+        converter.attributeUpdated(attribute, attribute.getLastValue());
+        verify(thingHandler).setChannelState(channel.getUID(), new StringType(STATE_OPTION_BATTERY_THRESHOLD_1));
     }
 
     @Test
     public void testAttributeUpdateForThreshold2() {
         // Bit 2 indicates threshold 2
-        converter.attributeUpdated(makeAlarmState(0b0100));
-        verify(thingHandler).setChannelState(channel.getUID(),
-                new StringType(STATE_OPTION_BATTERY_THRESHOLD_2));
+        ZclAttribute attribute = makeAlarmState(0b0100);
+        converter.attributeUpdated(attribute, attribute.getLastValue());
+        verify(thingHandler).setChannelState(channel.getUID(), new StringType(STATE_OPTION_BATTERY_THRESHOLD_2));
     }
 
     @Test
     public void testAttributeUpdateForThreshold3() {
         // Bit 3 indicates threshold 3
-        converter.attributeUpdated(makeAlarmState(0b1000));
-        verify(thingHandler).setChannelState(channel.getUID(),
-                new StringType(STATE_OPTION_BATTERY_THRESHOLD_3));
+        ZclAttribute attribute = makeAlarmState(0b1000);
+        converter.attributeUpdated(attribute, attribute.getLastValue());
+        verify(thingHandler).setChannelState(channel.getUID(), new StringType(STATE_OPTION_BATTERY_THRESHOLD_3));
     }
 
     @Test
     public void testAttributeUpdateForNoThreshold() {
-        converter.attributeUpdated(makeAlarmState(0b0000));
-        verify(thingHandler).setChannelState(channel.getUID(),
-                new StringType(STATE_OPTION_BATTERY_NO_THRESHOLD));
+        ZclAttribute attribute = makeAlarmState(0b0000);
+        converter.attributeUpdated(attribute, attribute.getLastValue());
+        verify(thingHandler).setChannelState(channel.getUID(), new StringType(STATE_OPTION_BATTERY_NO_THRESHOLD));
     }
 
     @Test
     public void testAttributeUpdateMultipleThresholds() {
-        converter.attributeUpdated(makeAlarmState(0b1110));
-        verify(thingHandler).setChannelState(channel.getUID(),
-                new StringType(STATE_OPTION_BATTERY_THRESHOLD_1));
+        ZclAttribute attribute = makeAlarmState(0b1110);
+        converter.attributeUpdated(attribute, attribute.getLastValue());
+        verify(thingHandler).setChannelState(channel.getUID(), new StringType(STATE_OPTION_BATTERY_THRESHOLD_1));
     }
 
     @Test
     public void testAttributeUpdateUnsuitableAttribute() {
-        converter.attributeUpdated(new ZclAttribute(POWER_CONFIGURATION, ATTR_BATTERYALARMMASK, "alarm_mask",
-                ZclDataType.BITMAP_32_BIT, false, true, false, true));
+        ZclAttribute attribute = new ZclAttribute(new ZclPowerConfigurationCluster(endpoint), ATTR_BATTERYALARMMASK,
+                "alarm_mask", ZclDataType.BITMAP_32_BIT, false, true, false, true);
+        converter.attributeUpdated(attribute, attribute.getLastValue());
         verify(thingHandler, never()).setChannelState(any(ChannelUID.class), any(State.class));
     }
 
     @Test
     public void testAttributeUpdateUnsuitableCluster() {
-        converter.attributeUpdated(new ZclAttribute(FAN_CONTROL, ATTR_BATTERYALARMMASK, "bla",
-                ZclDataType.BITMAP_32_BIT, false, true, false, true));
+        ZclAttribute attribute = new ZclAttribute(new ZclFanControlCluster(endpoint), ATTR_BATTERYALARMMASK, "bla",
+                ZclDataType.BITMAP_32_BIT, false, true, false, true);
+        converter.attributeUpdated(attribute, attribute.getLastValue());
         verify(thingHandler, never()).setChannelState(any(ChannelUID.class), any(State.class));
     }
 
     private ZclAttribute makeAlarmState(int bitmask) {
-        ZclAttribute attribute = new ZclAttribute(POWER_CONFIGURATION, ATTR_BATTERYALARMSTATE, "alarm_state",
-                ZclDataType.BITMAP_32_BIT, false, true, false, true);
+        ZclAttribute attribute = new ZclAttribute(new ZclPowerConfigurationCluster(endpoint), ATTR_BATTERYALARMSTATE,
+                "alarm_state", ZclDataType.BITMAP_32_BIT, false, true, false, true);
         attribute.updateValue(Integer.valueOf(bitmask));
         return attribute;
     }

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColorTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColorTest.java
@@ -15,7 +15,6 @@ package org.openhab.binding.zigbee.internal.converter;
 import static org.junit.Assert.assertEquals;
 
 import org.eclipse.smarthome.core.library.types.HSBType;
-import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
@@ -31,8 +30,10 @@ import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.zcl.ZclAttribute;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclColorControlCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclLevelControlCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclOnOffCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.ColorModeEnum;
-import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -59,15 +60,15 @@ public class ZigBeeConverterColorColorTest {
         Channel channel = ChannelBuilder.create(new ChannelUID("a:b:c:d"), "").build();
         converter.initialize(thingHandler, channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
 
-        ZclAttribute onAttribute = new ZclAttribute(ZclClusterType.ON_OFF, 0, "OnOff", ZclDataType.BOOLEAN, false,
-                false, false, false);
-        ZclAttribute levelAttribute = new ZclAttribute(ZclClusterType.LEVEL_CONTROL, 0, "Level", ZclDataType.BOOLEAN,
+        ZclAttribute onAttribute = new ZclAttribute(new ZclOnOffCluster(endpoint), 0, "OnOff", ZclDataType.BOOLEAN,
                 false, false, false, false);
+        ZclAttribute levelAttribute = new ZclAttribute(new ZclLevelControlCluster(endpoint), 0, "Level",
+                ZclDataType.BOOLEAN, false, false, false, false);
 
         // The following sequence checks that the level is ignored if the OnOff state is OFF
         // Note that the converter assumes the default HSB is 0,0,100, so this is returned first.
         onAttribute.updateValue(new Boolean(true));
-        converter.attributeUpdated(onAttribute);
+        converter.attributeUpdated(onAttribute, onAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(new ChannelUID("a:b:c:d"), channelCapture.getValue());
@@ -75,14 +76,14 @@ public class ZigBeeConverterColorColorTest {
 
         // Set the level to ensure that when no OnOff has been received, state updates are made
         levelAttribute.updateValue(new Integer(50));
-        converter.attributeUpdated(levelAttribute);
+        converter.attributeUpdated(levelAttribute, levelAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(2)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(new HSBType("0,0,20"), stateCapture.getValue());
 
         // Turn OFF, and state should be OFF (indeed 0,0,0)
         onAttribute.updateValue(new Boolean(false));
-        converter.attributeUpdated(onAttribute);
+        converter.attributeUpdated(onAttribute, onAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(3)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(new ChannelUID("a:b:c:d"), channelCapture.getValue());
@@ -90,20 +91,20 @@ public class ZigBeeConverterColorColorTest {
 
         // No update here since state is OFF, but we remember the level (20%)...
         levelAttribute.updateValue(new Integer(101));
-        converter.attributeUpdated(levelAttribute);
+        converter.attributeUpdated(levelAttribute, levelAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(3)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
 
         // When turned ON, we are set to the last level
         onAttribute.updateValue(new Boolean(true));
-        converter.attributeUpdated(onAttribute);
+        converter.attributeUpdated(onAttribute, onAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(4)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(new HSBType("0,0,40"), stateCapture.getValue());
 
         // Set the level and ensure it updates
         levelAttribute.updateValue(new Integer(50));
-        converter.attributeUpdated(levelAttribute);
+        converter.attributeUpdated(levelAttribute, levelAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(5)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(new HSBType("0,0,20"), stateCapture.getValue());
@@ -123,61 +124,61 @@ public class ZigBeeConverterColorColorTest {
         Channel channel = ChannelBuilder.create(new ChannelUID("a:b:c:d"), "").build();
         converter.initialize(thingHandler, channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
 
-        ZclAttribute colorModeAttribute = new ZclAttribute(ZclClusterType.COLOR_CONTROL, 8, "ColorMode",
+        ZclAttribute colorModeAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 8, "ColorMode",
                 ZclDataType.ENUMERATION_8_BIT, false, false, false, false);
-        ZclAttribute onAttribute = new ZclAttribute(ZclClusterType.ON_OFF, 0, "OnOff", ZclDataType.BOOLEAN, false,
-                false, false, false);
-        ZclAttribute levelAttribute = new ZclAttribute(ZclClusterType.LEVEL_CONTROL, 0, "Level", ZclDataType.BOOLEAN,
+        ZclAttribute onAttribute = new ZclAttribute(new ZclOnOffCluster(endpoint), 0, "OnOff", ZclDataType.BOOLEAN,
                 false, false, false, false);
-        ZclAttribute currentHueAttribute = new ZclAttribute(ZclClusterType.COLOR_CONTROL, 0, "CurrentHue",
+        ZclAttribute levelAttribute = new ZclAttribute(new ZclLevelControlCluster(endpoint), 0, "Level",
+                ZclDataType.BOOLEAN, false, false, false, false);
+        ZclAttribute currentHueAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 0, "CurrentHue",
                 ZclDataType.UNSIGNED_8_BIT_INTEGER, false, false, false, false);
-        ZclAttribute currentSaturationAttribute = new ZclAttribute(ZclClusterType.COLOR_CONTROL, 1, "CurrentSaturation",
-                ZclDataType.UNSIGNED_8_BIT_INTEGER, false, false, false, false);
-        ZclAttribute currentXAttribute = new ZclAttribute(ZclClusterType.COLOR_CONTROL, 3, "CurrentX",
+        ZclAttribute currentSaturationAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 1,
+                "CurrentSaturation", ZclDataType.UNSIGNED_8_BIT_INTEGER, false, false, false, false);
+        ZclAttribute currentXAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 3, "CurrentX",
                 ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, false, false);
-        ZclAttribute currentYAttribute = new ZclAttribute(ZclClusterType.COLOR_CONTROL, 4, "CurrentY",
+        ZclAttribute currentYAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 4, "CurrentY",
                 ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, false, false);
 
         // Update the color mode to COLOR_TEMPERATURE and ensure that the state is set to UNDEF
-        colorModeAttribute.updateValue(ColorModeEnum.COLORTEMPERATURE.getKey());
-        converter.attributeUpdated(colorModeAttribute);
+        colorModeAttribute.updateValue(ColorModeEnum.COLOR_TEMPERATURE.getKey());
+        converter.attributeUpdated(colorModeAttribute, colorModeAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(UnDefType.UNDEF, stateCapture.getValue());
 
         // Turn ON and ensure that the channel is not set
         onAttribute.updateValue(new Boolean(true));
-        converter.attributeUpdated(onAttribute);
+        converter.attributeUpdated(onAttribute, onAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
 
         // Set the level and ensure that the channel is not set
         levelAttribute.updateValue(new Integer(50));
-        converter.attributeUpdated(levelAttribute);
+        converter.attributeUpdated(levelAttribute, levelAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
 
         // Set the hue and ensure that the channel is not set
         currentHueAttribute.updateValue(new Integer(10));
-        converter.attributeUpdated(currentHueAttribute);
+        converter.attributeUpdated(currentHueAttribute, currentHueAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
 
         // Set the saturation and ensure that the channel is not set
         currentSaturationAttribute.updateValue(new Integer(10));
-        converter.attributeUpdated(currentSaturationAttribute);
+        converter.attributeUpdated(currentSaturationAttribute, currentSaturationAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
 
         // Set the currentX and ensure that the channel is not set
         currentXAttribute.updateValue(new Integer(10));
-        converter.attributeUpdated(currentXAttribute);
+        converter.attributeUpdated(currentXAttribute, currentXAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
 
         // Set the level and ensure that the channel is not set
         currentYAttribute.updateValue(new Integer(10));
-        converter.attributeUpdated(currentYAttribute);
+        converter.attributeUpdated(currentYAttribute, currentYAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
 

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperatureTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperatureTest.java
@@ -34,8 +34,8 @@ import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.zcl.ZclAttribute;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclColorControlCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.ColorModeEnum;
-import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -135,34 +135,34 @@ public class ZigBeeConverterColorTemperatureTest {
         Channel channel = ChannelBuilder.create(new ChannelUID("a:b:c:d"), "").build();
         converter.initialize(thingHandler, channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
 
-        ZclAttribute colorModeAttribute = new ZclAttribute(ZclClusterType.COLOR_CONTROL, 8, "ColorMode",
+        ZclAttribute colorModeAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 8, "ColorMode",
                 ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, false, false);
-        ZclAttribute colorTemperatureAttribute = new ZclAttribute(ZclClusterType.COLOR_CONTROL, 7, "ColorTemperature",
-                ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, false, false);
+        ZclAttribute colorTemperatureAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 7,
+                "ColorTemperature", ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, false, false);
 
         // Update the color mode to CURRENTHUE_AND_CURRENTSATURATION and ensure that the state is set to UNDEF
-        colorModeAttribute.updateValue(ColorModeEnum.CURRENTHUE_AND_CURRENTSATURATION.getKey());
-        converter.attributeUpdated(colorModeAttribute);
+        colorModeAttribute.updateValue(ColorModeEnum.CURRENT_HUE_AND_CURRENT_SATURATION.getKey());
+        converter.attributeUpdated(colorModeAttribute, colorModeAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(UnDefType.UNDEF, stateCapture.getValue());
 
         // Set the color temperature and ensure that the channel is not set
         colorTemperatureAttribute.updateValue(new Integer(100));
-        converter.attributeUpdated(colorTemperatureAttribute);
+        converter.attributeUpdated(colorTemperatureAttribute, colorTemperatureAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
 
         // Update the color mode to CURRENTX_AND_CURRENTY and ensure that the state is set to UNDEF
-        colorModeAttribute.updateValue(ColorModeEnum.CURRENTX_AND_CURRENTY.getKey());
-        converter.attributeUpdated(colorModeAttribute);
+        colorModeAttribute.updateValue(ColorModeEnum.CURRENT_X_AND_CURRENT_Y.getKey());
+        converter.attributeUpdated(colorModeAttribute, colorModeAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(2)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(UnDefType.UNDEF, stateCapture.getValue());
 
         // Set the color temperature and ensure that the channel is not set
         colorTemperatureAttribute.updateValue(new Integer(100));
-        converter.attributeUpdated(colorTemperatureAttribute);
+        converter.attributeUpdated(colorTemperatureAttribute, colorTemperatureAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(2)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
     }
@@ -181,14 +181,14 @@ public class ZigBeeConverterColorTemperatureTest {
         Channel channel = ChannelBuilder.create(new ChannelUID("a:b:c:d"), "").build();
         converter.initialize(thingHandler, channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
 
-        ZclAttribute colorTemperatureAttribute = new ZclAttribute(ZclClusterType.COLOR_CONTROL, 7, "ColorTemperature",
-                ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, false, false);
+        ZclAttribute colorTemperatureAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 7,
+                "ColorTemperature", ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, false, false);
 
         // Do not initialize the color mode
 
         // Set the color temperature and ensure that the channel is set
         colorTemperatureAttribute.updateValue(new Integer(250));
-        converter.attributeUpdated(colorTemperatureAttribute);
+        converter.attributeUpdated(colorTemperatureAttribute, colorTemperatureAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(convertMiredToPercent(converter, 250), stateCapture.getValue());
@@ -208,20 +208,20 @@ public class ZigBeeConverterColorTemperatureTest {
         Channel channel = ChannelBuilder.create(new ChannelUID("a:b:c:d"), "").build();
         converter.initialize(thingHandler, channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
 
-        ZclAttribute colorModeAttribute = new ZclAttribute(ZclClusterType.COLOR_CONTROL, 8, "ColorMode",
+        ZclAttribute colorModeAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 8, "ColorMode",
                 ZclDataType.ENUMERATION_8_BIT, false, false, false, false);
-        ZclAttribute colorTemperatureAttribute = new ZclAttribute(ZclClusterType.COLOR_CONTROL, 7, "ColorTemperature",
-                ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, false, false);
+        ZclAttribute colorTemperatureAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 7,
+                "ColorTemperature", ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, false, false);
 
         // Update the color mode to COLOR_TEMPERATURE and ensure that the state is not set
-        colorModeAttribute.updateValue(ColorModeEnum.COLORTEMPERATURE.getKey());
-        converter.attributeUpdated(colorModeAttribute);
+        colorModeAttribute.updateValue(ColorModeEnum.COLOR_TEMPERATURE.getKey());
+        converter.attributeUpdated(colorModeAttribute, colorModeAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(0)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
 
         // Set the color temperature and ensure that the channel is not set
         colorTemperatureAttribute.updateValue(new Integer(250));
-        converter.attributeUpdated(colorTemperatureAttribute);
+        converter.attributeUpdated(colorTemperatureAttribute, colorTemperatureAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(convertMiredToPercent(converter, 250), stateCapture.getValue());

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButtonTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButtonTest.java
@@ -13,18 +13,13 @@
 package org.openhab.binding.zigbee.internal.converter;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import com.zsmartsystems.zigbee.zcl.ZclAttribute;
-import com.zsmartsystems.zigbee.zcl.ZclAttributeListener;
-import com.zsmartsystems.zigbee.zcl.ZclCommandListener;
-import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
-import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -39,8 +34,13 @@ import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.ZigBeeProfileType;
+import com.zsmartsystems.zigbee.zcl.ZclAttribute;
+import com.zsmartsystems.zigbee.zcl.ZclAttributeListener;
 import com.zsmartsystems.zigbee.zcl.ZclCluster;
+import com.zsmartsystems.zigbee.zcl.ZclCommandListener;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclMultistateInputBasicCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.MoveHueCommand;
+import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
  * Unit tests for the {@link ZigBeeConverterGenericButton}.
@@ -283,18 +283,15 @@ public class ZigBeeConverterGenericButtonTest {
         mockCluster(768);
         converter.initializeConverter();
 
-        ZclAttribute attribute = new ZclAttribute(
-                ZclClusterType.MULTISTATE_INPUT__BASIC, 85, "foo",
-                ZclDataType.UNSIGNED_16_BIT_INTEGER,
-                false, false, true, true);
+        ZclAttribute attribute = new ZclAttribute(new ZclMultistateInputBasicCluster(endpoint), 85, "foo",
+                ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, true, true);
         attribute.updateValue(1);
-        converter.attributeUpdated(attribute);
+        converter.attributeUpdated(attribute, attribute.getLastValue());
 
         verify(thingHandler, times(1)).triggerChannel(channel.getUID(), CommonTriggerEvents.SHORT_PRESSED);
         verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.LONG_PRESSED);
         verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.DOUBLE_PRESSED);
     }
-
 
     @Test
     public void commandWithNonMatchingSpecifiedParamNameIsNotHandled() {
@@ -340,18 +337,15 @@ public class ZigBeeConverterGenericButtonTest {
         mockCluster(768);
         converter.initializeConverter();
 
-        ZclAttribute attribute = new ZclAttribute(
-                ZclClusterType.MULTISTATE_INPUT__BASIC, 85, "foo",
-                ZclDataType.UNSIGNED_16_BIT_INTEGER,
-                false, false, true, true);
+        ZclAttribute attribute = new ZclAttribute(new ZclMultistateInputBasicCluster(endpoint), 85, "foo",
+                ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, true, true);
         attribute.updateValue(2);
-        converter.attributeUpdated(attribute);
+        converter.attributeUpdated(attribute, attribute.getLastValue());
 
         verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.SHORT_PRESSED);
         verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.LONG_PRESSED);
         verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.DOUBLE_PRESSED);
     }
-
 
     @Test
     public void commandTypeIsCorrectlyDetected() {
@@ -391,12 +385,10 @@ public class ZigBeeConverterGenericButtonTest {
         mockCluster(768);
         converter.initializeConverter();
 
-        ZclAttribute attribute = new ZclAttribute(
-                ZclClusterType.MULTISTATE_INPUT__BASIC, 0x17, "foo",
-                ZclDataType.UNSIGNED_16_BIT_INTEGER,
-                false, false, true, true);
+        ZclAttribute attribute = new ZclAttribute(new ZclMultistateInputBasicCluster(endpoint), 0x17, "foo",
+                ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, true, true);
         attribute.updateValue(2);
-        converter.attributeUpdated(attribute);
+        converter.attributeUpdated(attribute, attribute.getLastValue());
 
         verify(thingHandler, times(0)).triggerChannel(channel.getUID(), CommonTriggerEvents.SHORT_PRESSED);
         verify(thingHandler, times(1)).triggerChannel(channel.getUID(), CommonTriggerEvents.LONG_PRESSED);

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoffTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoffTest.java
@@ -28,7 +28,7 @@ import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.zcl.ZclAttribute;
-import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclOnOffCluster;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -52,9 +52,9 @@ public class ZigBeeConverterSwitchOnoffTest {
         ZigBeeThingHandler thingHandler = Mockito.mock(ZigBeeThingHandler.class);
         Channel channel = new Channel(new ChannelUID("a:b:c:d"), "");
         converter.initialize(thingHandler, channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
-        ZclAttribute attribute = new ZclAttribute(ZclClusterType.ON_OFF, 0, "OnOff", ZclDataType.BOOLEAN, false, false,
-                false, false);
-        converter.attributeUpdated(attribute);
+        ZclAttribute attribute = new ZclAttribute(new ZclOnOffCluster(endpoint), 0, "OnOff", ZclDataType.BOOLEAN, false,
+                false, false, false);
+        converter.attributeUpdated(attribute, attribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
 

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperatureTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperatureTest.java
@@ -60,9 +60,8 @@ public class ZigBeeConverterTemperatureTest {
         ZclAttribute attribute = Mockito.mock(ZclAttribute.class);
         Mockito.when(attribute.getCluster()).thenReturn(ZclClusterType.TEMPERATURE_MEASUREMENT);
         Mockito.when(attribute.getId()).thenReturn(ZclTemperatureMeasurementCluster.ATTR_MEASUREDVALUE);
-        Mockito.when(attribute.getLastValue()).thenReturn(Integer.valueOf(2345));
 
-        converter.attributeUpdated(attribute);
+        converter.attributeUpdated(attribute, Integer.valueOf(2345));
         Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
 

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/warningdevice/ZigBeeConverterWarningDeviceTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/warningdevice/ZigBeeConverterWarningDeviceTest.java
@@ -100,7 +100,7 @@ public class ZigBeeConverterWarningDeviceTest {
 
         // Squawk header is composed of: (a) squawk level, (b) strobe, (3) warning mode
         // In our case: squawk level medium: 1=0b01; strobe false: 0=0b00; squawk mode disarmed: 6=0b0001
-        verify(cluster).squawkCommand(0b01000001);
+        verify(cluster).squawk(0b01000001);
     }
 
     @Test


### PR DESCRIPTION
This PR adjusts the binding to be compatible with the changes introduced into Zsmartsystems by
https://github.com/zsmartsystems/com.zsmartsystems.zigbee/pull/572

~Before this PR can be merged, the dependency to zsmartsystems has to be raised to 1.2.0 as well, see
https://github.com/openhab/openhab-deps-repo/pull/14~

And a release of the 1.2.0 ZSS version has to be deployed.

Also-by: Henning Sudbrock <henning.sudbrock@telekom.de>
Signed-off-by: Stefan Triller <stefan.triller@telekom.de>