### PR TITLE
Disable local loopback of broadcast messages with Ember NCP

### DIFF
--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
@@ -104,6 +104,9 @@ public class EmberHandler extends ZigBeeCoordinatorHandler implements FirmwareUp
 
         dongle.updateDefaultConfiguration(EzspConfigId.EZSP_CONFIG_TX_POWER_MODE, config.zigbee_powermode);
 
+        // We don't need to receive broadcast and multicast messages that we send
+        dongle.passLoopbackMessages(false);
+
         // Set the child aging timeout.
         // Formulae is EZSP_CONFIG_END_DEVICE_POLL_TIMEOUT * 2 ^ EZSP_CONFIG_END_DEVICE_POLL_TIMEOUT_SHIFT
         int pollTimeoutValue;


### PR DESCRIPTION
Requires Z-Smart Systems libraries ```1.2.5```.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>