### PR TITLE
Add zigbee_networksize to Ember dongle

### DIFF
--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
@@ -100,6 +100,8 @@ public class EmberHandler extends ZigBeeCoordinatorHandler implements FirmwareUp
         logger.debug("ZigBee Ember Coordinator opening Port:'{}' PAN:{}, EPAN:{}, Channel:{}", config.zigbee_port,
                 Integer.toHexString(panId), extendedPanId, Integer.toString(channelId));
 
+        dongle.updateDefaultConfiguration(EzspConfigId.EZSP_CONFIG_ADDRESS_TABLE_SIZE, config.zigbee_networksize);
+
         dongle.updateDefaultConfiguration(EzspConfigId.EZSP_CONFIG_TX_POWER_MODE, config.zigbee_powermode);
 
         // Set the child aging timeout.

--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/internal/EmberConfiguration.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/internal/EmberConfiguration.java
@@ -25,4 +25,5 @@ public class EmberConfiguration {
     public Integer zigbee_powermode;
     public Integer zigbee_childtimeout;
     public Integer zigbee_concentrator;
+    public Integer zigbee_networksize;
 }

--- a/org.openhab.binding.zigbee.ember/src/main/resources/ESH-INF/thing/controller_ember.xml
+++ b/org.openhab.binding.zigbee.ember/src/main/resources/ESH-INF/thing/controller_ember.xml
@@ -107,6 +107,18 @@
 				</options>
 			</parameter>
 
+            <parameter name="zigbee_networksize" type="integer" min="10" max="250" groupName="ember">
+                <label>Network Size</label>
+                <description>Sets the number of nodes expected in the network</description>
+                <default>25</default>
+                <options>
+                    <option value="10">Small</option>
+                    <option value="25">Medium</option>
+                    <option value="100">Large</option>
+                    <option value="250">Enormous</option>
+                </options>
+            </parameter>
+
 			<parameter name="zigbee_initialise" type="boolean" groupName="network">
 				<label>Reset Controller</label>
 				<description>Resets the Controller and sets the configuration to the configured values</description>

--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -117,6 +117,10 @@ The binding is able to search the network to get a list of what devices can comm
 
 Please note that, technically, you are not bound to using the values from the table. But if you use an arbitrary number of seconds, not corresponding to one of the predefined periods, it might not be possible to display the configured value correctly in PaperUI.
 
+##### Network Size (zigbee_networksize)
+
+Some coordinators may need to allocate memory to handle each node in the network. This is an integer setting, and should be set to the maximum number of nodes expected to be added to the network. It should be noted that this will consume memory on the coordinator which may impact on other services such as packet buffers, so it is not advised to simply set this to the maximum value.
+
 #### Supported Coordinators
 
 The following coordinators are known to be supported.


### PR DESCRIPTION
Some coordinators may need to allocate memory to handle each node in the network. This is an integer setting, and should be set to the maximum number of nodes expected to be added to the network. It should be noted that this will consume memory on the coordinator which may impact on other services such as packet buffers, so it is not advised to simply set this to the maximum value.

This is applicable to the Ember NCP and this setting is therefore exposed for this coordinator.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>