### PR TITLE
Add methods to get supported cluster list from converters

### DIFF
--- a/org.openhab.binding.zigbee.cc2531/src/main/java/org/openhab/binding/zigbee/cc2531/handler/CC2531Handler.java
+++ b/org.openhab.binding.zigbee.cc2531/src/main/java/org/openhab/binding/zigbee/cc2531/handler/CC2531Handler.java
@@ -15,10 +15,10 @@ package org.openhab.binding.zigbee.cc2531.handler;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
 import org.openhab.binding.zigbee.cc2531.internal.CC2531Configuration;
+import org.openhab.binding.zigbee.converter.ZigBeeChannelConverterFactory;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.openhab.binding.zigbee.handler.ZigBeeSerialPort;
 import org.osgi.service.component.annotations.Activate;
@@ -41,15 +41,15 @@ import com.zsmartsystems.zigbee.zcl.clusters.ZclIasZoneCluster;
  *
  * @author Chris Jackson - Initial contribution
  */
-@NonNullByDefault
 public class CC2531Handler extends ZigBeeCoordinatorHandler {
     private final Logger logger = LoggerFactory.getLogger(CC2531Handler.class);
 
     private final SerialPortManager serialPortManager;
 
     @Activate
-    public CC2531Handler(Bridge coordinator, SerialPortManager serialPortManager) {
-        super(coordinator);
+    public CC2531Handler(Bridge coordinator, SerialPortManager serialPortManager,
+            ZigBeeChannelConverterFactory channelFactory) {
+        super(coordinator, channelFactory);
         this.serialPortManager = serialPortManager;
     }
 

--- a/org.openhab.binding.zigbee.cc2531/src/main/java/org/openhab/binding/zigbee/cc2531/internal/CC2531HandlerFactory.java
+++ b/org.openhab.binding.zigbee.cc2531/src/main/java/org/openhab/binding/zigbee/cc2531/internal/CC2531HandlerFactory.java
@@ -30,6 +30,7 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
 import org.openhab.binding.zigbee.cc2531.CC2531BindingConstants;
 import org.openhab.binding.zigbee.cc2531.handler.CC2531Handler;
+import org.openhab.binding.zigbee.converter.ZigBeeChannelConverterFactory;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
@@ -53,9 +54,21 @@ public class CC2531HandlerFactory extends BaseThingHandlerFactory {
 
     private final SerialPortManager serialPortManager;
 
+    @Nullable
+    private ZigBeeChannelConverterFactory zigbeeChannelConverterFactory;
+
     @Activate
     public CC2531HandlerFactory(final @Reference SerialPortManager serialPortManager) {
         this.serialPortManager = serialPortManager;
+    }
+
+    @Reference
+    protected void setZigBeeChannelConverterFactory(ZigBeeChannelConverterFactory zigbeeChannelConverterFactory) {
+        this.zigbeeChannelConverterFactory = zigbeeChannelConverterFactory;
+    }
+
+    protected void unsetZigBeeChannelConverterFactory(ZigBeeChannelConverterFactory zigbeeChannelConverterFactory) {
+        this.zigbeeChannelConverterFactory = null;
     }
 
     @Override
@@ -69,7 +82,7 @@ public class CC2531HandlerFactory extends BaseThingHandlerFactory {
 
         ZigBeeCoordinatorHandler coordinator = null;
         if (thingTypeUID.equals(CC2531BindingConstants.THING_TYPE_CC2531)) {
-            coordinator = new CC2531Handler((Bridge) thing, serialPortManager);
+            coordinator = new CC2531Handler((Bridge) thing, serialPortManager, zigbeeChannelConverterFactory);
         }
 
         if (coordinator != null) {

--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
@@ -28,6 +28,7 @@ import org.eclipse.smarthome.core.thing.binding.firmware.ProgressCallback;
 import org.eclipse.smarthome.core.thing.binding.firmware.ProgressStep;
 import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.converter.ZigBeeChannelConverterFactory;
 import org.openhab.binding.zigbee.ember.internal.EmberConfiguration;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.openhab.binding.zigbee.handler.ZigBeeSerialPort;
@@ -77,8 +78,9 @@ public class EmberHandler extends ZigBeeCoordinatorHandler implements FirmwareUp
 
     private @Nullable ScheduledFuture<?> pollingJob;
 
-    public EmberHandler(Bridge coordinator, SerialPortManager serialPortManager) {
-        super(coordinator);
+    public EmberHandler(Bridge coordinator, SerialPortManager serialPortManager,
+            ZigBeeChannelConverterFactory channelFactory) {
+        super(coordinator, channelFactory);
         this.serialPortManager = serialPortManager;
     }
 

--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/internal/EmberHandlerFactory.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/internal/EmberHandlerFactory.java
@@ -28,6 +28,7 @@ import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
+import org.openhab.binding.zigbee.converter.ZigBeeChannelConverterFactory;
 import org.openhab.binding.zigbee.ember.EmberBindingConstants;
 import org.openhab.binding.zigbee.ember.handler.EmberHandler;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
@@ -53,9 +54,21 @@ public class EmberHandlerFactory extends BaseThingHandlerFactory {
 
     private final SerialPortManager serialPortManager;
 
+    @Nullable
+    private ZigBeeChannelConverterFactory zigbeeChannelConverterFactory;
+
     @Activate
     public EmberHandlerFactory(final @Reference SerialPortManager serialPortManager) {
         this.serialPortManager = serialPortManager;
+    }
+
+    @Reference
+    protected void setZigBeeChannelConverterFactory(ZigBeeChannelConverterFactory zigbeeChannelConverterFactory) {
+        this.zigbeeChannelConverterFactory = zigbeeChannelConverterFactory;
+    }
+
+    protected void unsetZigBeeChannelConverterFactory(ZigBeeChannelConverterFactory zigbeeChannelConverterFactory) {
+        this.zigbeeChannelConverterFactory = null;
     }
 
     @Override
@@ -69,7 +82,7 @@ public class EmberHandlerFactory extends BaseThingHandlerFactory {
 
         ZigBeeCoordinatorHandler emberHandler = null;
         if (thingTypeUID.equals(EmberBindingConstants.THING_TYPE_EMBER)) {
-            emberHandler = new EmberHandler((Bridge) thing, serialPortManager);
+            emberHandler = new EmberHandler((Bridge) thing, serialPortManager, zigbeeChannelConverterFactory);
         }
 
         if (emberHandler != null) {

--- a/org.openhab.binding.zigbee.telegesis/src/main/java/org/openhab/binding/zigbee/telegesis/handler/TelegesisHandler.java
+++ b/org.openhab.binding.zigbee.telegesis/src/main/java/org/openhab/binding/zigbee/telegesis/handler/TelegesisHandler.java
@@ -25,6 +25,7 @@ import org.eclipse.smarthome.core.thing.binding.firmware.ProgressCallback;
 import org.eclipse.smarthome.core.thing.binding.firmware.ProgressStep;
 import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.converter.ZigBeeChannelConverterFactory;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.openhab.binding.zigbee.handler.ZigBeeSerialPort;
 import org.openhab.binding.zigbee.telegesis.internal.TelegesisConfiguration;
@@ -50,15 +51,15 @@ import com.zsmartsystems.zigbee.zcl.clusters.ZclIasZoneCluster;
  *
  * @author Chris Jackson - Initial contribution
  */
-// @NonNullByDefault
 public class TelegesisHandler extends ZigBeeCoordinatorHandler implements FirmwareUpdateHandler {
     private final Logger logger = LoggerFactory.getLogger(TelegesisHandler.class);
 
     private final SerialPortManager serialPortManager;
 
     @Activate
-    public TelegesisHandler(Bridge coordinator, SerialPortManager serialPortManager) {
-        super(coordinator);
+    public TelegesisHandler(Bridge coordinator, SerialPortManager serialPortManager,
+            ZigBeeChannelConverterFactory channelFactory) {
+        super(coordinator, channelFactory);
         this.serialPortManager = serialPortManager;
     }
 

--- a/org.openhab.binding.zigbee.telegesis/src/main/java/org/openhab/binding/zigbee/telegesis/internal/TelegesisHandlerFactory.java
+++ b/org.openhab.binding.zigbee.telegesis/src/main/java/org/openhab/binding/zigbee/telegesis/internal/TelegesisHandlerFactory.java
@@ -28,6 +28,7 @@ import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
+import org.openhab.binding.zigbee.converter.ZigBeeChannelConverterFactory;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.openhab.binding.zigbee.telegesis.TelegesisBindingConstants;
 import org.openhab.binding.zigbee.telegesis.handler.TelegesisHandler;
@@ -53,9 +54,21 @@ public class TelegesisHandlerFactory extends BaseThingHandlerFactory {
 
     private final SerialPortManager serialPortManager;
 
+    @Nullable
+    private ZigBeeChannelConverterFactory zigbeeChannelConverterFactory;
+
     @Activate
     public TelegesisHandlerFactory(final @Reference SerialPortManager serialPortManager) {
         this.serialPortManager = serialPortManager;
+    }
+
+    @Reference
+    protected void setZigBeeChannelConverterFactory(ZigBeeChannelConverterFactory zigbeeChannelConverterFactory) {
+        this.zigbeeChannelConverterFactory = zigbeeChannelConverterFactory;
+    }
+
+    protected void unsetZigBeeChannelConverterFactory(ZigBeeChannelConverterFactory zigbeeChannelConverterFactory) {
+        this.zigbeeChannelConverterFactory = null;
     }
 
     @Override
@@ -69,7 +82,7 @@ public class TelegesisHandlerFactory extends BaseThingHandlerFactory {
 
         ZigBeeCoordinatorHandler coordinator = null;
         if (thingTypeUID.equals(TelegesisBindingConstants.THING_TYPE_TELEGESIS)) {
-            coordinator = new TelegesisHandler((Bridge) thing, serialPortManager);
+            coordinator = new TelegesisHandler((Bridge) thing, serialPortManager, zigbeeChannelConverterFactory);
         }
 
         if (coordinator != null) {

--- a/org.openhab.binding.zigbee.xbee/src/main/java/org/openhab/binding/zigbee/xbee/handler/XBeeHandler.java
+++ b/org.openhab.binding.zigbee.xbee/src/main/java/org/openhab/binding/zigbee/xbee/handler/XBeeHandler.java
@@ -15,6 +15,7 @@ package org.openhab.binding.zigbee.xbee.handler;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.converter.ZigBeeChannelConverterFactory;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.openhab.binding.zigbee.handler.ZigBeeSerialPort;
 import org.openhab.binding.zigbee.xbee.internal.XBeeConfiguration;
@@ -36,15 +37,15 @@ import com.zsmartsystems.zigbee.transport.ZigBeeTransportTransmit;
  *
  * @author Chris Jackson - Initial contribution
  */
-// @NonNullByDefault
 public class XBeeHandler extends ZigBeeCoordinatorHandler {
     private final Logger logger = LoggerFactory.getLogger(XBeeHandler.class);
 
     private final SerialPortManager serialPortManager;
 
     @Activate
-    public XBeeHandler(Bridge coordinator, SerialPortManager serialPortManager) {
-        super(coordinator);
+    public XBeeHandler(Bridge coordinator, SerialPortManager serialPortManager,
+            ZigBeeChannelConverterFactory channelFactory) {
+        super(coordinator, channelFactory);
         this.serialPortManager = serialPortManager;
     }
 

--- a/org.openhab.binding.zigbee.xbee/src/main/java/org/openhab/binding/zigbee/xbee/internal/XBeeHandlerFactory.java
+++ b/org.openhab.binding.zigbee.xbee/src/main/java/org/openhab/binding/zigbee/xbee/internal/XBeeHandlerFactory.java
@@ -28,6 +28,7 @@ import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
+import org.openhab.binding.zigbee.converter.ZigBeeChannelConverterFactory;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.openhab.binding.zigbee.xbee.XBeeBindingConstants;
 import org.openhab.binding.zigbee.xbee.handler.XBeeHandler;
@@ -53,9 +54,21 @@ public class XBeeHandlerFactory extends BaseThingHandlerFactory {
 
     private final SerialPortManager serialPortManager;
 
+    @Nullable
+    private ZigBeeChannelConverterFactory zigbeeChannelConverterFactory;
+
     @Activate
     public XBeeHandlerFactory(final @Reference SerialPortManager serialPortManager) {
         this.serialPortManager = serialPortManager;
+    }
+
+    @Reference
+    protected void setZigBeeChannelConverterFactory(ZigBeeChannelConverterFactory zigbeeChannelConverterFactory) {
+        this.zigbeeChannelConverterFactory = zigbeeChannelConverterFactory;
+    }
+
+    protected void unsetZigBeeChannelConverterFactory(ZigBeeChannelConverterFactory zigbeeChannelConverterFactory) {
+        this.zigbeeChannelConverterFactory = null;
     }
 
     @Override
@@ -69,7 +82,7 @@ public class XBeeHandlerFactory extends BaseThingHandlerFactory {
 
         ZigBeeCoordinatorHandler coordinator = null;
         if (thingTypeUID.equals(XBeeBindingConstants.THING_TYPE_XBEE)) {
-            coordinator = new XBeeHandler((Bridge) thing, serialPortManager);
+            coordinator = new XBeeHandler((Bridge) thing, serialPortManager, zigbeeChannelConverterFactory);
         }
 
         if (coordinator != null) {

--- a/org.openhab.binding.zigbee.xbee/src/main/java/org/openhab/binding/zigbee/xbee/internal/XBeeHandlerFactory.java
+++ b/org.openhab.binding.zigbee.xbee/src/main/java/org/openhab/binding/zigbee/xbee/internal/XBeeHandlerFactory.java
@@ -18,7 +18,6 @@ import java.util.Hashtable;
 import java.util.Map;
 import java.util.Set;
 
-import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -43,7 +42,6 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Chris Jackson - Initial contribution
  */
-@NonNullByDefault
 @Component(service = ThingHandlerFactory.class, configurationPid = "org.openhab.binding.zigbee.xbee")
 public class XBeeHandlerFactory extends BaseThingHandlerFactory {
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -238,6 +238,7 @@ public class ZigBeeBindingConstants {
     public static final String THING_PROPERTY_STACKCOMPLIANCE = "zigbee_stkcompliance";
     public static final String THING_PROPERTY_DEVICE_INITIALIZED = "zigbee_device_initialised";
     public static final String THING_PROPERTY_MANUFACTURERCODE = "zigbee_manufacturercode";
+    public static final String THING_PROPERTY_MACADDRESS = "zigbee_macaddress";
 
     // List of all configuration parameters
     public static final String CONFIGURATION_PANID = "zigbee_panid";

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
@@ -215,18 +215,18 @@ public abstract class ZigBeeBaseChannelConverter {
     }
 
     /**
-     * Gets the cluster IDs that are supported by the converter
-     * 
+     * Gets the cluster IDs that are implemented within the converter on the client side.
+     *
      * @return Set of cluster IDs supported by the converter
      */
-    public abstract Set<Integer> getSupportedClientClusters();
+    public abstract Set<Integer> getImplementedClientClusters();
 
     /**
-     * Gets the cluster IDs that are supported by the converter
-     * 
+     * Gets the cluster IDs that are implemented within the converter on the server side.
+     *
      * @return Set of cluster IDs supported by the converter
      */
-    public abstract Set<Integer> getSupportedServerClusters();
+    public abstract Set<Integer> getImplementedServerClusters();
 
     /**
      * Initialise the converter. This is called by the {@link ZigBeeThingHandler} when the channel is created. The

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
@@ -17,6 +17,7 @@ import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Future;
 
 import org.eclipse.jdt.annotation.NonNull;
@@ -212,6 +213,20 @@ public abstract class ZigBeeBaseChannelConverter {
     public boolean initializeDevice() {
         return true;
     }
+
+    /**
+     * Gets the cluster IDs that are supported by the converter
+     * 
+     * @return Set of cluster IDs supported by the converter
+     */
+    public abstract Set<Integer> getSupportedClientClusters();
+
+    /**
+     * Gets the cluster IDs that are supported by the converter
+     * 
+     * @return Set of cluster IDs supported by the converter
+     */
+    public abstract Set<Integer> getSupportedServerClusters();
 
     /**
      * Initialise the converter. This is called by the {@link ZigBeeThingHandler} when the channel is created. The

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeChannelConverterFactory.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeChannelConverterFactory.java
@@ -66,12 +66,12 @@ public interface ZigBeeChannelConverterFactory {
      *
      * @return Set of cluster IDs supported by the system
      */
-    Set<Integer> getSupportedClientClusters();
+    Set<Integer> getImplementedClientClusters();
 
     /**
      * Gets the cluster IDs that are supported by all converters known to the system
      *
      * @return Set of cluster IDs supported by the system
      */
-    Set<Integer> getSupportedServerClusters();
+    Set<Integer> getImplementedServerClusters();
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeChannelConverterFactory.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeChannelConverterFactory.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.zigbee.converter;
 
 import java.util.Collection;
+import java.util.Set;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -50,13 +51,27 @@ public interface ZigBeeChannelConverterFactory {
     /**
      * Creates a channel converter for the requested {@link ChannelTypeUID}
      *
-     * @param thingHandler       the {@link ZigBeeThingHandler} for this channel
-     * @param channel            the {@link Channel} to create the converter for
+     * @param thingHandler the {@link ZigBeeThingHandler} for this channel
+     * @param channel the {@link Channel} to create the converter for
      * @param coordinatorHandler the {@link ZigBeeCoordinatorHandler}
-     * @param ieeeAddress        the {@link IeeeAddress} of the device
-     * @param endpointId         the endpoint ID for this channel on the device
+     * @param ieeeAddress the {@link IeeeAddress} of the device
+     * @param endpointId the endpoint ID for this channel on the device
      * @return the {@link ZigBeeBaseChannelConverter} or null if the channel is not supported
      */
     ZigBeeBaseChannelConverter createConverter(ZigBeeThingHandler thingHandler, Channel channel,
             ZigBeeCoordinatorHandler coordinatorHandler, IeeeAddress ieeeAddress, int endpointId);
+
+    /**
+     * Gets the cluster IDs that are supported by all converters known to the system
+     *
+     * @return Set of cluster IDs supported by the system
+     */
+    Set<Integer> getSupportedClientClusters();
+
+    /**
+     * Gets the cluster IDs that are supported by all converters known to the system
+     *
+     * @return Set of cluster IDs supported by the system
+     */
+    Set<Integer> getSupportedServerClusters();
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -447,9 +447,9 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
 
         // Add all the clusters that we are supporting.
         // If we don't do this, the framework will reject any packets for clusters we have not stated support for.
-        channelFactory.getSupportedClientClusters().stream()
+        channelFactory.getImplementedClientClusters().stream()
                 .forEach(clusterId -> networkManager.addSupportedClientCluster(clusterId));
-        channelFactory.getSupportedServerClusters().stream()
+        channelFactory.getImplementedServerClusters().stream()
                 .forEach(clusterId -> networkManager.addSupportedServerCluster(clusterId));
 
         // Show the initial network configuration for debugging

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeDataStore.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeDataStore.java
@@ -51,7 +51,7 @@ public class ZigBeeDataStore implements ZigBeeNetworkDataStore {
     /**
      * The logger.
      */
-    private final static Logger logger = LoggerFactory.getLogger(ZigBeeDataStore.class);
+    private final Logger logger = LoggerFactory.getLogger(ZigBeeDataStore.class);
 
     private final String networkStateFilePath;
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactoryImpl.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactoryImpl.java
@@ -18,6 +18,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -132,4 +134,47 @@ public final class ZigBeeChannelConverterFactoryImpl implements ZigBeeChannelCon
         channelMap.keySet().removeAll(zigBeeChannelConverterProvider.getChannelConverters().keySet());
     }
 
+    /**
+     * Gets the cluster IDs that are supported by the converter
+     *
+     * @return Set of cluster IDs supported by the converter. The Set will be ordered by ascending ID
+     */
+    @Override
+    public Set<Integer> getSupportedClientClusters() {
+        Set<Integer> clusters = new TreeSet<>();
+        try {
+            for (Class<? extends ZigBeeBaseChannelConverter> converter : channelMap.values()) {
+                Constructor<? extends ZigBeeBaseChannelConverter> constructor = converter.getConstructor();
+                ZigBeeBaseChannelConverter instance = constructor.newInstance();
+
+                clusters.addAll(instance.getSupportedClientClusters());
+            }
+        } catch (Exception e) {
+            logger.error("Unable to consolidate client cluster IDs", e);
+        }
+
+        return clusters;
+    }
+
+    /**
+     * Gets the cluster IDs that are supported by the converter
+     *
+     * @return Set of cluster IDs supported by the converter. The Set will be ordered by ascending ID
+     */
+    @Override
+    public Set<Integer> getSupportedServerClusters() {
+        Set<Integer> clusters = new TreeSet<>();
+        try {
+            for (Class<? extends ZigBeeBaseChannelConverter> converter : channelMap.values()) {
+                Constructor<? extends ZigBeeBaseChannelConverter> constructor = converter.getConstructor();
+                ZigBeeBaseChannelConverter instance = constructor.newInstance();
+
+                clusters.addAll(instance.getSupportedServerClusters());
+            }
+        } catch (Exception e) {
+            logger.error("Unable to consolidate server cluster IDs", e);
+        }
+
+        return clusters;
+    }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactoryImpl.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactoryImpl.java
@@ -147,7 +147,7 @@ public final class ZigBeeChannelConverterFactoryImpl implements ZigBeeChannelCon
                 Constructor<? extends ZigBeeBaseChannelConverter> constructor = converter.getConstructor();
                 ZigBeeBaseChannelConverter instance = constructor.newInstance();
 
-                clusters.addAll(instance.getSupportedClientClusters());
+                clusters.addAll(instance.getImplementedClientClusters());
             }
         } catch (Exception e) {
             logger.error("Unable to consolidate client cluster IDs", e);
@@ -169,7 +169,7 @@ public final class ZigBeeChannelConverterFactoryImpl implements ZigBeeChannelCon
                 Constructor<? extends ZigBeeBaseChannelConverter> constructor = converter.getConstructor();
                 ZigBeeBaseChannelConverter instance = constructor.newInstance();
 
-                clusters.addAll(instance.getSupportedServerClusters());
+                clusters.addAll(instance.getImplementedServerClusters());
             }
         } catch (Exception e) {
             logger.error("Unable to consolidate server cluster IDs", e);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactoryImpl.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactoryImpl.java
@@ -140,7 +140,7 @@ public final class ZigBeeChannelConverterFactoryImpl implements ZigBeeChannelCon
      * @return Set of cluster IDs supported by the converter. The Set will be ordered by ascending ID
      */
     @Override
-    public Set<Integer> getSupportedClientClusters() {
+    public Set<Integer> getImplementedClientClusters() {
         Set<Integer> clusters = new TreeSet<>();
         try {
             for (Class<? extends ZigBeeBaseChannelConverter> converter : channelMap.values()) {
@@ -162,7 +162,7 @@ public final class ZigBeeChannelConverterFactoryImpl implements ZigBeeChannelCon
      * @return Set of cluster IDs supported by the converter. The Set will be ordered by ascending ID
      */
     @Override
-    public Set<Integer> getSupportedServerClusters() {
+    public Set<Integer> getImplementedServerClusters() {
         Set<Integer> clusters = new TreeSet<>();
         try {
             for (Class<? extends ZigBeeBaseChannelConverter> converter : channelMap.values()) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
@@ -19,8 +19,6 @@ import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.measure.quantity.Pressure;
 
@@ -56,7 +54,7 @@ public class ZigBeeConverterAtmosphericPressure extends ZigBeeBaseChannelConvert
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclPressureMeasurementCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclPressureMeasurementCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
@@ -55,12 +55,12 @@ public class ZigBeeConverterAtmosphericPressure extends ZigBeeBaseChannelConvert
     private ZclPressureMeasurementCluster cluster;
 
     @Override
-    public Set<Integer> getSupportedClientClusters() {
+    public Set<Integer> getImplementedClientClusters() {
         return Stream.of(ZclPressureMeasurementCluster.CLUSTER_ID).collect(Collectors.toSet());
     }
 
     @Override
-    public Set<Integer> getSupportedServerClusters() {
+    public Set<Integer> getImplementedServerClusters() {
         return Collections.emptySet();
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
@@ -16,7 +16,11 @@ import static com.zsmartsystems.zigbee.zcl.clusters.ZclPressureMeasurementCluste
 import static org.eclipse.smarthome.core.library.unit.MetricPrefix.HECTO;
 
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.measure.quantity.Pressure;
 
@@ -49,6 +53,16 @@ public class ZigBeeConverterAtmosphericPressure extends ZigBeeBaseChannelConvert
     private Logger logger = LoggerFactory.getLogger(ZigBeeConverterAtmosphericPressure.class);
 
     private ZclPressureMeasurementCluster cluster;
+
+    @Override
+    public Set<Integer> getSupportedClientClusters() {
+        return Stream.of(ZclPressureMeasurementCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getSupportedServerClusters() {
+        return Collections.emptySet();
+    }
 
     /**
      * If enhancedScale is null, then the binding will use the MeasuredValue report,

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
@@ -19,8 +19,6 @@ import static org.openhab.binding.zigbee.ZigBeeBindingConstants.*;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -74,7 +72,7 @@ public class ZigBeeConverterBatteryAlarm extends ZigBeeBaseChannelConverter impl
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclPowerConfigurationCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclPowerConfigurationCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
@@ -16,7 +16,11 @@ import static com.zsmartsystems.zigbee.zcl.clusters.ZclPowerConfigurationCluster
 import static java.time.Duration.*;
 import static org.openhab.binding.zigbee.ZigBeeBindingConstants.*;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -67,6 +71,16 @@ public class ZigBeeConverterBatteryAlarm extends ZigBeeBaseChannelConverter impl
     private static final int BATTERY_ALARM_POLLING_PERIOD = (int) ofMinutes(30).getSeconds();
 
     private ZclPowerConfigurationCluster cluster;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclPowerConfigurationCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
@@ -14,7 +14,11 @@ package org.openhab.binding.zigbee.internal.converter;
 
 import static com.zsmartsystems.zigbee.zcl.clusters.ZclPowerConfigurationCluster.ATTR_BATTERYPERCENTAGEREMAINING;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -42,6 +46,16 @@ public class ZigBeeConverterBatteryPercent extends ZigBeeBaseChannelConverter im
     private Logger logger = LoggerFactory.getLogger(ZigBeeConverterBatteryPercent.class);
 
     private ZclPowerConfigurationCluster cluster;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclPowerConfigurationCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
@@ -17,8 +17,6 @@ import static com.zsmartsystems.zigbee.zcl.clusters.ZclPowerConfigurationCluster
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -49,7 +47,7 @@ public class ZigBeeConverterBatteryPercent extends ZigBeeBaseChannelConverter im
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclPowerConfigurationCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclPowerConfigurationCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
@@ -16,8 +16,6 @@ import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.measure.quantity.ElectricPotential;
 
@@ -51,7 +49,7 @@ public class ZigBeeConverterBatteryVoltage extends ZigBeeBaseChannelConverter im
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclPowerConfigurationCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclPowerConfigurationCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
@@ -13,7 +13,11 @@
 package org.openhab.binding.zigbee.internal.converter;
 
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.measure.quantity.ElectricPotential;
 
@@ -44,6 +48,16 @@ public class ZigBeeConverterBatteryVoltage extends ZigBeeBaseChannelConverter im
     private Logger logger = LoggerFactory.getLogger(ZigBeeConverterBatteryVoltage.class);
 
     private ZclPowerConfigurationCluster cluster;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclPowerConfigurationCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBinaryInput.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBinaryInput.java
@@ -12,12 +12,10 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
-import com.zsmartsystems.zigbee.CommandResult;
-import com.zsmartsystems.zigbee.ZigBeeEndpoint;
-import com.zsmartsystems.zigbee.zcl.ZclAttribute;
-import com.zsmartsystems.zigbee.zcl.ZclAttributeListener;
-import com.zsmartsystems.zigbee.zcl.clusters.ZclBinaryInputBasicCluster;
-import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -27,7 +25,12 @@ import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.ExecutionException;
+import com.zsmartsystems.zigbee.CommandResult;
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.zcl.ZclAttribute;
+import com.zsmartsystems.zigbee.zcl.ZclAttributeListener;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclBinaryInputBasicCluster;
+import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
 
 /**
  * Converter for the binary input sensor.
@@ -39,6 +42,16 @@ public class ZigBeeConverterBinaryInput extends ZigBeeBaseChannelConverter imple
     private Logger logger = LoggerFactory.getLogger(ZigBeeConverterBinaryInput.class);
 
     private ZclBinaryInputBasicCluster binaryInputCluster;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Collections.singleton(ZclBinaryInputBasicCluster.CLUSTER_ID);
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {
@@ -68,7 +81,8 @@ public class ZigBeeConverterBinaryInput extends ZigBeeBaseChannelConverter imple
 
     @Override
     public boolean initializeConverter() {
-        binaryInputCluster = (ZclBinaryInputBasicCluster) endpoint.getInputCluster(ZclBinaryInputBasicCluster.CLUSTER_ID);
+        binaryInputCluster = (ZclBinaryInputBasicCluster) endpoint
+                .getInputCluster(ZclBinaryInputBasicCluster.CLUSTER_ID);
         if (binaryInputCluster == null) {
             logger.error("{}: Error opening binary input cluster", endpoint.getIeeeAddress());
             return false;
@@ -101,8 +115,8 @@ public class ZigBeeConverterBinaryInput extends ZigBeeBaseChannelConverter imple
                 .create(createChannelUID(thingUID, endpoint, ZigBeeBindingConstants.CHANNEL_NAME_BINARYINPUT),
                         ZigBeeBindingConstants.ITEM_TYPE_SWITCH)
                 .withType(ZigBeeBindingConstants.CHANNEL_BINARYINPUT)
-                .withLabel(ZigBeeBindingConstants.CHANNEL_LABEL_BINARYINPUT)
-                .withProperties(createProperties(endpoint)).build();
+                .withLabel(ZigBeeBindingConstants.CHANNEL_LABEL_BINARYINPUT).withProperties(createProperties(endpoint))
+                .build();
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
@@ -14,13 +14,17 @@ package org.openhab.binding.zigbee.internal.converter;
 
 import static com.zsmartsystems.zigbee.zcl.clusters.ZclColorControlCluster.*;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.config.core.Configuration;
@@ -88,6 +92,18 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
     private final AtomicBoolean currentOnOffState = new AtomicBoolean(true);
 
     private ZclLevelControlConfig configLevelControl;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream
+                .of(ZclOnOffCluster.CLUSTER_ID, ZclLevelControlCluster.CLUSTER_ID, ZclColorControlCluster.CLUSTER_ID)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
@@ -14,7 +14,11 @@ package org.openhab.binding.zigbee.internal.converter;
 
 import static com.zsmartsystems.zigbee.zcl.clusters.ZclColorControlCluster.ATTR_COLORTEMPERATURE;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
@@ -57,6 +61,16 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
     // Default range of 2000K to 6500K
     private final Integer DEFAULT_MIN_TEMPERATURE_IN_KELVIN = 2000;
     private final Integer DEFAULT_MAX_TEMPERATURE_IN_KELVIN = 6500;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclColorControlCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
@@ -17,8 +17,6 @@ import static com.zsmartsystems.zigbee.zcl.clusters.ZclColorControlCluster.ATTR_
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
@@ -64,7 +62,7 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclColorControlCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclColorControlCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterDoorLock.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterDoorLock.java
@@ -12,7 +12,11 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -42,6 +46,16 @@ public class ZigBeeConverterDoorLock extends ZigBeeBaseChannelConverter implemen
     private Logger logger = LoggerFactory.getLogger(ZigBeeConverterDoorLock.class);
 
     private ZclDoorLockCluster cluster;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclDoorLockCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterDoorLock.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterDoorLock.java
@@ -15,8 +15,6 @@ package org.openhab.binding.zigbee.internal.converter;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -49,7 +47,7 @@ public class ZigBeeConverterDoorLock extends ZigBeeBaseChannelConverter implemen
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclDoorLockCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclDoorLockCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterFanControl.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterFanControl.java
@@ -12,7 +12,11 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
@@ -50,6 +54,16 @@ public class ZigBeeConverterFanControl extends ZigBeeBaseChannelConverter implem
 
     private ZclFanControlCluster cluster;
     private ZclAttribute fanModeAttribute;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclFanControlCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterFanControl.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterFanControl.java
@@ -15,8 +15,6 @@ package org.openhab.binding.zigbee.internal.converter;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
@@ -57,7 +55,7 @@ public class ZigBeeConverterFanControl extends ZigBeeBaseChannelConverter implem
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclFanControlCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclFanControlCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButton.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButton.java
@@ -17,6 +17,7 @@ import static java.lang.Integer.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -69,6 +70,16 @@ public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter
     private Map<ButtonPressType, EventSpec> handledEvents = new EnumMap<>(ButtonPressType.class);
     private Set<ZclCluster> clientClusters = new HashSet<>();
     private Set<ZclCluster> serverClusters = new HashSet<>();
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public synchronized boolean initializeConverter() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
@@ -12,7 +12,11 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
@@ -59,6 +63,16 @@ public abstract class ZigBeeConverterIas extends ZigBeeBaseChannelConverter
     protected static final int CIE_ACMAINS = 0x0080;
     protected static final int CIE_TEST = 0x0100;
     protected static final int CIE_BATTERYDEFECT = 0x0200;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclIasZoneCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
@@ -18,8 +18,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.config.core.Configuration;
@@ -60,7 +58,7 @@ public class ZigBeeConverterIlluminance extends ZigBeeBaseChannelConverter imple
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclIlluminanceMeasurementCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclIlluminanceMeasurementCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
@@ -14,8 +14,12 @@ package org.openhab.binding.zigbee.internal.converter;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.config.core.Configuration;
@@ -53,6 +57,16 @@ public class ZigBeeConverterIlluminance extends ZigBeeBaseChannelConverter imple
     private ZclAttribute attribute;
 
     private ZclReportingConfig configReporting;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclIlluminanceMeasurementCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
@@ -13,7 +13,11 @@
 package org.openhab.binding.zigbee.internal.converter;
 
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.measure.quantity.Power;
 
@@ -46,6 +50,16 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
 
     private Integer divisor;
     private Integer multiplier;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclElectricalMeasurementCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
@@ -16,8 +16,6 @@ import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.measure.quantity.Power;
 
@@ -53,7 +51,7 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclElectricalMeasurementCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclElectricalMeasurementCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
@@ -16,8 +16,6 @@ import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.measure.quantity.ElectricCurrent;
 
@@ -54,7 +52,7 @@ public class ZigBeeConverterMeasurementRmsCurrent extends ZigBeeBaseChannelConve
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclElectricalMeasurementCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclElectricalMeasurementCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
@@ -13,7 +13,11 @@
 package org.openhab.binding.zigbee.internal.converter;
 
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.measure.quantity.ElectricCurrent;
 
@@ -47,6 +51,16 @@ public class ZigBeeConverterMeasurementRmsCurrent extends ZigBeeBaseChannelConve
 
     private Integer divisor;
     private Integer multiplier;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclElectricalMeasurementCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
@@ -16,8 +16,6 @@ import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.measure.quantity.ElectricPotential;
 
@@ -54,7 +52,7 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclElectricalMeasurementCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclElectricalMeasurementCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
@@ -13,7 +13,11 @@
 package org.openhab.binding.zigbee.internal.converter;
 
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.measure.quantity.ElectricPotential;
 
@@ -47,6 +51,16 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
 
     private Integer divisor;
     private Integer multiplier;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclElectricalMeasurementCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
@@ -12,7 +12,11 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -40,6 +44,16 @@ public class ZigBeeConverterOccupancy extends ZigBeeBaseChannelConverter impleme
     private Logger logger = LoggerFactory.getLogger(ZigBeeConverterOccupancy.class);
 
     private ZclOccupancySensingCluster clusterOccupancy;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclOccupancySensingCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
@@ -15,8 +15,6 @@ package org.openhab.binding.zigbee.internal.converter;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -47,7 +45,7 @@ public class ZigBeeConverterOccupancy extends ZigBeeBaseChannelConverter impleme
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclOccupancySensingCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclOccupancySensingCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
@@ -13,7 +13,11 @@
 package org.openhab.binding.zigbee.internal.converter;
 
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -41,6 +45,16 @@ public class ZigBeeConverterRelativeHumidity extends ZigBeeBaseChannelConverter 
     private Logger logger = LoggerFactory.getLogger(ZigBeeConverterRelativeHumidity.class);
 
     private ZclRelativeHumidityMeasurementCluster cluster;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclRelativeHumidityMeasurementCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
@@ -16,8 +16,6 @@ import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -48,7 +46,7 @@ public class ZigBeeConverterRelativeHumidity extends ZigBeeBaseChannelConverter 
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclRelativeHumidityMeasurementCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclRelativeHumidityMeasurementCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -14,12 +14,15 @@ package org.openhab.binding.zigbee.internal.converter;
 
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.config.core.Configuration;
@@ -100,6 +103,16 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
 
     private ScheduledExecutorService updateScheduler;
     private ScheduledFuture<?> updateTimer = null;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclOnOffCluster.CLUSTER_ID, ZclLevelControlCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Stream.of(ZclOnOffCluster.CLUSTER_ID, ZclLevelControlCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -14,12 +14,15 @@ package org.openhab.binding.zigbee.internal.converter;
 
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.config.core.Configuration;
@@ -75,6 +78,16 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
 
     private ScheduledExecutorService updateScheduler;
     private ScheduledFuture<?> updateTimer = null;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclOnOffCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Stream.of(ZclOnOffCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.zigbee.internal.converter;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -21,8 +22,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.config.core.Configuration;
@@ -81,12 +80,12 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclOnOffCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclOnOffCluster.CLUSTER_ID);
     }
 
     @Override
     public Set<Integer> getImplementedServerClusters() {
-        return Stream.of(ZclOnOffCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclOnOffCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
@@ -12,7 +12,11 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -39,6 +43,16 @@ public class ZigBeeConverterTemperature extends ZigBeeBaseChannelConverter imple
     private Logger logger = LoggerFactory.getLogger(ZigBeeConverterTemperature.class);
 
     private ZclTemperatureMeasurementCluster cluster;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclTemperatureMeasurementCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
@@ -15,8 +15,6 @@ package org.openhab.binding.zigbee.internal.converter;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -46,7 +44,7 @@ public class ZigBeeConverterTemperature extends ZigBeeBaseChannelConverter imple
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclTemperatureMeasurementCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclTemperatureMeasurementCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatLocalTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatLocalTemperature.java
@@ -12,7 +12,11 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -42,6 +46,16 @@ public class ZigBeeConverterThermostatLocalTemperature extends ZigBeeBaseChannel
     private final int INVALID_TEMPERATURE = 0x8000;
 
     private ZclThermostatCluster cluster;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclThermostatCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatLocalTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatLocalTemperature.java
@@ -15,8 +15,6 @@ package org.openhab.binding.zigbee.internal.converter;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -49,7 +47,7 @@ public class ZigBeeConverterThermostatLocalTemperature extends ZigBeeBaseChannel
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclThermostatCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclThermostatCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
@@ -12,7 +12,11 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -44,6 +48,16 @@ public class ZigBeeConverterThermostatOccupiedCooling extends ZigBeeBaseChannelC
 
     private ZclThermostatCluster cluster;
     private ZclAttribute attribute;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclThermostatCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
@@ -15,8 +15,6 @@ package org.openhab.binding.zigbee.internal.converter;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -51,7 +49,7 @@ public class ZigBeeConverterThermostatOccupiedCooling extends ZigBeeBaseChannelC
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclThermostatCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclThermostatCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedHeating.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedHeating.java
@@ -12,7 +12,11 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -42,6 +46,16 @@ public class ZigBeeConverterThermostatOccupiedHeating extends ZigBeeBaseChannelC
 
     private ZclThermostatCluster cluster;
     private ZclAttribute attribute;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclThermostatCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedHeating.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedHeating.java
@@ -15,8 +15,6 @@ package org.openhab.binding.zigbee.internal.converter;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -49,7 +47,7 @@ public class ZigBeeConverterThermostatOccupiedHeating extends ZigBeeBaseChannelC
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclThermostatCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclThermostatCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
@@ -15,8 +15,6 @@ package org.openhab.binding.zigbee.internal.converter;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -48,7 +46,7 @@ public class ZigBeeConverterThermostatOutdoorTemperature extends ZigBeeBaseChann
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclThermostatCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclThermostatCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
@@ -12,7 +12,11 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -41,6 +45,16 @@ public class ZigBeeConverterThermostatOutdoorTemperature extends ZigBeeBaseChann
 
     private ZclThermostatCluster cluster;
     private ZclAttribute attribute;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclThermostatCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
@@ -12,7 +12,11 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -46,6 +50,16 @@ public class ZigBeeConverterThermostatRunningMode extends ZigBeeBaseChannelConve
     private Logger logger = LoggerFactory.getLogger(ZigBeeConverterThermostatRunningMode.class);
 
     private ZclThermostatCluster cluster;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclThermostatCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
@@ -15,8 +15,6 @@ package org.openhab.binding.zigbee.internal.converter;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -53,7 +51,7 @@ public class ZigBeeConverterThermostatRunningMode extends ZigBeeBaseChannelConve
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclThermostatCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclThermostatCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
@@ -18,8 +18,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
@@ -61,7 +59,7 @@ public class ZigBeeConverterThermostatSystemMode extends ZigBeeBaseChannelConver
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclThermostatCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclThermostatCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
@@ -14,8 +14,12 @@ package org.openhab.binding.zigbee.internal.converter;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
@@ -54,6 +58,16 @@ public class ZigBeeConverterThermostatSystemMode extends ZigBeeBaseChannelConver
 
     private ZclThermostatCluster cluster;
     private ZclAttribute attribute;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclThermostatCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
@@ -12,7 +12,11 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -42,6 +46,16 @@ public class ZigBeeConverterThermostatUnoccupiedCooling extends ZigBeeBaseChanne
 
     private ZclThermostatCluster cluster;
     private ZclAttribute attribute;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclThermostatCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
@@ -15,8 +15,6 @@ package org.openhab.binding.zigbee.internal.converter;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -49,7 +47,7 @@ public class ZigBeeConverterThermostatUnoccupiedCooling extends ZigBeeBaseChanne
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclThermostatCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclThermostatCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
@@ -15,8 +15,6 @@ package org.openhab.binding.zigbee.internal.converter;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -49,7 +47,7 @@ public class ZigBeeConverterThermostatUnoccupiedHeating extends ZigBeeBaseChanne
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
-        return Stream.of(ZclThermostatCluster.CLUSTER_ID).collect(Collectors.toSet());
+        return Collections.singleton(ZclThermostatCluster.CLUSTER_ID);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
@@ -12,7 +12,11 @@
  */
 package org.openhab.binding.zigbee.internal.converter;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -42,6 +46,16 @@ public class ZigBeeConverterThermostatUnoccupiedHeating extends ZigBeeBaseChanne
 
     private ZclThermostatCluster cluster;
     private ZclAttribute attribute;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclThermostatCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/warningdevice/ZigBeeConverterWarningDevice.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/warningdevice/ZigBeeConverterWarningDevice.java
@@ -14,9 +14,13 @@ package org.openhab.binding.zigbee.internal.converter.warningdevice;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.config.core.Configuration;
@@ -48,6 +52,16 @@ public class ZigBeeConverterWarningDevice extends ZigBeeBaseChannelConverter {
     private final Logger logger = LoggerFactory.getLogger(ZigBeeConverterWarningDevice.class);
 
     private ZclIasWdCluster iasWdCluster;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclIasWdCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Collections.emptySet();
+    }
 
     @Override
     public boolean initializeDevice() {

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <report.fail.on.error>false</report.fail.on.error>
-    <zsmartsystems.version>1.2.3</zsmartsystems.version>
+    <zsmartsystems.version>1.2.6-SNAPSHOT</zsmartsystems.version>
     <spotless.version>1.24.3</spotless.version>
     <spotless.check.skip>true</spotless.check.skip> <!-- Spotless disabled for now -->
     <sat.version>0.8.0</sat.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <report.fail.on.error>false</report.fail.on.error>
-    <zsmartsystems.version>1.2.6-SNAPSHOT</zsmartsystems.version>
+    <zsmartsystems.version>1.2.6</zsmartsystems.version>
     <spotless.version>1.24.3</spotless.version>
     <spotless.check.skip>true</spotless.check.skip> <!-- Spotless disabled for now -->
     <sat.version>0.8.0</sat.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <report.fail.on.error>false</report.fail.on.error>
-    <zsmartsystems.version>1.2.6</zsmartsystems.version>
+    <zsmartsystems.version>1.2.8</zsmartsystems.version>
     <spotless.version>1.24.3</spotless.version>
     <spotless.check.skip>true</spotless.check.skip> <!-- Spotless disabled for now -->
     <sat.version>0.8.0</sat.version>


### PR DESCRIPTION
This PR is incomplete and will fail CI - do not merge!!

From recent versions of the Z-Smart Systems ZigBee library (1.2.6 I think), we need to tell the framework what clusters we support. This is to allow the framework to only process messages that the application supports, and more importantly, to reject ones that are not supported with the appropriate error. 

***This is required for ZigBee certification and there is a test for this***.

To achieve this, I've added two methods to the converters, and the converter factory to allow the coordinator handler to get the list of clusters that are implemented by the system. Each cluster will return a Set of cluster IDs it supports through the ```Set<Integer> getSupportedClientClusters()``` and ```Set<Integer> getSupportedServerClusters()``` methods. The converter factory has a similar set of methods and will return the consolidated Set of cluster IDs supported by all converters so that this can be passed to the framework.

@hsudbrock or @triller-telekom you should review this concept please.

Design questions - I have one thought - the framework methods set the client/server clusters the framework supports, but the converters internally use client/server clusters on the remote device, so the naming is reversed. Within the converter, does the ```getSupportedServerClusters``` method return the server clusters consumed by the converter, or the server clusters implemented by the converted?

---

This PR currently only implements the initial concept, and the methods in a single converter for comment.

Note that we probably also need to add the converter factory provider to the coordinator factories as this information is required in the ```ZigBeeCoordinatorHandler``` class (I've added this as a parameter on the constructor, but not hooked this all together yet).

Signed-off-by: Chris Jackson <chris@cd-jackson.com>