### PR TITLE
Ensure leave command is send to the device

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -637,7 +637,6 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
     @Override
     public void handleRemoval() {
         coordinatorHandler.leave(nodeIeeeAddress);
-        coordinatorHandler.removeNode(nodeIeeeAddress);
         updateStatus(ThingStatus.REMOVED);
     }
 


### PR DESCRIPTION
Once a Thing is about to be removed, we send out a leave command, however
this is done asynchronously. Meanwhile we delete the node from the
ZigbeeNetworkManager. Now the ZigbeeTransactionManager wants to dispatch the
leave command over the air and fails to do so because the destination is unknown

ZigBeeTransactionManager] - Attempt to send command with unknown destination: ZigBeeTransaction [queueTime=6, state=DISPATCHED, sendCnt=1, command=ManagementLeaveRequest [0/0 -> 23592/0, cluster=0034, TID=7A, deviceAddress=00124B00043D6DE1, removeChildrenRejoin=false]]

The removeNode call is unneccessary because if the leave command gets a reply
the node will be removed anyhow.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>