### PR TITLE
Fix illuminance conversion

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
@@ -160,8 +160,7 @@ public class ZigBeeConverterIlluminance extends ZigBeeBaseChannelConverter imple
         logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getCluster() == ZclClusterType.ILLUMINANCE_MEASUREMENT
                 && attribute.getId() == ZclIlluminanceMeasurementCluster.ATTR_MEASUREDVALUE) {
-            Integer value = (Integer) val;
-            updateChannelState(new DecimalType(BigDecimal.valueOf(value, 2)));
+            updateChannelState(new DecimalType(Math.pow(10.0, (Integer) val / 10000.0) - 1));
         }
     }
 }


### PR DESCRIPTION
This fixes a bug in the reporting of the Illuminance data. This was previously incorrectly reported and now uses the ZigBee formula to calculate lux from the returned value.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>