### PR TITLE
Illuminance configuration improvements

### DIFF
--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -352,6 +352,16 @@ then
 end
 ```
 
+## Reporting and Polling
+
+ZigBee has a standard way of configuring how a device sends status reports to the binding - this is called Reporting. Reporting is configured using three pieces of information -:
+
+* Minimum Reporting Period: This is the minimum time between reports that the device will send updates. So, if data is changing regularly, this will prevent the binding receiving a flood of reports.
+* Maximum Reporting Period: This is the maximum time between reports that the device will send updates. If the data never changes, then the device will still send an update at this rate. This is important so that the binding knows the device has not failed, so it should not be set too long (normally a couple of hours will be fine).
+* Change: This is only applicable for "Analogue" data such as temperature, humidity, power. If the value changes by this amount since the last update, then an update will be sent so long as the minimum reporting period has passed.
+
+Polling may be used by the binding to request data from the device. Polling is normally only used if reporting doesn't work for some reason. This may happen if the reporting table in a device is full - if the binding detects this, it will increase the polling rate.
+
 
 ## When things don't appear to be working
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
@@ -312,10 +312,8 @@ public abstract class ZigBeeBaseChannelConverter {
     /**
      * Gets the polling period for this channel in seconds. Normally this should be left at the default
      * ({@link ZigBeeBaseChannelConverter#POLLING_PERIOD_DEFAULT}), however if the channel does not support reporting,
-     * it can be set to a higher
-     * period such as {@link ZigBeeBaseChannelConverter#POLLING_PERIOD_HIGH} during the converter initialisation. Any
-     * period may be used, however
-     * it is recommended to use these standard settings.
+     * it can be set to a higher period such as {@link ZigBeeBaseChannelConverter#POLLING_PERIOD_HIGH} during the
+     * converter initialisation. Any period may be used, however it is recommended to use these standard settings.
      *
      * @return the polling period for this channel in seconds
      */

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
@@ -127,7 +127,18 @@ public class ZigBeeConverterIlluminance extends ZigBeeBaseChannelConverter imple
     @Override
     public void updateConfiguration(@NonNull Configuration currentConfiguration,
             Map<String, Object> updatedParameters) {
-        configReporting.updateConfiguration(currentConfiguration, updatedParameters);
+        if (configReporting.updateConfiguration(currentConfiguration, updatedParameters)) {
+            try {
+                ZclAttribute attribute = cluster.getAttribute(ZclIlluminanceMeasurementCluster.ATTR_MEASUREDVALUE);
+                CommandResult reportingResponse;
+                reportingResponse = attribute.setReporting(configReporting.getReportingTimeMin(),
+                        configReporting.getReportingTimeMax(), configReporting.getReportingChange()).get();
+                handleReportingResponse(reportingResponse, configReporting.getPollingPeriod(),
+                        configReporting.getReportingTimeMax());
+            } catch (InterruptedException | ExecutionException e) {
+                logger.debug("{}: Illuminance measurement exception setting reporting", endpoint.getIeeeAddress(), e);
+            }
+        }
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
@@ -161,8 +161,7 @@ public class ZigBeeConverterIlluminance extends ZigBeeBaseChannelConverter imple
         if (attribute.getCluster() == ZclClusterType.ILLUMINANCE_MEASUREMENT
                 && attribute.getId() == ZclIlluminanceMeasurementCluster.ATTR_MEASUREDVALUE) {
             Integer value = (Integer) val;
-            double illuminance = Math.pow(10.0, value / 10000.0) - 1;
-            updateChannelState(new DecimalType(illuminance));
+            updateChannelState(new DecimalType(BigDecimal.valueOf(value, 2)));
         }
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -135,7 +135,7 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
         currentOnOffState.set(true);
 
         // Create a configuration handler and get the available options
-        configReporting = new ZclReportingConfig();
+        configReporting = new ZclReportingConfig(channel);
         configLevelControl = new ZclLevelControlConfig();
         configLevelControl.initialize(clusterLevelControl);
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -116,7 +116,7 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
             clusterOnOffClient.addCommandListener(this);
         }
 
-        configReporting = new ZclReportingConfig();
+        configReporting = new ZclReportingConfig(channel);
 
         configOptions = new ArrayList<>();
         configOptions.addAll(configReporting.getConfiguration());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclClusterConfigHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclClusterConfigHandler.java
@@ -56,6 +56,7 @@ public interface ZclClusterConfigHandler {
      *
      * @param currentConfiguration the current {@link Configuration}
      * @param updatedParameters a map containing the updated configuration parameters to be set
+     * @return true if the configuration was updated
      */
-    void updateConfiguration(@NonNull Configuration currentConfiguration, Map<String, Object> updatedParameters);
+    boolean updateConfiguration(@NonNull Configuration currentConfiguration, Map<String, Object> updatedParameters);
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclDoorLockConfig.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclDoorLockConfig.java
@@ -103,8 +103,9 @@ public class ZclDoorLockConfig implements ZclClusterConfigHandler {
     }
 
     @Override
-    public void updateConfiguration(@NonNull Configuration currentConfiguration,
+    public boolean updateConfiguration(@NonNull Configuration currentConfiguration,
             Map<String, Object> updatedParameters) {
+        boolean updated = false;
         for (Entry<String, Object> configurationParameter : updatedParameters.entrySet()) {
             if (!configurationParameter.getKey().startsWith(CONFIG_ID)) {
                 continue;
@@ -148,7 +149,10 @@ public class ZclDoorLockConfig implements ZclClusterConfigHandler {
 
             if (response != null) {
                 currentConfiguration.put(configurationParameter.getKey(), response);
+                updated = true;
             }
         }
+
+        return updated;
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclLevelControlConfig.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclLevelControlConfig.java
@@ -129,9 +129,10 @@ public class ZclLevelControlConfig implements ZclClusterConfigHandler {
     }
 
     @Override
-    public void updateConfiguration(@NonNull Configuration currentConfiguration,
+    public boolean updateConfiguration(@NonNull Configuration currentConfiguration,
             Map<String, Object> configurationParameters) {
 
+        boolean updated = false;
         for (Entry<String, Object> configurationParameter : configurationParameters.entrySet()) {
             if (!configurationParameter.getKey().startsWith(CONFIG_ID)) {
                 continue;
@@ -183,8 +184,11 @@ public class ZclLevelControlConfig implements ZclClusterConfigHandler {
 
             if (response != null) {
                 currentConfiguration.put(configurationParameter.getKey(), BigInteger.valueOf(response));
+                updated = true;
             }
         }
+
+        return updated;
     }
 
     /**

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclReportingConfig.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclReportingConfig.java
@@ -70,16 +70,16 @@ public class ZclReportingConfig implements ZclClusterConfigHandler {
     public ZclReportingConfig(Channel channel) {
         Configuration configuration = channel.getConfiguration();
         if (configuration.containsKey(CONFIG_REPORTINGMIN)) {
-            reportingTimeMin = Integer.parseInt((String) configuration.get(CONFIG_REPORTINGMIN));
+            reportingTimeMin = ((BigDecimal) configuration.get(CONFIG_REPORTINGMIN)).intValue();
         }
         if (configuration.containsKey(CONFIG_REPORTINGMIN)) {
-            reportingTimeMin = Integer.parseInt((String) configuration.get(CONFIG_REPORTINGMAX));
+            reportingTimeMin = ((BigDecimal) configuration.get(CONFIG_REPORTINGMAX)).intValue();
         }
         if (configuration.containsKey(CONFIG_REPORTINGMIN)) {
-            reportingTimeMin = Integer.parseInt((String) configuration.get(CONFIG_REPORTINGCHANGE));
+            reportingTimeMin = ((BigDecimal) configuration.get(CONFIG_REPORTINGCHANGE)).intValue();
         }
         if (configuration.containsKey(CONFIG_POLLING)) {
-            pollingPeriod = Integer.parseInt((String) configuration.get(CONFIG_POLLING));
+            pollingPeriod = ((BigDecimal) configuration.get(CONFIG_POLLING)).intValue();
         }
     }
 
@@ -137,9 +137,10 @@ public class ZclReportingConfig implements ZclClusterConfigHandler {
     }
 
     @Override
-    public void updateConfiguration(@NonNull Configuration currentConfiguration,
+    public boolean updateConfiguration(@NonNull Configuration currentConfiguration,
             Map<String, Object> configurationParameters) {
 
+        boolean updated = false;
         for (Entry<String, Object> configurationParameter : configurationParameters.entrySet()) {
             if (!configurationParameter.getKey().startsWith(CONFIG_ID)) {
                 continue;
@@ -154,21 +155,27 @@ public class ZclReportingConfig implements ZclClusterConfigHandler {
             switch (configurationParameter.getKey()) {
                 case CONFIG_REPORTINGMIN:
                     reportingTimeMin = ((BigDecimal) (configurationParameter.getValue())).intValue();
+                    updated = true;
                     break;
                 case CONFIG_REPORTINGMAX:
                     reportingTimeMax = ((BigDecimal) (configurationParameter.getValue())).intValue();
+                    updated = true;
                     break;
                 case CONFIG_REPORTINGCHANGE:
                     reportingChange = ((BigDecimal) (configurationParameter.getValue())).intValue();
+                    updated = true;
                     break;
                 case CONFIG_POLLING:
                     pollingPeriod = ((BigDecimal) (configurationParameter.getValue())).intValue();
+                    updated = true;
                     break;
                 default:
                     logger.warn("Unhandled configuration property {}", configurationParameter.getKey());
                     break;
             }
         }
+
+        return updated;
     }
 
     /**

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclReportingConfig.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclReportingConfig.java
@@ -24,6 +24,7 @@ import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameterBuilder;
 import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.thing.Channel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,6 +67,22 @@ public class ZclReportingConfig implements ZclClusterConfigHandler {
     private BigDecimal minimumChange;
     private BigDecimal maximumChange;
 
+    public ZclReportingConfig(Channel channel) {
+        Configuration configuration = channel.getConfiguration();
+        if (configuration.containsKey(CONFIG_REPORTINGMIN)) {
+            reportingTimeMin = Integer.parseInt((String) configuration.get(CONFIG_REPORTINGMIN));
+        }
+        if (configuration.containsKey(CONFIG_REPORTINGMIN)) {
+            reportingTimeMin = Integer.parseInt((String) configuration.get(CONFIG_REPORTINGMAX));
+        }
+        if (configuration.containsKey(CONFIG_REPORTINGMIN)) {
+            reportingTimeMin = Integer.parseInt((String) configuration.get(CONFIG_REPORTINGCHANGE));
+        }
+        if (configuration.containsKey(CONFIG_POLLING)) {
+            pollingPeriod = Integer.parseInt((String) configuration.get(CONFIG_POLLING));
+        }
+    }
+
     @Override
     public boolean initialize(ZclCluster cluster) {
         return true;
@@ -73,7 +90,7 @@ public class ZclReportingConfig implements ZclClusterConfigHandler {
 
     /**
      * Sets the analogue reporting values
-     * 
+     *
      * @param defaultChange the default value
      * @param minimumChange the minimum reporting value
      * @param maximumChange the maximum reporting value

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclReportingConfig.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclReportingConfig.java
@@ -72,10 +72,10 @@ public class ZclReportingConfig implements ZclClusterConfigHandler {
         if (configuration.containsKey(CONFIG_REPORTINGMIN)) {
             reportingTimeMin = ((BigDecimal) configuration.get(CONFIG_REPORTINGMIN)).intValue();
         }
-        if (configuration.containsKey(CONFIG_REPORTINGMIN)) {
+        if (configuration.containsKey(CONFIG_REPORTINGMAX)) {
             reportingTimeMin = ((BigDecimal) configuration.get(CONFIG_REPORTINGMAX)).intValue();
         }
-        if (configuration.containsKey(CONFIG_REPORTINGMIN)) {
+        if (configuration.containsKey(CONFIG_REPORTINGCHANGE)) {
             reportingTimeMin = ((BigDecimal) configuration.get(CONFIG_REPORTINGCHANGE)).intValue();
         }
         if (configuration.containsKey(CONFIG_POLLING)) {

--- a/org.openhab.binding.zigbee/src/main/resources/ESH-INF/thing/channels.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/ESH-INF/thing/channels.xml
@@ -168,9 +168,9 @@
     <channel-type id="measurement_illuminance">
         <item-type>Number</item-type>
         <label>Illuminance</label>
-        <description>Indicates the current illuminance</description>
+        <description>Indicates the current illuminance in lux</description>
         <category></category>
-        <state pattern="%.1f" readOnly="true" />
+        <state pattern="%.0f" readOnly="true" />
     </channel-type>
     
     <!-- Atmospheric Pressure Channel -->

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/config/ZclReportingConfigTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/config/ZclReportingConfigTest.java
@@ -79,9 +79,9 @@ public class ZclReportingConfigTest {
         Channel channel = Mockito.mock(Channel.class);
         Configuration configuration = new Configuration();
         Map<String, Object> properties = new HashMap<>();
-        properties.put("zigbee_reporting_min", "12");
-        properties.put("zigbee_reporting_max", "34");
-        properties.put("zigbee_reporting_change", "56");
+        properties.put("zigbee_reporting_min", BigDecimal.valueOf(12));
+        properties.put("zigbee_reporting_max", BigDecimal.valueOf(34));
+        properties.put("zigbee_reporting_change", BigDecimal.valueOf(56));
         configuration.setProperties(properties);
         Mockito.when(channel.getConfiguration()).thenReturn(configuration);
         ZclReportingConfig config = new ZclReportingConfig(channel);

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/config/ZclReportingConfigTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/config/ZclReportingConfigTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.thing.Channel;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -40,7 +41,9 @@ public class ZclReportingConfigTest {
     public void getConfiguration() {
         ZclLevelControlCluster cluster = Mockito.mock(ZclLevelControlCluster.class);
 
-        ZclReportingConfig config = new ZclReportingConfig();
+        Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(channel.getConfiguration()).thenReturn(Mockito.mock(Configuration.class));
+        ZclReportingConfig config = new ZclReportingConfig(channel);
         config.initialize(cluster);
         List<ConfigDescriptionParameter> configuration = config.getConfiguration();
 
@@ -53,7 +56,9 @@ public class ZclReportingConfigTest {
     public void getConfigurationAnalogue() {
         ZclLevelControlCluster cluster = Mockito.mock(ZclLevelControlCluster.class);
 
-        ZclReportingConfig config = new ZclReportingConfig();
+        Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(channel.getConfiguration()).thenReturn(Mockito.mock(Configuration.class));
+        ZclReportingConfig config = new ZclReportingConfig(channel);
         config.initialize(cluster);
 
         config.setAnalogue(BigDecimal.valueOf(1), BigDecimal.valueOf(2), BigDecimal.valueOf(3));
@@ -71,12 +76,19 @@ public class ZclReportingConfigTest {
     public void setReportingTime() {
         ZclLevelControlCluster cluster = Mockito.mock(ZclLevelControlCluster.class);
 
-        ZclReportingConfig config = new ZclReportingConfig();
+        Channel channel = Mockito.mock(Channel.class);
+        Configuration configuration = new Configuration();
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("zigbee_reporting_min", "12");
+        properties.put("zigbee_reporting_max", "34");
+        properties.put("zigbee_reporting_change", "56");
+        configuration.setProperties(properties);
+        Mockito.when(channel.getConfiguration()).thenReturn(configuration);
+        ZclReportingConfig config = new ZclReportingConfig(channel);
         config.initialize(cluster);
         config.getConfiguration();
 
-        Configuration configuration = new Configuration();
-
+        configuration = new Configuration();
         Map<String, Object> parameters = new HashMap<>();
         parameters.put(CONFIG_REPORTINGMIN, new BigDecimal(45));
         parameters.put(CONFIG_REPORTINGMAX, new BigDecimal(95));


### PR DESCRIPTION
This PR includes changes to the reporting configuration class ```ZclReportingConfig```. This now supports changing the reporting change, and also the reporting min/max times.

@triller-telekom I'd welcome your review on this.

Note that there will be a subsequent PR to improve the handling of reporting configuration which is  possible with the way reporting is now handled in the latest ZSS, but I'd like to get this merged as it already covers more than one feature.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>
