### PR TITLE
update readme

### DIFF
--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -185,40 +185,40 @@ The thing type is ```coordinator_xbee```. Other XBee S2C devices should also be 
 
 The following devices have been tested by openHAB users with the binding. The absence of a device in this list does not mean it will not work - if the device is a standard ZigBee device similar to ones on this list, then it should work.
 
-| Device                                         | Description                                         |
-| ---------------------------------------------- | --------------------------------------------------- |
-| Busch-Jaeger 6711 U                            | Relay Insert                                        |
-| Busch-Jaeger 6715 U                            | LED-Dimmer Insert                                   |
-| Busch-Jaeger 6735                              | Control Element (1-channel)                         |
-| Busch-Jaeger 6735/01                           | Control Element (1-channel, battery-operated)       |
-| Busch-Jaeger 6736                              | Control Element (2-channel)                         |
-| Eurotronic Spirit Thermostat                   | Radiator Thermostat                                 |
-| GE Bulbs                                       |                                                     |
-| GE Tapt Wall Switch                            | On/Off Switch                                       |
-| Hue Bulbs                                      | Color LED Bulb                                      |
-| Hue Dimmer                                     | Hue Dimmer Switch Remote *[<sup>[2]</sup>](#note2)* |
-| Hue Motion Sensor                              | Motion and Luminance sensor                         |
-| Innr Bulbs                                     | *[<sup>[1]</sup>](#note1)*                          |
-| Innr SP 120                                    | Smart Plug *[<sup>[1]</sup>](#note1)*               |
-| Lupus Small Zigbee Temperature Sensor 12314    | Lupus-Electronics Temperature and Humidity sensor   |
-| Osram Bulbs                                    |                                                     |
-| Osram Motion Sensor                            | Osram Smart+ Motion Sensor                          |
-| SmartThings Plug                               | Metered Plug                                        |
-| SmartThings Motion Sensor                      | CentraLite 3325-S Motion and Temperature sensor     |
-| SmartThings Contact Sensor                     | Contact and Temperature sensor                      |
-| Telkonet EcoInsight Thermostat                 | Intelligent HVAC Thermostat                         |
-| Tradfri Bulbs                                  |                                                     |
-| Tradfri Motion Sensor                          |                                                     |
-| Tradfri Outlet                                 |                                                     |
-| Tradfri Repeater                               |                                                     |
-| Trust Bulbs                                    | *[<sup>[1]</sup> ](#note1)*                         |
-| Ubisys modules                                 | D1 Dimmer, S1/S2 Switch modules                     |
-| Xiaomi Aqara Door and Window Sensor            |                                                     |
-| Xiaomi Aqara Temperature and Humidity Sensor   |                                                     |
-| Xiaomi Aqara Human Motion Sensor               |                                                     |
-| Xiaomi Aqara Wireless Mini Switch              |                                                     |
-| Xiaomi Aqara Wireless Remote Switch            | Double Rocker variant                               |
-| Shenzhen Ksentry Electronics On Off Controller | Relay                                               |
+| Device                                         | Description                                           |
+| ---------------------------------------------- | ----------------------------------------------------- |
+| Busch-Jaeger 6711 U                            | Relay Insert                                          |
+| Busch-Jaeger 6715 U                            | LED-Dimmer Insert                                     |
+| Busch-Jaeger 6735                              | Control Element (1-channel)                           |
+| Busch-Jaeger 6735/01                           | Control Element (1-channel, battery-operated)         |
+| Busch-Jaeger 6736                              | Control Element (2-channel)                           |
+| Eurotronic Spirit Thermostat                   | Radiator Thermostat                                   |
+| GE Bulbs                                       |                                                       |
+| GE Tapt Wall Switch                            | On/Off Switch                                         |
+| Hue Bulbs                                      | Color LED Bulb                                        |
+| Hue Dimmer                                     | Hue Dimmer Switch Remote *[<sup>[2]</sup>](#note2)*   |
+| Hue Motion Sensor                              | Motion and Luminance sensor                           |
+| Innr Bulbs                                     | *[<sup>[1]</sup>](#note1)*                            |
+| Innr SP 120                                    | Smart Plug *[<sup>[1]</sup>](#note1)*                 |
+| Lupus Small Zigbee Temperature Sensor 12314    | Lupus-Electronics Temperature and Humidity sensor     |
+| Osram Bulbs                                    |                                                       |
+| Osram Motion Sensor                            | Osram Smart+ Motion Sensor *[<sup>[1]</sup>](#note1)* |
+| SmartThings Plug                               | Metered Plug                                          |
+| SmartThings Motion Sensor                      | CentraLite 3325-S Motion and Temperature sensor       |
+| SmartThings Contact Sensor                     | Contact and Temperature sensor                        |
+| Telkonet EcoInsight Thermostat                 | Intelligent HVAC Thermostat                           |
+| Tradfri Bulbs                                  |                                                       |
+| Tradfri Motion Sensor                          |                                                       |
+| Tradfri Outlet                                 |                                                       |
+| Tradfri Repeater                               |                                                       |
+| Trust Bulbs                                    | *[<sup>[1]</sup> ](#note1)*                           |
+| Ubisys modules                                 | D1 Dimmer, S1/S2 Switch modules                       |
+| Xiaomi Aqara Door and Window Sensor            |                                                       |
+| Xiaomi Aqara Temperature and Humidity Sensor   |                                                       |
+| Xiaomi Aqara Human Motion Sensor               |                                                       |
+| Xiaomi Aqara Wireless Mini Switch              |                                                       |
+| Xiaomi Aqara Wireless Remote Switch            | Double Rocker variant                                 |
+| Shenzhen Ksentry Electronics On Off Controller | Relay                                                 |
 
 <a name="note1"></a> *Note 1: Some devices may not work with the Telegesis dongle.*
 


### PR DESCRIPTION
@cdjackson As [discussed here](https://community.openhab.org/t/osram-smart-motion-sensor/70629), the 'Osram Smart+ Motion Sensor' seems also to be incompatible with the Telegesis coordinator, so I've updated the README accordingly.

Signed-off-by: weak <weak@fraglab.at>