### PR TITLE
Update POM parent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openhab.addons</groupId>
     <artifactId>org.openhab.addons.reactor</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1-SNAPSHOT</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
@kaikreuzer please can you check this - I assume this wasn't left at ```2.5.0``` for a reason?

I'm currently struggling to get the ZigBee binding working after the 2.5 release - the dependencies seem to be messed up in the IDE (it's another bnd related issue I think).

Signed-off-by: Chris Jackson <chris@cd-jackson.com>