### PR TITLE
Add support for level control server

### DIFF
--- a/org.openhab.binding.zigbee/src/main/resources/ESH-INF/thing/philips/rwl021.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/ESH-INF/thing/philips/rwl021.xml
@@ -6,6 +6,14 @@
    <thing-type id="philips_rwl021" listed="false">
       <label>Hue Dimmer Switch</label>
       <channels>
+         <channel id="switch_level" typeId="switch_level">
+            <label>Level Control</label>
+            <description></description>
+            <properties>
+               <property name="zigbee_endpoint">1</property>
+            </properties>
+         </channel>
+
          <channel id="buttonI" typeId="system.button">
             <label>Button I</label>
             <description>Top Button 'I'</description>


### PR DESCRIPTION
This adds support in the level control converter for the server side - ie to receive commands sent by a client.
The converter is instantiated as either a client or server side - if a client, it will look at the remote server attributes, and if it's a server, it will receive the remote client commands.

@triller-telekom would you mind reviewing please.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>