### PR TITLE
Timeout from commands will be interpreted as thing being OFFLINE

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
@@ -305,8 +305,7 @@ public abstract class ZigBeeBaseChannelConverter {
      * <p>
      * Ideally, implementations should use the {@link ZclCluster#discoverAttributes(boolean)} method and the
      * {@link ZclCluster#isAttributeSupported(int)} method to understand exactly what the device supports and only
-     * provide
-     * configuration as necessary.
+     * provide configuration as necessary.
      * <p>
      * This method should not be overridden - the {@link #configOptions} list should be populated during converter
      * initialisation.
@@ -361,10 +360,10 @@ public abstract class ZigBeeBaseChannelConverter {
     protected void handleReportingResponse(CommandResult reportResponse, int reportingFailedPollingInterval,
             int reportingSuccessMaxReportInterval) {
         if (!reportResponse.isSuccess()) {
-            // we want the minimum of all pollingPeriods
+            // We want the minimum of all pollingPeriods
             pollingPeriod = Math.min(pollingPeriod, reportingFailedPollingInterval);
         } else {
-            // we want to know the minimum of all maximum reporting periods to be used as a timeout value
+            // We want to know the minimum of all maximum reporting periods to be used as a timeout value
             minimalReportingPeriod = Math.min(minimalReportingPeriod, reportingSuccessMaxReportInterval);
         }
     }
@@ -481,19 +480,41 @@ public abstract class ZigBeeBaseChannelConverter {
     }
 
     /**
-     * Monitors the command response. If the command fails, then we set the thing OFFLINE.
+     * Monitors the command response.
+     * <ul>
+     * <li>If the command fails (timeout), then we set the thing OFFLINE.
+     * <li>If the command succeeds, we wait for an attribute report to update the state
+     * <li>If there is no attribute report received, then we set the state to the original command (if applicable)
+     * </ul>
      * <p>
      * Note that this is called from a separate thread created in the ThingHandler, so we can safely block here.
      *
-     * @param futureResponse the response from the sendCommand method when sending a command
+     * @param command the {@link Command} that was sent from the framework
+     * @param futureResponse the response from the sendCommand method when sending a command (may be null)
      */
-    protected void monitorCommandResponse(final Future<CommandResult> futureResponse) {
+    protected void monitorCommandResponse(final Command command, final Future<CommandResult> futureResponse) {
+        if (futureResponse == null) {
+            return;
+        }
         try {
+            logger.debug("{}: Channel {} waiting for response to {}", endpoint.getIeeeAddress(), channelUID, command);
             CommandResult response = futureResponse.get();
             if (response.isTimeout()) {
+                logger.debug("{}: Channel {} received TIMEOUT in response to {}", endpoint.getIeeeAddress(), channelUID,
+                        command);
                 thing.aliveTimeoutReached();
+                return;
             }
+            if (response.isError()) {
+                logger.debug("{}: Channel {} received ERROR in response to {}", endpoint.getIeeeAddress(), channelUID,
+                        command);
+                return;
+            }
+            logger.debug("{}: Channel {} received SUCCESS in response to {}", endpoint.getIeeeAddress(), channelUID,
+                    command);
+            thing.alive();
         } catch (InterruptedException | ExecutionException e) {
         }
     }
+
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import org.eclipse.jdt.annotation.NonNull;
@@ -477,5 +478,22 @@ public abstract class ZigBeeBaseChannelConverter {
     protected Future<CommandResult> bind(ZclCluster cluster) {
         return cluster.bind(coordinator.getLocalIeeeAddress(),
                 coordinator.getLocalEndpointId(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION));
+    }
+
+    /**
+     * Monitors the command response. If the command fails, then we set the thing OFFLINE.
+     * <p>
+     * Note that this is called from a separate thread created in the ThingHandler, so we can safely block here.
+     *
+     * @param futureResponse the response from the sendCommand method when sending a command
+     */
+    protected void monitorCommandResponse(final Future<CommandResult> futureResponse) {
+        try {
+            CommandResult response = futureResponse.get();
+            if (response.isTimeout()) {
+                thing.aliveTimeoutReached();
+            }
+        } catch (InterruptedException | ExecutionException e) {
+        }
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -496,6 +496,13 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
         updateStatus(ThingStatus.OFFLINE);
     }
 
+    /**
+     * If the channel converter responds to a command, then the thing is considered ONLINE
+     */
+    public void alive() {
+        updateStatus(ThingStatus.ONLINE);
+    }
+
     private synchronized void initializeDevice() {
         logger.debug("{}: Initializing device", nodeIeeeAddress);
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -58,11 +59,13 @@ import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.StepCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.StepWithOnOffCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.StopCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.StopWithOnOffCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.ZclLevelControlCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.onoff.OffCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.onoff.OffWithEffectCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.onoff.OnCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.onoff.OnWithTimedOffCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.onoff.ToggleCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.onoff.ZclOnOffCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
 
 /**
@@ -352,12 +355,13 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
 
     @Override
     public void handleCommand(final Command command) {
+        Future<CommandResult> responseFuture = null;
         if (command instanceof OnOffType) {
-            handleOnOffCommand((OnOffType) command);
+            responseFuture = handleOnOffCommand((OnOffType) command);
         } else if (command instanceof PercentType) {
-            handlePercentCommand((PercentType) command);
+            responseFuture = handlePercentCommand((PercentType) command);
         } else if (command instanceof IncreaseDecreaseType) {
-            handleIncreaseDecreaseCommand((IncreaseDecreaseType) command);
+            responseFuture = handleIncreaseDecreaseCommand((IncreaseDecreaseType) command);
         } else {
             logger.warn("{}: Level converter only accepts PercentType, IncreaseDecreaseType and OnOffType - not {}",
                     endpoint.getIeeeAddress(), command.getClass().getSimpleName());
@@ -365,44 +369,54 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
 
         // Some functionality (eg IncreaseDecrease) requires that we know the last command received
         lastCommand = command;
+        if (responseFuture != null) {
+            monitorCommandResponse(responseFuture);
+        }
     }
 
     /**
      * If we support the OnOff cluster then we should perform the same function as the SwitchOnoffConverter. Otherwise,
      * interpret ON commands as moving to level 100%, and OFF commands as moving to level 0%.
+     *
+     * @return command result future
      */
-    private void handleOnOffCommand(OnOffType cmdOnOff) {
+    private Future<CommandResult> handleOnOffCommand(OnOffType cmdOnOff) {
         if (clusterOnOffServer != null) {
+            ZclOnOffCommand onOffCommand;
             if (cmdOnOff == OnOffType.ON) {
-                clusterOnOffServer.onCommand();
+                onOffCommand = new OnCommand();
             } else {
-                clusterOnOffServer.offCommand();
+                onOffCommand = new OffCommand();
             }
+            return clusterOnOffServer.sendCommand(onOffCommand);
         } else {
             if (cmdOnOff == OnOffType.ON) {
-                moveToLevel(PercentType.HUNDRED);
+                return moveToLevel(PercentType.HUNDRED);
             } else {
-                moveToLevel(PercentType.ZERO);
+                return moveToLevel(PercentType.ZERO);
             }
         }
     }
 
-    private void handlePercentCommand(PercentType cmdPercent) {
-        moveToLevel(cmdPercent);
+    private Future<CommandResult> handlePercentCommand(PercentType cmdPercent) {
+        return moveToLevel(cmdPercent);
     }
 
-    private void moveToLevel(PercentType percent) {
+    private Future<CommandResult> moveToLevel(PercentType percent) {
+        ZclLevelControlCommand levelControlCommand = null;
         if (clusterOnOffServer != null) {
             if (percent.equals(PercentType.ZERO)) {
-                clusterOnOffServer.offCommand();
+                return clusterOnOffServer.sendCommand(new OffCommand());
             } else {
-                clusterLevelControlServer.moveToLevelWithOnOffCommand(percentToLevel(percent),
+                levelControlCommand = new MoveToLevelWithOnOffCommand(percentToLevel(percent),
                         configLevelControl.getDefaultTransitionTime());
             }
         } else {
-            clusterLevelControlServer.moveToLevelCommand(percentToLevel(percent),
+            levelControlCommand = new MoveToLevelCommand(percentToLevel(percent),
                     configLevelControl.getDefaultTransitionTime());
         }
+
+        return clusterLevelControlServer.sendCommand(levelControlCommand);
     }
 
     /**
@@ -416,20 +430,26 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
      *
      * @param cmdIncreaseDecrease the command received
      */
-    private void handleIncreaseDecreaseCommand(IncreaseDecreaseType cmdIncreaseDecrease) {
+    private Future<CommandResult> handleIncreaseDecreaseCommand(IncreaseDecreaseType cmdIncreaseDecrease) {
+        ZclLevelControlCommand levelControlCommand = null;
         if (!cmdIncreaseDecrease.equals(lastCommand)) {
             switch (cmdIncreaseDecrease) {
                 case INCREASE:
-                    clusterLevelControlServer.moveWithOnOffCommand(0, 50);
-                    break;
+                    levelControlCommand = new MoveWithOnOffCommand(0, 50);
                 case DECREASE:
-                    clusterLevelControlServer.moveWithOnOffCommand(1, 50);
+                    levelControlCommand = new MoveWithOnOffCommand(1, 50);
                     break;
                 default:
                     break;
             }
         }
+
         startStopTimer(INCREASEDECREASE_TIMEOUT);
+        if (levelControlCommand != null) {
+            return clusterLevelControlServer.sendCommand(levelControlCommand);
+        }
+
+        return null;
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -365,13 +365,12 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
         } else {
             logger.warn("{}: Level converter only accepts PercentType, IncreaseDecreaseType and OnOffType - not {}",
                     endpoint.getIeeeAddress(), command.getClass().getSimpleName());
+            return;
         }
 
         // Some functionality (eg IncreaseDecrease) requires that we know the last command received
         lastCommand = command;
-        if (responseFuture != null) {
-            monitorCommandResponse(responseFuture);
-        }
+        monitorCommandResponse(command, responseFuture);
     }
 
     /**

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -231,7 +231,7 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
         } else {
             onOffCommand = new OffCommand();
         }
-        monitorCommandResponse(clusterOnOffServer.sendCommand(onOffCommand));
+        monitorCommandResponse(command, clusterOnOffServer.sendCommand(onOffCommand));
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -52,6 +52,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.onoff.OffWithEffectCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.onoff.OnCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.onoff.OnWithTimedOffCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.onoff.ToggleCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.onoff.ZclOnOffCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
 
 /**
@@ -145,7 +146,6 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
             return false;
         }
 
-
         if (clusterOnOffServer != null) {
             // Add the listener
             clusterOnOffServer.addAttributeListener(this);
@@ -225,11 +225,13 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
             return;
         }
 
+        ZclOnOffCommand onOffCommand;
         if (cmdOnOff == OnOffType.ON) {
-            clusterOnOffServer.onCommand();
+            onOffCommand = new OnCommand();
         } else {
-            clusterOnOffServer.offCommand();
+            onOffCommand = new OffCommand();
         }
+        monitorCommandResponse(clusterOnOffServer.sendCommand(onOffCommand));
     }
 
     @Override


### PR DESCRIPTION
Currently this is only implemented in the Switch and Dimmer channels.  This also migrates away from the deprecated command methods in these converters.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>