### PR TITLE
Add support for IncreaseDecreaseType in LevelControl

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -76,6 +77,9 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
     // The number of milliseconds between state updates into OH when handling level control changes at a rate
     private static final int STATE_UPDATE_RATE = 50;
 
+    // The number of milliseconds after the last IncreaseDecreaseType is received before sending the Stop command
+    private static final int INCREASEDECREASE_TIMEOUT = 200;
+
     private ZclOnOffCluster clusterOnOffClient;
     private ZclLevelControlCluster clusterLevelControlClient;
 
@@ -91,6 +95,8 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
     private final AtomicBoolean currentOnOffState = new AtomicBoolean(true);
 
     private PercentType lastLevel = PercentType.HUNDRED;
+
+    private Command lastCommand;
 
     private ScheduledExecutorService updateScheduler;
     private ScheduledFuture<?> updateTimer = null;
@@ -330,10 +336,15 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
             handleOnOffCommand((OnOffType) command);
         } else if (command instanceof PercentType) {
             handlePercentCommand((PercentType) command);
+        } else if (command instanceof IncreaseDecreaseType) {
+            handleIncreaseDecreaseCommand((IncreaseDecreaseType) command);
         } else {
-            logger.warn("{}: Level converter only accepts PercentType and OnOffType - not {}",
+            logger.warn("{}: Level converter only accepts PercentType, IncreaseDecreaseType and OnOffType - not {}",
                     endpoint.getIeeeAddress(), command.getClass().getSimpleName());
         }
+
+        // Some functionality (eg IncreaseDecrease) requires that we know the last command received
+        lastCommand = command;
     }
 
     /**
@@ -372,6 +383,33 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
             clusterLevelControlServer.moveToLevelCommand(percentToLevel(percent),
                     configLevelControl.getDefaultTransitionTime());
         }
+    }
+
+    /**
+     * The IncreaseDecreaseType in openHAB is defined as a STEP command. however we want to use this for the Move/Stop
+     * command which is not available in openHAB.
+     * When the first IncreaseDecreaseType is received, we send the Move command and start a timer to send the Stop
+     * command when no further IncreaseDecreaseType commands are received.
+     * We use the lastCommand to check if the current command is the same IncreaseDecreaseType, and if so we just
+     * restart the timer.
+     * When the timer times out and sends the Stop command, it also sets lastCommand to null.
+     *
+     * @param cmdIncreaseDecrease the command received
+     */
+    private void handleIncreaseDecreaseCommand(IncreaseDecreaseType cmdIncreaseDecrease) {
+        if (!cmdIncreaseDecrease.equals(lastCommand)) {
+            switch (cmdIncreaseDecrease) {
+                case INCREASE:
+                    clusterLevelControlServer.moveWithOnOffCommand(0, 50);
+                    break;
+                case DECREASE:
+                    clusterLevelControlServer.moveWithOnOffCommand(1, 50);
+                    break;
+                default:
+                    break;
+            }
+        }
+        startStopTimer(INCREASEDECREASE_TIMEOUT);
     }
 
     @Override
@@ -631,10 +669,7 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
      * @param delay the number of milliseconds to wait before setting the value to OFF
      */
     private void startOffTimer(int delay) {
-        if (updateTimer != null) {
-            updateTimer.cancel(true);
-            updateTimer = null;
-        }
+        stopTransitionTimer();
 
         updateTimer = updateScheduler.schedule(new Runnable() {
             @Override
@@ -654,10 +689,7 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
      * @param effectVariant the effect variant
      */
     private void startOffEffect(int effectId, int effectVariant) {
-        if (updateTimer != null) {
-            updateTimer.cancel(true);
-            updateTimer = null;
-        }
+        stopTransitionTimer();
 
         int effect = effectId << 8 + effectVariant;
 
@@ -681,4 +713,24 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
                 break;
         }
     }
+
+    /**
+     * Starts a timer after which the Stop command will be sent
+     *
+     * @param delay the number of milliseconds to wait before setting the value to OFF
+     */
+    private void startStopTimer(int delay) {
+        stopTransitionTimer();
+
+        updateTimer = updateScheduler.schedule(new Runnable() {
+            @Override
+            public void run() {
+                logger.debug("{}: IncreaseDecrease Stop timer expired", endpoint.getIeeeAddress());
+                clusterLevelControlServer.stop2Command();
+                lastCommand = null;
+                updateTimer = null;
+            }
+        }, delay, TimeUnit.MILLISECONDS);
+    }
+
 }


### PR DESCRIPTION
Adds support for the ```LevelControlCluster``` ```Move``` command. This really requires https://github.com/openhab/openhab-core/pull/1097 to allow support of the ```Stop``` command otherwise it's not of use, so I don't plan to merge this until there is a mechanism for stopping the travel.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>