### PR TITLE
Read multiple attributes at once during discovery

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -232,6 +232,7 @@ public class ZigBeeBindingConstants {
     public static final String THING_PROPERTY_INSTALLCODE = "zigbee_installcode";
     public static final String THING_PROPERTY_STACKCOMPLIANCE = "zigbee_stkcompliance";
     public static final String THING_PROPERTY_DEVICE_INITIALIZED = "zigbee_device_initialised";
+    public static final String THING_PROPERTY_MANUFACTURERCODE = "zigbee_manufacturercode";
 
     // List of all configuration parameters
     public static final String CONFIGURATION_PANID = "zigbee_panid";


### PR DESCRIPTION
This replaces #400 and resolves #399 by using a multi-attribute read request in the `ZigBeeNodePropertyDiscoverer`. I did some smaller refactorings in that class as well, and used separate commits for those to ease the review.

Please note that this PR needs the new ZSS version before it can be merged (the new version that supports multi-attribute-read commands).

The basic idea is to do a multi-attribute read first, and then read each attribute separately from the ZSS layer as is already done before this PR. If the multi-attribute read succeeds, then the subsequent separate reading of each attribute will be obtained from the cache; if the multi-attribute read fails, then the subsequent separate readings serve as a fallback.

As a small additional change I added in this PR is adding a thing property for the manufacturer code obtained from the node descriptor (as I think that this is helpful in particular with the upcoming support for manufacturer-specific clusters).

Also-by: Henning Sudbrock
Signed-off-by: Chris Jackson <chris@cd-jackson.com>