### PR TITLE
Fix problems reading from serial port.

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeSerialPort.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeSerialPort.java
@@ -280,7 +280,7 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
                 synchronized (bufferSynchronisationObject) {
                     int available = inputStream.available();
                     logger.trace("Processing DATA_AVAILABLE event: have {} bytes available", available);
-                    byte[] buf = new byte[available];
+                    byte buf[] = new byte[available];
                     int offset = 0;
                     while (offset != available) {
                         if (logger.isTraceEnabled()) {
@@ -293,11 +293,11 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
                                     available - offset, offset);
                         }
                         if (n <= 0) {
-                            logger.error("Processing DATA_AVAILABLE event: Expected to be able to read " + available
-                                    + " bytes, but saw error after " + offset);
-                            throw new IOException(
+                            final String message =
                                     "Expected to be able to read " + available + " bytes, but saw error after "
-                                            + offset);
+                                            + offset;
+                            logger.warn("Processing DATA_AVAILABLE event: {}", message);
+                            throw new IOException(message);
                         }
                         offset += n;
                     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeSerialPort.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeSerialPort.java
@@ -293,11 +293,9 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
                                     available - offset, offset);
                         }
                         if (n <= 0) {
-                            final String message =
+                            throw new IOException(
                                     "Expected to be able to read " + available + " bytes, but saw error after "
-                                            + offset;
-                            logger.warn("Processing DATA_AVAILABLE event: {}", message);
-                            throw new IOException(message);
+                                            + offset);
                         }
                         offset += n;
                     }
@@ -316,7 +314,7 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
                     }
                 }
             } catch (IOException e) {
-                logger.debug("Masking IOException in serial port event", e);
+                logger.warn("Processing DATA_AVAILABLE event: received IOException in serial port event", e);
             }
 
             synchronized (this) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeSerialPort.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeSerialPort.java
@@ -159,7 +159,6 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
                         break;
                 }
 
-                serialPort.enableReceiveThreshold(1);
                 serialPort.enableReceiveTimeout(100);
                 serialPort.addEventListener(this);
                 serialPort.notifyOnDataAvailable(true);
@@ -279,15 +278,45 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
         if (event.getEventType() == SerialPortEvent.DATA_AVAILABLE) {
             try {
                 synchronized (bufferSynchronisationObject) {
-                    int recv;
-                    while ((recv = inputStream.read()) != -1) {
-                        buffer[end++] = recv;
+                    int available = inputStream.available();
+                    logger.trace("Processing DATA_AVAILABLE event: have {} bytes available", available);
+                    byte[] buf = new byte[available];
+                    int offset = 0;
+                    while (offset != available) {
+                        if (logger.isTraceEnabled()) {
+                            logger.trace("Processing DATA_AVAILABLE event: try read  {} at offset {}",
+                                    available - offset, offset);
+                        }
+                        int n = inputStream.read(buf, offset, available - offset);
+                        if (logger.isTraceEnabled()) {
+                            logger.trace("Processing DATA_AVAILABLE event: did read {} of {} at offset {}", n,
+                                    available - offset, offset);
+                        }
+                        if (n <= 0) {
+                            logger.error("Processing DATA_AVAILABLE event: Expected to be able to read " + available
+                                    + " bytes, but saw error after " + offset);
+                            throw new IOException(
+                                    "Expected to be able to read " + available + " bytes, but saw error after "
+                                            + offset);
+                        }
+                        offset += n;
+                    }
+                    for (int i = 0; i < available; i++) {
+                        buffer[end++] = buf[i] & 0xff;
                         if (end >= RX_BUFFER_LEN) {
                             end = 0;
+                        }
+                        if (end == start) {
+                            logger.warn("Processing DATA_AVAILABLE event: Serial buffer overrun");
+                            if (++start == RX_BUFFER_LEN) {
+                                start = 0;
+                            }
+
                         }
                     }
                 }
             } catch (IOException e) {
+                logger.debug("Masking IOException in serial port event", e);
             }
 
             synchronized (this) {


### PR DESCRIPTION
This PR addresses a group of interconnected issues when reading from the serial port. 

#### Bytes being read one-at-a-time from the native serial port

The first reason for this is the setting of a read threshold on the serial port to 1. 
This causes the input stream to return after reading at most 1 byte, regardless of how many are  available. 

The second reason is that bytes were being read from  inputstream one at a time.  This results in a separate read for each byte.

#### Data always read  reading until a timeout occurred when processing data-received events 

After receiving a notification that data is available for reading, the event handler did not check to see how many bytes were available, and read continuously until halted by a timeout. Since this was performed whilst a lock was being held, no bytes were made available to the application until no bytes had been available for the configured timeout period. This could cause readers to block indefinitely. Also, the number of bytes that could be read was unbounded. 

#### No checks for buffer overrun
If the circular buffer capacity was exceeded, this  was not detected.  The write pointer was advanced and the read pointer  left unmodified. This caused all content read up until the overrun  to be discarded, including data that might be part of the current frame being read.  A  typical behavior for serial ports is to use a head-drop strategy, with the oldest bytes being discarded . 

 ### Impact
The following log extracts shows the Ember drivers periodic keep-alive activity, which sends an EZSP NetworkStateRequest, which generates a NetworkStateResponse.

The first line in each trace is generated immediately before the request frame is written to the port.
The second line is generated after the response frame has been received. 

Before the changes, the time per transaction is 0.110ms. 
After the changes, the time per transaction is 0.014ms 

Note that there are no changes to write behavior in this PR.  Data is still written to the file descriptor one byte at a time. This is suboptimal, but is not as significant as the read issues. 

#### Before changes
```
2019-10-18 14:04:56.129 [DEBUG] [e.ember.internal.ash.AshFrameHandler] - --> TX ASH frame: AshFrameData [frmNum=7, ackNum=7, reTx=false, data=D1 00 18]
2019-10-18 14:04:56.239 [DEBUG] [e.ember.internal.ash.AshFrameHandler] - <-- RX ASH frame: AshFrameData [frmNum=7, ackNum=0, reTx=false, data=D1 80 18 02]
2019-10-18 14:04:56.249 [DEBUG] [e.ember.internal.ash.AshFrameHandler] - ASH: Frame acked and removed AshFrameData [frmNum=7, ackNum=7, reTx=false, data=D1 00 18]
2019-10-18 14:04:56.252 [WARN ] [zigbee.dongle.ember.ZigBeeDongleEzsp] - Unhandled EZSP response received: EzspNetworkStateResponse [status=EMBER_JOINED_NETWORK]
2019-10-18 14:04:56.254 [DEBUG] [e.ember.internal.ash.AshFrameHandler] - --> TX ASH frame: AshFrameAck [ackNum=0, notRdy=false]
```

#### After changes
```
15:21:03.007 [DEBUG] [le.ember.internal.ash.AshFrameHandler] - --> TX ASH frame: AshFrameData [frmNum=3, ackNum=1, reTx=false, data=EF 00 18]
15:21:03.021 [DEBUG] [le.ember.internal.ash.AshFrameHandler] - <-- RX ASH frame: AshFrameData [frmNum=1, ackNum=4, reTx=false, data=EF 80 18 02]
15:21:03.025 [DEBUG] [le.ember.internal.ash.AshFrameHandler] - ASH: Frame acked and removed AshFrameData [frmNum=3, ackNum=1, reTx=false, data=EF 00 18]
15:21:03.030 [WARN ] [.zigbee.dongle.ember.ZigBeeDongleEzsp] - Unhandled EZSP response received: EzspNetworkStateResponse [status=EMBER_JOINED_NETWORK]
15:21:03.034 [DEBUG] [le.ember.internal.ash.AshFrameHandler] - --> TX ASH frame: AshFrameAck [ackNum=2, notRdy=false]
```