### PR TITLE
Improved thing removal management

### DIFF
--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -280,7 +280,7 @@ Note that the last four characters in the install code are the checksum and may 
 
 ## Leave
 
-When a thing is deleted, the binding will attempt to remove the device from the network by sending the *leave* command on the network.
+When a thing is deleted, the binding will attempt to remove the device from the network by sending the *leave* command on the network. The binding will put the Thing into the `REMOVING` state and once the leave is confirmed it will be finally `REMOVED`. It is not advised for force remove the Thing as this may cause an incomplete removal, and the device may be immediately added back to the Inbox.
 
 ## Thing Configuration
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -977,6 +977,18 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
     }
 
     /**
+     * Removes a node from the network manager and deletes the data store files. This does not cause the network manager
+     * to tell the node to leave the network, and should only be used if the device has already left the network, or we
+     * are permanently deleting it.
+     *
+     * @param nodeIeeeAddress the {@link IeeeAddress} of the node to delete
+     */
+    public void deleteNode(IeeeAddress nodeIeeeAddress) {
+        removeNode(nodeIeeeAddress);
+        networkDataStore.removeNode(nodeIeeeAddress);
+    }
+
+    /**
      * Permit joining only for the specified node
      *
      * @param address the 16 bit network address of the node to enable joining


### PR DESCRIPTION
This improves the handling of ZigBee thing removal by deleting the persistence file once the device is removed from the network if the user has requested the thing is removed from the framework.

If the user force removes the thing then the persistence file will be retained and the thing may still be re-added to the Inbox during discovery however the binding is not notified about force removal (see https://github.com/openhab/openhab-core/issues/1571).

Signed-off-by: Chris Jackson <chris@cd-jackson.com>