### PR TITLE
Fixed NPE in ZigbeeIsAliveTracker.scheduleTask(...)

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigbeeIsAliveTracker.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigbeeIsAliveTracker.java
@@ -58,7 +58,7 @@ public class ZigbeeIsAliveTracker {
 
     private void scheduleTask(ZigBeeThingHandler handler) {
         ScheduledFuture<?> existingTask = scheduledTasks.get(handler);
-        if (existingTask == null) {
+        if (existingTask == null && handlerIntervalMapping.containsKey(handler)) {
             int interval = handlerIntervalMapping.get(handler);
             logger.debug("Scheduling timeout task for thingUID={} in {} seconds",
                     handler.getThing().getUID().getAsString(), interval);


### PR DESCRIPTION
Resolves #444 

In scheduleTask now there is a check to ensure that the timeout task is
scheduled only if the handler is known to the tracker.

Signed-off-by: Tommaso Travaglino <tommaso.travaglino@telekom.de>