### PR TITLE
Fix ignores and classpath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-target/
+.idea
+.DS_Store
+*.iml
 bin/
-*/OSGI-INF/*.xml
+target/
+**/.settings/org.eclipse.*

--- a/org.openhab.binding.zigbee/.classpath
+++ b/org.openhab.binding.zigbee/.classpath
@@ -28,5 +28,11 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
* Ignore commonly generated files by Eclipse, IntelliJ and macOS (we also use these with openhab2-addons)
* Add missing classpath entry which is automatically added after importing the Maven projects
* Remove OSGI-INF ignore for content that is now generated in the target dir