### PR TITLE
Fix reporting configuration

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -66,6 +66,8 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
 
     @Override
     public boolean initializeDevice() {
+        ZclReportingConfig reporting = new ZclReportingConfig(channel);
+
         ZclLevelControlCluster serverClusterLevelControl = (ZclLevelControlCluster) endpoint
                 .getInputCluster(ZclLevelControlCluster.CLUSTER_ID);
         if (serverClusterLevelControl == null) {
@@ -86,9 +88,8 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
                 ZclAttribute attribute = serverClusterLevelControl
                         .getAttribute(ZclLevelControlCluster.ATTR_CURRENTLEVEL);
                 CommandResult reportingResponse = attribute
-                        .setReporting(configReporting.getReportingTimeMin(), configReporting.getReportingTimeMax(), 1)
-                        .get();
-                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, configReporting.getPollingPeriod());
+                        .setReporting(reporting.getReportingTimeMin(), reporting.getReportingTimeMax(), 1).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, reporting.getPollingPeriod());
             } else {
                 pollingPeriod = POLLING_PERIOD_HIGH;
                 logger.debug("{}: Failed to bind level control cluster", endpoint.getIeeeAddress());
@@ -104,9 +105,8 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter imple
                 // Configure reporting
                 ZclAttribute attribute = serverClusterOnOff.getAttribute(ZclOnOffCluster.ATTR_ONOFF);
                 CommandResult reportingResponse = attribute
-                        .setReporting(configReporting.getReportingTimeMin(), configReporting.getReportingTimeMax())
-                        .get();
-                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, configReporting.getPollingPeriod());
+                        .setReporting(reporting.getReportingTimeMin(), reporting.getReportingTimeMax()).get();
+                handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, reporting.getPollingPeriod());
             } else {
                 pollingPeriod = POLLING_PERIOD_HIGH;
                 logger.debug("{}: Failed to bind on off control cluster", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -80,6 +80,8 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
             return false;
         }
 
+        ZclReportingConfig reporting = new ZclReportingConfig(channel);
+
         if (serverCluster != null) {
             try {
                 CommandResult bindResponse = bind(serverCluster).get();
@@ -87,9 +89,8 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
                     // Configure reporting
                     ZclAttribute attribute = serverCluster.getAttribute(ZclOnOffCluster.ATTR_ONOFF);
                     CommandResult reportingResponse = attribute
-                            .setReporting(configReporting.getReportingTimeMin(), configReporting.getReportingTimeMax())
-                            .get();
-                    handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, configReporting.getPollingPeriod());
+                            .setReporting(reporting.getReportingTimeMin(), reporting.getReportingTimeMax()).get();
+                    handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, reporting.getPollingPeriod());
                 } else {
                     logger.debug("{}: Error 0x{} setting server binding", endpoint.getIeeeAddress(),
                             Integer.toHexString(bindResponse.getStatusCode()));


### PR DESCRIPTION
Ensures ```ZclReportingConfig``` is instantiated before use.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>