### PR TITLE
Fix for Xiaomi WLeak AQ1

### DIFF
--- a/org.openhab.binding.zigbee/src/main/resources/discovery.txt
+++ b/org.openhab.binding.zigbee/src/main/resources/discovery.txt
@@ -8,6 +8,6 @@ xiaomi_lumisensor-motion,modelId=lumi.sensor_motion
 xiaomi_lumiremoteb286acn01,modelId=lumi.remote.b286acn01
 xiaomi_lumisensor86sw2,modelId=lumi.sensor_86sw2
 xiaomi_lumisensor-switchaq2,modelId=lumi.sensor_switch.aq2
-xiaomi_lumisensor-wleakaq1,modelId=lumi.sensor_wleak.aq1
+xiaomi_lumisensorwaterleak,modelId=lumi.sensor_wleak.aq1
 innr-rc-110,vendor=innr,modelId=RC 110
 osram-switch-4x-eu,vendor=OSRAM,modelId=Switch 4x EU-LIGHTIFY


### PR DESCRIPTION
Non-existent thing-type was specified for this device.