### PR TITLE
Removed baud configuration on telegesis dongle discovery 

### DIFF
--- a/org.openhab.binding.zigbee.telegesis/src/main/java/org/openhab/binding/zigbee/telegesis/internal/discovery/ZigBeeTelegesisUsbSerialDiscoveryParticipant.java
+++ b/org.openhab.binding.zigbee.telegesis/src/main/java/org/openhab/binding/zigbee/telegesis/internal/discovery/ZigBeeTelegesisUsbSerialDiscoveryParticipant.java
@@ -13,7 +13,6 @@
 package org.openhab.binding.zigbee.telegesis.internal.discovery;
 
 import static java.util.Arrays.asList;
-import static org.openhab.binding.zigbee.ZigBeeBindingConstants.CONFIGURATION_BAUD;
 import static org.openhab.binding.zigbee.ZigBeeBindingConstants.CONFIGURATION_PORT;
 import static org.openhab.binding.zigbee.telegesis.TelegesisBindingConstants.THING_TYPE_TELEGESIS;
 
@@ -74,7 +73,7 @@ public class ZigBeeTelegesisUsbSerialDiscoveryParticipant implements UsbSerialDi
                     .withLabel(createQiviconTelegesisDongleLabel(deviceInformation))
                     .withRepresentationProperty(CONFIGURATION_PORT)
                     .withProperty(CONFIGURATION_PORT, deviceInformation.getSerialPort())
-                    .withProperty(CONFIGURATION_BAUD, QIVICON_DONGLE_BAUD_RATE).build();
+                    .build();
         } else {
             return null;
         }

--- a/org.openhab.binding.zigbee.telegesis/src/test/java/org/openhab/binding/zigbee/telegesis/internal/discovery/ZigBeeTelegesisUsbSerialDiscoveryParticipantTest.java
+++ b/org.openhab.binding.zigbee.telegesis/src/test/java/org/openhab/binding/zigbee/telegesis/internal/discovery/ZigBeeTelegesisUsbSerialDiscoveryParticipantTest.java
@@ -15,7 +15,6 @@ package org.openhab.binding.zigbee.telegesis.internal.discovery;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.openhab.binding.zigbee.ZigBeeBindingConstants.CONFIGURATION_BAUD;
 import static org.openhab.binding.zigbee.ZigBeeBindingConstants.CONFIGURATION_PORT;
 import static org.openhab.binding.zigbee.telegesis.TelegesisBindingConstants.THING_TYPE_TELEGESIS;
 import static org.openhab.binding.zigbee.telegesis.internal.discovery.ZigBeeTelegesisUsbSerialDiscoveryParticipant.QIVICON_DONGLE_V1_AND_TELEGESIS_USB_PRODUCT_ID;
@@ -82,7 +81,6 @@ public class ZigBeeTelegesisUsbSerialDiscoveryParticipantTest {
         assertNotNull(discoveryResult.getLabel());
         assertEquals(discoveryResult.getRepresentationProperty(), CONFIGURATION_PORT);
         assertEquals(discoveryResult.getProperties().get(CONFIGURATION_PORT), "/dev/ttyUSB0");
-        assertNotNull(discoveryResult.getProperties().get(CONFIGURATION_BAUD));
     }
     
     /**
@@ -110,7 +108,6 @@ public class ZigBeeTelegesisUsbSerialDiscoveryParticipantTest {
         assertNotNull(discoveryResult.getLabel());
         assertEquals(discoveryResult.getRepresentationProperty(), CONFIGURATION_PORT);
         assertEquals(discoveryResult.getProperties().get(CONFIGURATION_PORT), "/dev/ttyUSB0");
-        assertNotNull(discoveryResult.getProperties().get(CONFIGURATION_BAUD));
     }
     
     private UsbSerialDeviceInformation forUsbDongle(int vendorId, int productId, String serial, String device) {


### PR DESCRIPTION
So the thing discovery will not overwrite configured items, see #506 