### PR TITLE
Create new ZSS transport and config on handler restart

### DIFF
--- a/org.openhab.binding.zigbee.cc2531/src/main/java/org/openhab/binding/zigbee/cc2531/handler/CC2531Handler.java
+++ b/org.openhab.binding.zigbee.cc2531/src/main/java/org/openhab/binding/zigbee/cc2531/handler/CC2531Handler.java
@@ -54,21 +54,29 @@ public class CC2531Handler extends ZigBeeCoordinatorHandler {
     }
 
     @Override
-    public void initialize() {
+    protected void initializeDongle() {
         logger.debug("Initializing ZigBee CC2531 serial bridge handler.");
 
-        // Call the parent to finish any global initialisation
-        super.initialize();
-
         CC2531Configuration config = getConfigAs(CC2531Configuration.class);
+        ZigBeeTransportTransmit dongle = createDongle(config);
+        TransportConfig transportConfig = createTransportConfig(config);
 
+        startZigBee(dongle, transportConfig, DefaultSerializer.class, DefaultDeserializer.class);
+    }
+
+    private ZigBeeTransportTransmit createDongle(CC2531Configuration config) {
         ZigBeePort serialPort = new ZigBeeSerialPort(serialPortManager, config.zigbee_port, config.zigbee_baud,
                 FlowControl.FLOWCONTROL_OUT_RTSCTS);
-        final ZigBeeTransportTransmit dongle = new ZigBeeDongleTiCc2531(serialPort);
+
+        ZigBeeTransportTransmit dongle = new ZigBeeDongleTiCc2531(serialPort);
 
         logger.debug("ZigBee CC2531 Coordinator opening Port:'{}' PAN:{}, EPAN:{}, Channel:{}", config.zigbee_port,
                 Integer.toHexString(panId), extendedPanId, Integer.toString(channelId));
 
+        return dongle;
+    }
+
+    private TransportConfig createTransportConfig(CC2531Configuration config) {
         TransportConfig transportConfig = new TransportConfig();
 
         // The CC2531EMK dongle doesn't pass the MatchDescriptor commands to the stack, so we can't manage our services
@@ -77,7 +85,7 @@ public class CC2531Handler extends ZigBeeCoordinatorHandler {
         clusters.add(ZclIasZoneCluster.CLUSTER_ID);
         transportConfig.addOption(TransportConfigOption.SUPPORTED_OUTPUT_CLUSTERS, clusters);
 
-        startZigBee(dongle, transportConfig, DefaultSerializer.class, DefaultDeserializer.class);
+        return transportConfig;
     }
 
 }

--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
@@ -85,123 +85,40 @@ public class EmberHandler extends ZigBeeCoordinatorHandler implements FirmwareUp
     }
 
     @Override
-    public void initialize() {
+    protected void initializeDongle() {
         logger.debug("Initializing ZigBee Ember serial bridge handler.");
 
-        // Call the parent to finish any global initialisation
-        super.initialize();
-
         EmberConfiguration config = getConfigAs(EmberConfiguration.class);
-
-        FlowControl flowControl;
-        if (ZigBeeBindingConstants.FLOWCONTROL_CONFIG_HARDWARE_CTSRTS.equals(config.zigbee_flowcontrol)) {
-            flowControl = FlowControl.FLOWCONTROL_OUT_RTSCTS;
-        } else if (ZigBeeBindingConstants.FLOWCONTROL_CONFIG_SOFTWARE_XONXOFF.equals(config.zigbee_flowcontrol)) {
-            flowControl = FlowControl.FLOWCONTROL_OUT_XONOFF;
-        } else {
-            flowControl = FlowControl.FLOWCONTROL_OUT_NONE;
-        }
-
-        ZigBeePort serialPort = new ZigBeeSerialPort(serialPortManager, config.zigbee_port, config.zigbee_baud,
-                flowControl);
-        final ZigBeeDongleEzsp dongle = new ZigBeeDongleEzsp(serialPort);
-
-        logger.debug("ZigBee Ember Coordinator opening Port:'{}' PAN:{}, EPAN:{}, Channel:{}", config.zigbee_port,
-                Integer.toHexString(panId), extendedPanId, Integer.toString(channelId));
-
-        dongle.updateDefaultConfiguration(EzspConfigId.EZSP_CONFIG_ADDRESS_TABLE_SIZE, config.zigbee_networksize);
-
-        dongle.updateDefaultConfiguration(EzspConfigId.EZSP_CONFIG_TX_POWER_MODE, config.zigbee_powermode);
-
-        // We don't need to receive broadcast and multicast messages that we send
-        dongle.passLoopbackMessages(false);
-
-        // Set the child aging timeout.
-        // Formulae is EZSP_CONFIG_END_DEVICE_POLL_TIMEOUT * 2 ^ EZSP_CONFIG_END_DEVICE_POLL_TIMEOUT_SHIFT
-        int pollTimeoutValue;
-        int pollTimeoutShift;
-
-        if (config.zigbee_childtimeout <= 320) {
-            pollTimeoutValue = 5;
-            pollTimeoutShift = 6;
-        } else if (config.zigbee_childtimeout <= 1800) {
-            pollTimeoutValue = 225;
-            pollTimeoutShift = 3;
-        } else if (config.zigbee_childtimeout <= 7200) {
-            pollTimeoutValue = 225;
-            pollTimeoutShift = 5;
-        } else if (config.zigbee_childtimeout <= 43200) {
-            pollTimeoutValue = 169;
-            pollTimeoutShift = 8;
-        } else if (config.zigbee_childtimeout <= 86400) {
-            pollTimeoutValue = 169;
-            pollTimeoutShift = 9;
-        } else if (config.zigbee_childtimeout <= 172800) {
-            pollTimeoutValue = 169;
-            pollTimeoutShift = 10;
-        } else if (config.zigbee_childtimeout <= 432000) {
-            pollTimeoutValue = 211;
-            pollTimeoutShift = 11;
-        } else if (config.zigbee_childtimeout <= 864000) {
-            pollTimeoutValue = 211;
-            pollTimeoutShift = 12;
-        } else if (config.zigbee_childtimeout <= 1209600) {
-            pollTimeoutValue = 147;
-            pollTimeoutShift = 13;
-        } else if (config.zigbee_childtimeout <= 2419200) {
-            pollTimeoutValue = 147;
-            pollTimeoutShift = 14;
-        } else {
-            pollTimeoutValue = 255;
-            pollTimeoutShift = 14;
-        }
-
-        logger.debug("Ember end device poll timout set to ({} * 2^{}) = {} seconds", pollTimeoutValue, pollTimeoutShift,
-                (int) (pollTimeoutValue * Math.pow(2, pollTimeoutShift)));
-        dongle.updateDefaultConfiguration(EzspConfigId.EZSP_CONFIG_END_DEVICE_POLL_TIMEOUT, pollTimeoutValue);
-        dongle.updateDefaultConfiguration(EzspConfigId.EZSP_CONFIG_END_DEVICE_POLL_TIMEOUT_SHIFT, pollTimeoutShift);
-
-        TransportConfig transportConfig = new TransportConfig();
-
-        // Configure the concentrator
-        // Max Hops defaults to system max
-        ConcentratorConfig concentratorConfig = new ConcentratorConfig();
-        if (config.zigbee_concentrator == 1) {
-            concentratorConfig.setType(ConcentratorType.HIGH_RAM);
-        } else {
-            concentratorConfig.setType(ConcentratorType.LOW_RAM);
-        }
-        concentratorConfig.setMaxFailures(8);
-        concentratorConfig.setMaxHops(0);
-        concentratorConfig.setRefreshMinimum(60);
-        concentratorConfig.setRefreshMaximum(3600);
-        transportConfig.addOption(TransportConfigOption.CONCENTRATOR_CONFIG, concentratorConfig);
+        ZigBeeDongleEzsp dongle = createDongle(config);
+        TransportConfig transportConfig = createTransportConfig(config);
 
         startZigBee(dongle, transportConfig, DefaultSerializer.class, DefaultDeserializer.class);
 
-        Runnable pollingRunnable = new Runnable() {
-            @Override
-            public void run() {
-                Map<String, Long> counters = dongle.getCounters();
+        if (pollingJob == null) {
+            Runnable pollingRunnable = new Runnable() {
+                @Override
+                public void run() {
+                    Map<String, Long> counters = dongle.getCounters();
 
-                if (!counters.isEmpty()) {
-                    updateState(new ChannelUID(getThing().getUID(), UID_ASH_RX_DAT),
-                            new DecimalType(counters.get(ASH_RX_DAT)));
-                    updateState(new ChannelUID(getThing().getUID(), UID_ASH_TX_DAT),
-                            new DecimalType(counters.get(ASH_TX_DAT)));
-                    updateState(new ChannelUID(getThing().getUID(), UID_ASH_RX_ACK),
-                            new DecimalType(counters.get(ASH_RX_ACK)));
-                    updateState(new ChannelUID(getThing().getUID(), UID_ASH_TX_ACK),
-                            new DecimalType(counters.get(ASH_TX_ACK)));
-                    updateState(new ChannelUID(getThing().getUID(), UID_ASH_RX_NAK),
-                            new DecimalType(counters.get(ASH_RX_NAK)));
-                    updateState(new ChannelUID(getThing().getUID(), UID_ASH_TX_NAK),
-                            new DecimalType(counters.get(ASH_TX_NAK)));
+                    if (!counters.isEmpty()) {
+                        updateState(new ChannelUID(getThing().getUID(), UID_ASH_RX_DAT),
+                                new DecimalType(counters.get(ASH_RX_DAT)));
+                        updateState(new ChannelUID(getThing().getUID(), UID_ASH_TX_DAT),
+                                new DecimalType(counters.get(ASH_TX_DAT)));
+                        updateState(new ChannelUID(getThing().getUID(), UID_ASH_RX_ACK),
+                                new DecimalType(counters.get(ASH_RX_ACK)));
+                        updateState(new ChannelUID(getThing().getUID(), UID_ASH_TX_ACK),
+                                new DecimalType(counters.get(ASH_TX_ACK)));
+                        updateState(new ChannelUID(getThing().getUID(), UID_ASH_RX_NAK),
+                                new DecimalType(counters.get(ASH_RX_NAK)));
+                        updateState(new ChannelUID(getThing().getUID(), UID_ASH_TX_NAK),
+                                new DecimalType(counters.get(ASH_TX_NAK)));
+                    }
                 }
-            }
-        };
+            };
 
-        pollingJob = scheduler.scheduleAtFixedRate(pollingRunnable, 30, 30, TimeUnit.SECONDS);
+            pollingJob = scheduler.scheduleAtFixedRate(pollingRunnable, 30, 30, TimeUnit.SECONDS);
+        }
     }
 
     @Override
@@ -278,4 +195,94 @@ public class EmberHandler extends ZigBeeCoordinatorHandler implements FirmwareUp
         return true;
     }
 
+    private ZigBeeDongleEzsp createDongle(EmberConfiguration config) {
+        FlowControl flowControl;
+        if (ZigBeeBindingConstants.FLOWCONTROL_CONFIG_HARDWARE_CTSRTS.equals(config.zigbee_flowcontrol)) {
+            flowControl = FlowControl.FLOWCONTROL_OUT_RTSCTS;
+        } else if (ZigBeeBindingConstants.FLOWCONTROL_CONFIG_SOFTWARE_XONXOFF.equals(config.zigbee_flowcontrol)) {
+            flowControl = FlowControl.FLOWCONTROL_OUT_XONOFF;
+        } else {
+            flowControl = FlowControl.FLOWCONTROL_OUT_NONE;
+        }
+
+        ZigBeePort serialPort = new ZigBeeSerialPort(serialPortManager, config.zigbee_port, config.zigbee_baud,
+                flowControl);
+        final ZigBeeDongleEzsp dongle = new ZigBeeDongleEzsp(serialPort);
+
+        logger.debug("ZigBee Ember Coordinator opening Port:'{}' PAN:{}, EPAN:{}, Channel:{}", config.zigbee_port,
+                Integer.toHexString(panId), extendedPanId, Integer.toString(channelId));
+
+        dongle.updateDefaultConfiguration(EzspConfigId.EZSP_CONFIG_ADDRESS_TABLE_SIZE, config.zigbee_networksize);
+
+        dongle.updateDefaultConfiguration(EzspConfigId.EZSP_CONFIG_TX_POWER_MODE, config.zigbee_powermode);
+
+        // We don't need to receive broadcast and multicast messages that we send
+        dongle.passLoopbackMessages(false);
+
+        // Set the child aging timeout.
+        // Formulae is EZSP_CONFIG_END_DEVICE_POLL_TIMEOUT * 2 ^ EZSP_CONFIG_END_DEVICE_POLL_TIMEOUT_SHIFT
+        int pollTimeoutValue;
+        int pollTimeoutShift;
+
+        if (config.zigbee_childtimeout <= 320) {
+            pollTimeoutValue = 5;
+            pollTimeoutShift = 6;
+        } else if (config.zigbee_childtimeout <= 1800) {
+            pollTimeoutValue = 225;
+            pollTimeoutShift = 3;
+        } else if (config.zigbee_childtimeout <= 7200) {
+            pollTimeoutValue = 225;
+            pollTimeoutShift = 5;
+        } else if (config.zigbee_childtimeout <= 43200) {
+            pollTimeoutValue = 169;
+            pollTimeoutShift = 8;
+        } else if (config.zigbee_childtimeout <= 86400) {
+            pollTimeoutValue = 169;
+            pollTimeoutShift = 9;
+        } else if (config.zigbee_childtimeout <= 172800) {
+            pollTimeoutValue = 169;
+            pollTimeoutShift = 10;
+        } else if (config.zigbee_childtimeout <= 432000) {
+            pollTimeoutValue = 211;
+            pollTimeoutShift = 11;
+        } else if (config.zigbee_childtimeout <= 864000) {
+            pollTimeoutValue = 211;
+            pollTimeoutShift = 12;
+        } else if (config.zigbee_childtimeout <= 1209600) {
+            pollTimeoutValue = 147;
+            pollTimeoutShift = 13;
+        } else if (config.zigbee_childtimeout <= 2419200) {
+            pollTimeoutValue = 147;
+            pollTimeoutShift = 14;
+        } else {
+            pollTimeoutValue = 255;
+            pollTimeoutShift = 14;
+        }
+
+        logger.debug("Ember end device poll timeout set to ({} * 2^{}) = {} seconds", pollTimeoutValue,
+                pollTimeoutShift, (int) (pollTimeoutValue * Math.pow(2, pollTimeoutShift)));
+        dongle.updateDefaultConfiguration(EzspConfigId.EZSP_CONFIG_END_DEVICE_POLL_TIMEOUT, pollTimeoutValue);
+        dongle.updateDefaultConfiguration(EzspConfigId.EZSP_CONFIG_END_DEVICE_POLL_TIMEOUT_SHIFT, pollTimeoutShift);
+
+        return dongle;
+    }
+
+    private TransportConfig createTransportConfig(EmberConfiguration config) {
+        TransportConfig transportConfig = new TransportConfig();
+
+        // Configure the concentrator
+        // Max Hops defaults to system max
+        ConcentratorConfig concentratorConfig = new ConcentratorConfig();
+        if (config.zigbee_concentrator == 1) {
+            concentratorConfig.setType(ConcentratorType.HIGH_RAM);
+        } else {
+            concentratorConfig.setType(ConcentratorType.LOW_RAM);
+        }
+        concentratorConfig.setMaxFailures(8);
+        concentratorConfig.setMaxHops(0);
+        concentratorConfig.setRefreshMinimum(60);
+        concentratorConfig.setRefreshMaximum(3600);
+        transportConfig.addOption(TransportConfigOption.CONCENTRATOR_CONFIG, concentratorConfig);
+        return transportConfig;
+    }
 }

--- a/org.openhab.binding.zigbee.xbee/src/main/java/org/openhab/binding/zigbee/xbee/handler/XBeeHandler.java
+++ b/org.openhab.binding.zigbee.xbee/src/main/java/org/openhab/binding/zigbee/xbee/handler/XBeeHandler.java
@@ -50,14 +50,29 @@ public class XBeeHandler extends ZigBeeCoordinatorHandler {
     }
 
     @Override
-    public void initialize() {
+    public void initializeDongle() {
         logger.debug("Initializing ZigBee XBee serial bridge handler.");
 
-        // Call the parent to finish any global initialisation
-        super.initialize();
-
         XBeeConfiguration config = getConfigAs(XBeeConfiguration.class);
+        ZigBeeTransportTransmit dongle = createDongle(config);
+        TransportConfig transportConfig = new TransportConfig();
 
+        startZigBee(dongle, transportConfig, DefaultSerializer.class, DefaultDeserializer.class);
+    }
+
+    private ZigBeeTransportTransmit createDongle(XBeeConfiguration config) {
+        FlowControl flowControl = createFlowControl(config);
+        ZigBeePort serialPort = new ZigBeeSerialPort(serialPortManager, config.zigbee_port, config.zigbee_baud,
+                flowControl);
+        ZigBeeTransportTransmit dongle = new ZigBeeDongleXBee(serialPort);
+
+        logger.debug("ZigBee XBee Coordinator opening Port:'{}' PAN:{}, EPAN:{}, Channel:{}", config.zigbee_port,
+                Integer.toHexString(panId), extendedPanId, Integer.toString(channelId));
+
+        return dongle;
+    }
+
+    private FlowControl createFlowControl(XBeeConfiguration config) {
         FlowControl flowControl;
         if (ZigBeeBindingConstants.FLOWCONTROL_CONFIG_HARDWARE_CTSRTS.equals(config.zigbee_flowcontrol)) {
             flowControl = FlowControl.FLOWCONTROL_OUT_RTSCTS;
@@ -67,16 +82,7 @@ public class XBeeHandler extends ZigBeeCoordinatorHandler {
             flowControl = FlowControl.FLOWCONTROL_OUT_NONE;
         }
 
-        ZigBeePort serialPort = new ZigBeeSerialPort(serialPortManager, config.zigbee_port, config.zigbee_baud,
-                flowControl);
-        final ZigBeeTransportTransmit dongle = new ZigBeeDongleXBee(serialPort);
-
-        logger.debug("ZigBee XBee Coordinator opening Port:'{}' PAN:{}, EPAN:{}, Channel:{}", config.zigbee_port,
-                Integer.toHexString(panId), extendedPanId, Integer.toString(channelId));
-
-        TransportConfig transportConfig = new TransportConfig();
-
-        startZigBee(dongle, transportConfig, DefaultSerializer.class, DefaultDeserializer.class);
+        return flowControl;
     }
 
 }


### PR DESCRIPTION
This improves the restarting of the binding if there is an error.

https://github.com/openhab/org.openhab.binding.zigbee/issues/440

Replaces #477 
Relates to #474 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>