### PR TITLE
Remove unnecessary discoveries

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeDiscoveryService.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeDiscoveryService.java
@@ -133,7 +133,7 @@ public class ZigBeeDiscoveryService extends AbstractDiscoveryService {
 
         for (ZigBeeCoordinatorHandler coordinator : coordinatorHandlers) {
             for (ZigBeeNode node : coordinator.getNodes()) {
-                if (node.getNetworkAddress() == 0) {
+                if (node.getNetworkAddress() == 0 || node.isDiscovered()) {
                     continue;
                 }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -220,7 +220,10 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
         coordinatorHandler = (ZigBeeCoordinatorHandler) getBridge().getHandler();
         coordinatorHandler.addNetworkNodeListener(this);
         coordinatorHandler.addAnnounceListener(this);
-        coordinatorHandler.rediscoverNode(nodeIeeeAddress);
+        ZigBeeNode node = coordinatorHandler.getNode(nodeIeeeAddress);
+        if (!node.isDiscovered()) {
+            coordinatorHandler.rediscoverNode(nodeIeeeAddress);
+        }
 
         initialiseZigBeeNode();
     }


### PR DESCRIPTION
Reduce the traffic on the network, especially when a zigbee `scan` is initiated.

This fixes the issue of new nodes failing to join an existing network (~5 ROUTERs and 15 END_DEVICEs) due to excessive traffic.