### PR TITLE
Use OHC serial transport

### DIFF
--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/internal/EmberHandlerFactory.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/internal/EmberHandlerFactory.java
@@ -27,11 +27,14 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
 import org.openhab.binding.zigbee.ember.EmberBindingConstants;
 import org.openhab.binding.zigbee.ember.handler.EmberHandler;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * The {@link EmberHandlerFactory} is responsible for creating things and thing
@@ -39,13 +42,21 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Chris Jackson - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, configurationPid = "org.openhab.binding.zigbee.ember")
 @NonNullByDefault
+@Component(service = ThingHandlerFactory.class, configurationPid = "org.openhab.binding.zigbee.ember")
 public class EmberHandlerFactory extends BaseThingHandlerFactory {
-    private Map<ThingUID, ServiceRegistration> coordinatorHandlerRegs = new HashMap<>();
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
             .singleton(EmberBindingConstants.THING_TYPE_EMBER);
+
+    private final Map<ThingUID, ServiceRegistration<?>> coordinatorHandlerRegs = new HashMap<>();
+
+    private final SerialPortManager serialPortManager;
+
+    @Activate
+    public EmberHandlerFactory(final @Reference SerialPortManager serialPortManager) {
+        this.serialPortManager = serialPortManager;
+    }
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -58,12 +69,12 @@ public class EmberHandlerFactory extends BaseThingHandlerFactory {
 
         ZigBeeCoordinatorHandler emberHandler = null;
         if (thingTypeUID.equals(EmberBindingConstants.THING_TYPE_EMBER)) {
-            emberHandler = new EmberHandler((Bridge) thing);
+            emberHandler = new EmberHandler((Bridge) thing, serialPortManager);
         }
 
         if (emberHandler != null) {
-            coordinatorHandlerRegs.put(emberHandler.getThing().getUID(), bundleContext.registerService(
-                    ZigBeeCoordinatorHandler.class.getName(), emberHandler, new Hashtable<String, Object>()));
+            coordinatorHandlerRegs.put(emberHandler.getThing().getUID(), bundleContext
+                    .registerService(ZigBeeCoordinatorHandler.class.getName(), emberHandler, new Hashtable<>()));
 
             return emberHandler;
         }
@@ -74,7 +85,7 @@ public class EmberHandlerFactory extends BaseThingHandlerFactory {
     @Override
     protected synchronized void removeHandler(ThingHandler thingHandler) {
         if (thingHandler instanceof EmberHandler) {
-            ServiceRegistration coordinatorHandlerReg = coordinatorHandlerRegs.get(thingHandler.getThing().getUID());
+            ServiceRegistration<?> coordinatorHandlerReg = coordinatorHandlerRegs.get(thingHandler.getThing().getUID());
             if (coordinatorHandlerReg != null) {
                 coordinatorHandlerReg.unregister();
                 coordinatorHandlerRegs.remove(thingHandler.getThing().getUID());

--- a/org.openhab.binding.zigbee.xbee/src/main/java/org/openhab/binding/zigbee/xbee/handler/XBeeHandler.java
+++ b/org.openhab.binding.zigbee.xbee/src/main/java/org/openhab/binding/zigbee/xbee/handler/XBeeHandler.java
@@ -13,10 +13,12 @@
 package org.openhab.binding.zigbee.xbee.handler;
 
 import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.openhab.binding.zigbee.handler.ZigBeeSerialPort;
 import org.openhab.binding.zigbee.xbee.internal.XBeeConfiguration;
+import org.osgi.service.component.annotations.Activate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,8 +40,12 @@ import com.zsmartsystems.zigbee.transport.ZigBeeTransportTransmit;
 public class XBeeHandler extends ZigBeeCoordinatorHandler {
     private final Logger logger = LoggerFactory.getLogger(XBeeHandler.class);
 
-    public XBeeHandler(Bridge coordinator) {
+    private final SerialPortManager serialPortManager;
+
+    @Activate
+    public XBeeHandler(Bridge coordinator, SerialPortManager serialPortManager) {
         super(coordinator);
+        this.serialPortManager = serialPortManager;
     }
 
     @Override
@@ -53,14 +59,15 @@ public class XBeeHandler extends ZigBeeCoordinatorHandler {
 
         FlowControl flowControl;
         if (ZigBeeBindingConstants.FLOWCONTROL_CONFIG_HARDWARE_CTSRTS.equals(config.zigbee_flowcontrol)) {
-        	flowControl = FlowControl.FLOWCONTROL_OUT_RTSCTS;
+            flowControl = FlowControl.FLOWCONTROL_OUT_RTSCTS;
         } else if (ZigBeeBindingConstants.FLOWCONTROL_CONFIG_SOFTWARE_XONXOFF.equals(config.zigbee_flowcontrol)) {
-        	flowControl = FlowControl.FLOWCONTROL_OUT_XONOFF;
+            flowControl = FlowControl.FLOWCONTROL_OUT_XONOFF;
         } else {
-        	flowControl = FlowControl.FLOWCONTROL_OUT_NONE;
+            flowControl = FlowControl.FLOWCONTROL_OUT_NONE;
         }
 
-        ZigBeePort serialPort = new ZigBeeSerialPort(config.zigbee_port, config.zigbee_baud, flowControl);
+        ZigBeePort serialPort = new ZigBeeSerialPort(serialPortManager, config.zigbee_port, config.zigbee_baud,
+                flowControl);
         final ZigBeeTransportTransmit dongle = new ZigBeeDongleXBee(serialPort);
 
         logger.debug("ZigBee XBee Coordinator opening Port:'{}' PAN:{}, EPAN:{}, Channel:{}", config.zigbee_port,

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>org.openhab.addons.zigbee.reactor</artifactId>
   <version>2.5.0-SNAPSHOT</version>
   <!-- do not delete the version here as it is required by the release process -->
-
+  
   <name>openHAB Add-ons :: Bundles :: ZigBee Reactor</name>
 
   <packaging>pom</packaging>
@@ -34,8 +34,6 @@
   <properties>
     <report.fail.on.error>false</report.fail.on.error>
     <zsmartsystems.version>1.2.3</zsmartsystems.version>
-    <spotless.version>1.24.3</spotless.version>
-    <spotless.check.skip>true</spotless.check.skip> <!-- Spotless disabled for now -->
   </properties>
 
   <scm>
@@ -104,75 +102,6 @@
             </archive>
             <skipIfEmpty>true</skipIfEmpty>
           </configuration>
-        </plugin>
-        <plugin>
-          <groupId>com.diffplug.spotless</groupId>
-          <artifactId>spotless-maven-plugin</artifactId>
-          <version>${spotless.version}</version>
-          <configuration>
-            <java>
-              <eclipse>
-                <file>openhab_codestyle.xml</file>
-                <version>4.11.0</version>
-              </eclipse>
-              <removeUnusedImports></removeUnusedImports>
-              <importOrder>
-                <file>openhab.importorder</file>
-              </importOrder>
-              <endWithNewline />
-            </java>
-            <formats>
-              <format>
-                <!-- *.xml -->
-                <includes>
-                  <include>src/**/*.xml</include>
-                </includes>
-                <excludes>
-                  <exclude>**/pom.xml</exclude>
-                </excludes>
-                <eclipseWtp>
-                  <type>XML</type>
-                  <files>
-                    <file>openhab_wst_xml_files.prefs</file>
-                  </files>
-                  <version>4.12.0</version>
-                </eclipseWtp>
-                <trimTrailingWhitespace />
-                <endWithNewline />
-              </format>
-              <format>
-                <!-- pom.xml -->
-                <includes>
-                  <include>pom.xml</include>
-                </includes>
-                <eclipseWtp>
-                  <type>XML</type>
-                  <files>
-                    <file>openhab_wst_pom_file.prefs</file>
-                  </files>
-                  <version>4.12.0</version>
-                </eclipseWtp>
-                <trimTrailingWhitespace />
-                <endWithNewline />
-              </format>
-            </formats>
-          </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.openhab.core.tools.codestyle</groupId>
-              <artifactId>org.openhab.core.reactor.tools.codestyle</artifactId>
-              <version>${project.version}</version>
-            </dependency>
-          </dependencies>
-          <executions>
-            <execution>
-              <id>codestyle_check</id>
-              <goals>
-                <goal>check</goal>
-              </goals>
-              <phase>initialize</phase>
-            </execution>
-          </executions>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Switches the binding to use the OHC serial transport instead of gnu.io directly.

Related to https://github.com/openhab/openhab-core/issues/1176