### PR TITLE
Add lumi.sensor_magnet static thing definition

### DIFF
--- a/org.openhab.binding.zigbee/src/main/resources/ESH-INF/thing/xiaomi/lumisensor-magnet.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/ESH-INF/thing/xiaomi/lumisensor-magnet.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zigbee"
+                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                          xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+                          xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+    <!-- This is needed to avoid the device being considered just a Level Control client -->
+
+    <thing-type id="xiaomi_lumisensormagnet" listed="false">
+        <label>Xiaomi Door Window Sensor</label>
+
+        <channels>
+            <channel id="contact_switch" typeId="switch_onoff">
+                <label>Contact open (Switch)</label>
+                <description>The magnetic contact, seen by the device as a switch that is on when the contact is open</description>
+                <properties>
+                    <property name="zigbee_endpoint">1</property>
+                    <property name="zigbee_inputclusters">6</property>
+                </properties>
+            </channel>
+        </channels>
+
+        <properties>
+            <property name="vendor">Xiaomi</property>
+            <property name="modelId">lumi.sensor_magnet</property>
+            <property name="zigbee_logicaltype">END_DEVICE</property>
+        </properties>
+
+        <representation-property>zigbee_macaddress</representation-property>
+
+        <config-description>
+            <parameter name="zigbee_macaddress" type="text" readOnly="true" required="true">
+                <label>MAC Address</label>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/org.openhab.binding.zigbee/src/main/resources/discovery.txt
+++ b/org.openhab.binding.zigbee/src/main/resources/discovery.txt
@@ -9,5 +9,6 @@ xiaomi_lumiremoteb286acn01,modelId=lumi.remote.b286acn01
 xiaomi_lumisensor86sw2,modelId=lumi.sensor_86sw2
 xiaomi_lumisensor-switchaq2,modelId=lumi.sensor_switch.aq2
 xiaomi_lumisensorwaterleak,modelId=lumi.sensor_wleak.aq1
+xiaomi_lumisensormagnet,modelId=lumi.sensor_magnet
 innr-rc-110,vendor=innr,modelId=RC 110
 osram-switch-4x-eu,vendor=OSRAM,modelId=Switch 4x EU-LIGHTIFY


### PR DESCRIPTION
This is a workaround for the #601 issue that was causing the Zigbee binding don't get any attribute update report from the On Off server cluster of that device.

I've tested this with my MCCGQ01LM Xiaomi Door Window Sensor, and it's working fine.

I'm not sure if the channel name is acceptable for Openhab standards, but I haven't found a better name :) 
It's an hacky solution anyway, since the magnetic contact is seen as a Switch instead of a Contact. If from Openhab you try to toggle that switch, the operation will obviously fail.