### PR TITLE
Refactor channel converter to support device configuration during discovery

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
@@ -180,19 +180,16 @@ public abstract class ZigBeeBaseChannelConverter {
     /**
      * Creates the converter handler.
      *
-     * @param thing the {@link ZigBeeThingHandler} the channel is part of
      * @param channel the {@link Channel} for the channel
      * @param coordinator the {@link ZigBeeCoordinatorHandler} this endpoint is part of
      * @param address the {@link IeeeAddress} of the node
      * @param endpointId the endpoint this channel is linked to
      */
-    public void initialize(ZigBeeThingHandler thing, Channel channel, ZigBeeCoordinatorHandler coordinator,
-            IeeeAddress address, int endpointId) {
+    public void initialize(Channel channel, ZigBeeCoordinatorHandler coordinator, IeeeAddress address, int endpointId) {
         this.endpoint = coordinator.getEndpoint(address, endpointId);
         if (this.endpoint == null) {
-            throw new IllegalArgumentException("Device was not found");
+            throw new IllegalArgumentException("Endpoint was not found");
         }
-        this.thing = thing;
         this.channel = channel;
         this.channelUID = channel.getUID();
         this.coordinator = coordinator;
@@ -236,9 +233,13 @@ public abstract class ZigBeeBaseChannelConverter {
      * A list of configuration parameters for the thing should be built and added to {@link #configOptions} based on the
      * features the device supports.
      *
+     * @param thing the {@link ZigBeeThingHandler} the channel is part of
      * @return true if the converter was initialised successfully
      */
-    public abstract boolean initializeConverter();
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        this.thing = thing;
+        return false;
+    }
 
     /**
      * Closes the converter and releases any resources.

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeChannelConverterFactory.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeChannelConverterFactory.java
@@ -19,7 +19,6 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
-import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
@@ -33,7 +32,7 @@ import com.zsmartsystems.zigbee.ZigBeeEndpoint;
  * <li>instantiates converters based on the channel UID.
  * </ul>
  *
- * @author Chris Jackson
+ * @author Chris Jackson - initial contribution. Refactored to remove ThingHandler from createConverter
  * @author Thomas Höfer - osgified the mechanism how converters are made available to the binding
  */
 public interface ZigBeeChannelConverterFactory {
@@ -51,15 +50,14 @@ public interface ZigBeeChannelConverterFactory {
     /**
      * Creates a channel converter for the requested {@link ChannelTypeUID}
      *
-     * @param thingHandler the {@link ZigBeeThingHandler} for this channel
      * @param channel the {@link Channel} to create the converter for
      * @param coordinatorHandler the {@link ZigBeeCoordinatorHandler}
      * @param ieeeAddress the {@link IeeeAddress} of the device
      * @param endpointId the endpoint ID for this channel on the device
      * @return the {@link ZigBeeBaseChannelConverter} or null if the channel is not supported
      */
-    ZigBeeBaseChannelConverter createConverter(ZigBeeThingHandler thingHandler, Channel channel,
-            ZigBeeCoordinatorHandler coordinatorHandler, IeeeAddress ieeeAddress, int endpointId);
+    ZigBeeBaseChannelConverter createConverter(Channel channel, ZigBeeCoordinatorHandler coordinatorHandler,
+            IeeeAddress ieeeAddress, int endpointId);
 
     /**
      * Gets the cluster IDs that are supported by all converters known to the system

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeDiscoveryService.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeDiscoveryService.java
@@ -25,11 +25,14 @@ import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
+import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.UID;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.converter.ZigBeeChannelConverterFactory;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -41,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.ZigBeeNetworkNodeListener;
 import com.zsmartsystems.zigbee.ZigBeeNode;
 import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.LogicalType;
@@ -73,6 +77,8 @@ public class ZigBeeDiscoveryService extends AbstractDiscoveryService {
     private final Set<ZigBeeDiscoveryParticipant> participants = new CopyOnWriteArraySet<>();
     private final Map<UID, ZigBeeNetworkNodeListener> registeredListeners = new ConcurrentHashMap<>();
 
+    private ZigBeeChannelConverterFactory zigbeeChannelConverterFactory;
+
     public ZigBeeDiscoveryService() {
         super(SEARCH_TIME);
         logger.debug("Starting ZigBeeDiscoveryService");
@@ -85,6 +91,15 @@ public class ZigBeeDiscoveryService extends AbstractDiscoveryService {
 
     protected void removeZigBeeDiscoveryParticipant(ZigBeeDiscoveryParticipant participant) {
         participants.remove(participant);
+    }
+
+    @Reference
+    protected void setZigBeeChannelConverterFactory(ZigBeeChannelConverterFactory zigbeeChannelConverterFactory) {
+        this.zigbeeChannelConverterFactory = zigbeeChannelConverterFactory;
+    }
+
+    protected void unsetZigBeeChannelConverterFactory(ZigBeeChannelConverterFactory zigbeeChannelConverterFactory) {
+        this.zigbeeChannelConverterFactory = null;
     }
 
     @Override
@@ -199,7 +214,7 @@ public class ZigBeeDiscoveryService extends AbstractDiscoveryService {
                     return;
                 }
 
-                // Perform the device properties discovery
+                // Perform the device properties discovery.
                 // This is designed to allow us to provide the users with more information about what the device is.
                 // This information is also performed here so that it is available to discovery participants
                 // as this can take some time and discovery participants should return promptly.
@@ -220,6 +235,32 @@ public class ZigBeeDiscoveryService extends AbstractDiscoveryService {
                         }
                     } catch (Exception e) {
                         logger.error("Participant '{}' threw an exception", participant.getClass().getName(), e);
+                    }
+                }
+
+                // Perform a service discovery.
+                // This is performed here to allow us to configure the device while it is awake - ie during the initial
+                // association and discovery. Many battery devices will quickly go to sleep, and if we don't perform the
+                // service interrogation here the device may have gone to sleep by the time it the channels are
+                // discovered and created in the thing handler.
+                for (ZigBeeEndpoint endpoint : node.getEndpoints()) {
+                    logger.debug("{}: Checking endpoint {} channels", node.getIeeeAddress(), endpoint.getEndpointId());
+                    for (Channel channel : zigbeeChannelConverterFactory.getChannels(defaultThingUID, endpoint)) {
+                        // ZigBeeBaseChannelConverter handler = createZigBeeBaseChannelConverter(channel);
+                        ZigBeeBaseChannelConverter channelConverter = zigbeeChannelConverterFactory
+                                .createConverter(channel, coordinator, node.getIeeeAddress(), endpoint.getEndpointId());
+                        if (channelConverter == null) {
+                            logger.debug("{}: No channel converter found for {}", node.getIeeeAddress(),
+                                    channel.getUID());
+                            continue;
+                        }
+
+                        logger.debug("{}: Initializing channel {} with {}", node.getIeeeAddress(), channel.getUID(),
+                                channelConverter);
+                        if (channelConverter.initializeDevice() == false) {
+                            logger.info("{}: Channel {} failed to initialise device", node.getIeeeAddress(),
+                                    channel.getUID());
+                        }
                     }
                 }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -388,13 +388,13 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
 
             // Create the channel map to simplify processing incoming events
             for (Channel channel : getThing().getChannels()) {
-                ZigBeeBaseChannelConverter handler = createZigBeeBaseChannelConverter(channel);
+                ZigBeeBaseChannelConverter handler = createZigBeeChannelConverter(channel);
                 if (handler == null) {
                     logger.debug("{}: No handler found for {}", nodeIeeeAddress, channel.getUID());
                     continue;
                 }
 
-                if (handler.initializeConverter() == false) {
+                if (handler.initializeConverter(this) == false) {
                     logger.info("{}: Channel {} failed to initialise converter", nodeIeeeAddress, channel.getUID());
                     continue;
                 }
@@ -503,7 +503,7 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
 
         boolean channelInitializationSuccessful = true;
         for (Channel channel : getThing().getChannels()) {
-            ZigBeeBaseChannelConverter handler = createZigBeeBaseChannelConverter(channel);
+            ZigBeeBaseChannelConverter handler = createZigBeeChannelConverter(channel);
             if (handler == null) {
                 logger.debug("{}: No handler found for {}", nodeIeeeAddress, channel.getUID());
                 continue;
@@ -520,10 +520,10 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
                 channelInitializationSuccessful ? Boolean.TRUE.toString() : Boolean.FALSE.toString());
     }
 
-    private ZigBeeBaseChannelConverter createZigBeeBaseChannelConverter(Channel channel) {
+    private ZigBeeBaseChannelConverter createZigBeeChannelConverter(Channel channel) {
         ZigBeeNode node = coordinatorHandler.getNode(nodeIeeeAddress);
         Map<String, String> properties = channel.getProperties();
-        return channelFactory.createConverter(this, channel, coordinatorHandler, node.getIeeeAddress(),
+        return channelFactory.createConverter(channel, coordinatorHandler, node.getIeeeAddress(),
                 Integer.parseInt(properties.get(ZigBeeBindingConstants.CHANNEL_PROPERTY_ENDPOINT)));
     }
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactoryImpl.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactoryImpl.java
@@ -29,7 +29,6 @@ import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
 import org.openhab.binding.zigbee.converter.ZigBeeChannelConverterFactory;
 import org.openhab.binding.zigbee.converter.ZigBeeChannelConverterProvider;
 import org.openhab.binding.zigbee.handler.ZigBeeCoordinatorHandler;
-import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -104,8 +103,8 @@ public final class ZigBeeChannelConverterFactoryImpl implements ZigBeeChannelCon
     }
 
     @Override
-    public ZigBeeBaseChannelConverter createConverter(ZigBeeThingHandler thingHandler, Channel channel,
-            ZigBeeCoordinatorHandler coordinatorHandler, IeeeAddress ieeeAddress, int endpointId) {
+    public ZigBeeBaseChannelConverter createConverter(Channel channel, ZigBeeCoordinatorHandler coordinatorHandler,
+            IeeeAddress ieeeAddress, int endpointId) {
         Constructor<? extends ZigBeeBaseChannelConverter> constructor;
         try {
             if (channelMap.get(channel.getChannelTypeUID()) == null) {
@@ -116,7 +115,7 @@ public final class ZigBeeChannelConverterFactoryImpl implements ZigBeeChannelCon
             constructor = channelMap.get(channel.getChannelTypeUID()).getConstructor();
             ZigBeeBaseChannelConverter instance = constructor.newInstance();
 
-            instance.initialize(thingHandler, channel, coordinatorHandler, ieeeAddress, endpointId);
+            instance.initialize(channel, coordinatorHandler, ieeeAddress, endpointId);
             return instance;
         } catch (Exception e) {
             logger.error("{}: Unable to create channel {}", ieeeAddress, channel.getUID(), e);
@@ -177,4 +176,5 @@ public final class ZigBeeChannelConverterFactoryImpl implements ZigBeeChannelCon
 
         return clusters;
     }
+
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
@@ -29,6 +29,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,7 +110,8 @@ public class ZigBeeConverterAtmosphericPressure extends ZigBeeBaseChannelConvert
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         cluster = (ZclPressureMeasurementCluster) endpoint.getInputCluster(ZclPressureMeasurementCluster.CLUSTER_ID);
         if (cluster == null) {
             logger.error("{}: Error opening device pressure measurement cluster", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
@@ -26,6 +26,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,7 +116,8 @@ public class ZigBeeConverterBatteryAlarm extends ZigBeeBaseChannelConverter impl
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         cluster = (ZclPowerConfigurationCluster) endpoint.getInputCluster(ZclPowerConfigurationCluster.CLUSTER_ID);
         if (cluster == null) {
             logger.error("{}: Error opening power configuration cluster", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
@@ -24,6 +24,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,7 +89,8 @@ public class ZigBeeConverterBatteryPercent extends ZigBeeBaseChannelConverter im
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         cluster = (ZclPowerConfigurationCluster) endpoint.getInputCluster(ZclPowerConfigurationCluster.CLUSTER_ID);
         if (cluster == null) {
             logger.error("{}: Error opening power configuration cluster", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
@@ -26,6 +26,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,7 +86,8 @@ public class ZigBeeConverterBatteryVoltage extends ZigBeeBaseChannelConverter im
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         cluster = (ZclPowerConfigurationCluster) endpoint.getInputCluster(ZclPowerConfigurationCluster.CLUSTER_ID);
         if (cluster == null) {
             logger.error("{}: Error opening power configuration cluster", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBinaryInput.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBinaryInput.java
@@ -22,6 +22,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +81,8 @@ public class ZigBeeConverterBinaryInput extends ZigBeeBaseChannelConverter imple
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         binaryInputCluster = (ZclBinaryInputBasicCluster) endpoint
                 .getInputCluster(ZclBinaryInputBasicCluster.CLUSTER_ID);
         if (binaryInputCluster == null) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
@@ -39,6 +39,7 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.openhab.binding.zigbee.internal.converter.config.ZclLevelControlConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -208,7 +209,8 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         colorUpdateScheduler = Executors.newSingleThreadScheduledExecutor();
 
         clusterColorControl = (ZclColorControlCluster) endpoint.getInputCluster(ZclColorControlCluster.CLUSTER_ID);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
@@ -27,6 +27,7 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,7 +107,8 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         clusterColorControl = (ZclColorControlCluster) endpoint.getInputCluster(ZclColorControlCluster.CLUSTER_ID);
         if (clusterColorControl == null) {
             logger.error("{}: Error opening color control input cluster on endpoint {}", endpoint.getIeeeAddress(),

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterDoorLock.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterDoorLock.java
@@ -23,6 +23,7 @@ import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +82,8 @@ public class ZigBeeConverterDoorLock extends ZigBeeBaseChannelConverter implemen
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         cluster = (ZclDoorLockCluster) endpoint.getInputCluster(ZclDoorLockCluster.CLUSTER_ID);
         if (cluster == null) {
             logger.error("{}: Error opening device door lock controls", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterFanControl.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterFanControl.java
@@ -29,6 +29,7 @@ import org.eclipse.smarthome.core.types.StateDescription;
 import org.eclipse.smarthome.core.types.StateOption;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,7 +96,8 @@ public class ZigBeeConverterFanControl extends ZigBeeBaseChannelConverter implem
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         cluster = (ZclFanControlCluster) endpoint.getInputCluster(ZclFanControlCluster.CLUSTER_ID);
         if (cluster == null) {
             logger.error("{}: Error opening device fan controls", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButton.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButton.java
@@ -33,6 +33,7 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,7 +84,8 @@ public class ZigBeeConverterGenericButton extends ZigBeeBaseChannelConverter
     }
 
     @Override
-    public synchronized boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         for (ButtonPressType buttonPressType : ButtonPressType.values()) {
             EventSpec eventSpec = parseEventSpec(channel.getProperties(), buttonPressType);
             if (eventSpec != null) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,7 +104,8 @@ public abstract class ZigBeeConverterIas extends ZigBeeBaseChannelConverter
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         logger.debug("{}: Initialising device IAS Zone cluster for {}", endpoint.getIeeeAddress(),
                 channel.getChannelTypeUID());
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasCieSystem.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasCieSystem.java
@@ -16,6 +16,7 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
@@ -28,9 +29,9 @@ import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
  */
 public class ZigBeeConverterIasCieSystem extends ZigBeeConverterIas {
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
         bitTest = CIE_ALARM1;
-        return super.initializeConverter();
+        return super.initializeConverter(thing);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasCoDetector.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasCoDetector.java
@@ -16,6 +16,7 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
@@ -28,9 +29,9 @@ import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
  */
 public class ZigBeeConverterIasCoDetector extends ZigBeeConverterIas {
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
         bitTest = CIE_ALARM1;
-        return super.initializeConverter();
+        return super.initializeConverter(thing);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasContactPortal1.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasContactPortal1.java
@@ -16,6 +16,7 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
@@ -28,9 +29,9 @@ import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
  */
 public class ZigBeeConverterIasContactPortal1 extends ZigBeeConverterIas {
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
         bitTest = CIE_ALARM1;
-        return super.initializeConverter();
+        return super.initializeConverter(thing);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasFireIndicator.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasFireIndicator.java
@@ -16,6 +16,7 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
@@ -28,9 +29,9 @@ import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
  */
 public class ZigBeeConverterIasFireIndicator extends ZigBeeConverterIas {
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
         bitTest = CIE_ALARM1;
-        return super.initializeConverter();
+        return super.initializeConverter(thing);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasLowBattery.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasLowBattery.java
@@ -16,6 +16,7 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 
@@ -27,9 +28,9 @@ import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 public class ZigBeeConverterIasLowBattery extends ZigBeeConverterIas {
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
         bitTest = CIE_BATTERY;
-        return super.initializeConverter();
+        return super.initializeConverter(thing);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasMotionIntrusion.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasMotionIntrusion.java
@@ -16,6 +16,7 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
@@ -28,9 +29,9 @@ import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
  */
 public class ZigBeeConverterIasMotionIntrusion extends ZigBeeConverterIas {
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
         bitTest = CIE_ALARM1;
-        return super.initializeConverter();
+        return super.initializeConverter(thing);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasMotionPresence.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasMotionPresence.java
@@ -16,6 +16,7 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
@@ -28,9 +29,9 @@ import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
  */
 public class ZigBeeConverterIasMotionPresence extends ZigBeeConverterIas {
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
         bitTest = CIE_ALARM2;
-        return super.initializeConverter();
+        return super.initializeConverter(thing);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasMovement.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasMovement.java
@@ -16,6 +16,7 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
@@ -28,9 +29,9 @@ import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
 public class ZigBeeConverterIasMovement extends ZigBeeConverterIas {
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
         bitTest = CIE_ALARM1;
-        return super.initializeConverter();
+        return super.initializeConverter(thing);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasTamper.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasTamper.java
@@ -16,6 +16,7 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 
@@ -27,9 +28,9 @@ import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 public class ZigBeeConverterIasTamper extends ZigBeeConverterIas {
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
         bitTest = CIE_TAMPER;
-        return super.initializeConverter();
+        return super.initializeConverter(thing);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasVibration.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasVibration.java
@@ -16,6 +16,7 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
@@ -28,9 +29,9 @@ import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
 public class ZigBeeConverterIasVibration extends ZigBeeConverterIas {
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
         bitTest = CIE_ALARM2;
-        return super.initializeConverter();
+        return super.initializeConverter(thing);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasWaterSensor.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasWaterSensor.java
@@ -16,6 +16,7 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
@@ -28,9 +29,9 @@ import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
  */
 public class ZigBeeConverterIasWaterSensor extends ZigBeeConverterIas {
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
         bitTest = CIE_ALARM1;
-        return super.initializeConverter();
+        return super.initializeConverter(thing);
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
@@ -27,6 +27,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.openhab.binding.zigbee.internal.converter.config.ZclReportingConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,7 +96,8 @@ public class ZigBeeConverterIlluminance extends ZigBeeBaseChannelConverter imple
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         cluster = (ZclIlluminanceMeasurementCluster) endpoint
                 .getInputCluster(ZclIlluminanceMeasurementCluster.CLUSTER_ID);
         if (cluster == null) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
@@ -26,6 +26,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,7 +92,8 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         clusterMeasurement = (ZclElectricalMeasurementCluster) endpoint
                 .getInputCluster(ZclElectricalMeasurementCluster.CLUSTER_ID);
         if (clusterMeasurement == null) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
@@ -26,6 +26,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,7 +93,8 @@ public class ZigBeeConverterMeasurementRmsCurrent extends ZigBeeBaseChannelConve
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         clusterMeasurement = (ZclElectricalMeasurementCluster) endpoint
                 .getInputCluster(ZclElectricalMeasurementCluster.CLUSTER_ID);
         if (clusterMeasurement == null) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
@@ -26,6 +26,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,7 +93,8 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         clusterMeasurement = (ZclElectricalMeasurementCluster) endpoint
                 .getInputCluster(ZclElectricalMeasurementCluster.CLUSTER_ID);
         if (clusterMeasurement == null) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
@@ -22,6 +22,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +81,8 @@ public class ZigBeeConverterOccupancy extends ZigBeeBaseChannelConverter impleme
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         clusterOccupancy = (ZclOccupancySensingCluster) endpoint.getInputCluster(ZclOccupancySensingCluster.CLUSTER_ID);
         if (clusterOccupancy == null) {
             logger.error("{}: Error opening occupancy cluster", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
@@ -23,6 +23,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +81,8 @@ public class ZigBeeConverterRelativeHumidity extends ZigBeeBaseChannelConverter 
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         cluster = (ZclRelativeHumidityMeasurementCluster) endpoint
                 .getInputCluster(ZclRelativeHumidityMeasurementCluster.CLUSTER_ID);
         if (cluster == null) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -35,6 +35,7 @@ import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.openhab.binding.zigbee.internal.converter.config.ZclLevelControlConfig;
 import org.openhab.binding.zigbee.internal.converter.config.ZclReportingConfig;
 import org.slf4j.Logger;
@@ -229,7 +230,9 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
     }
 
     @Override
-    public synchronized boolean initializeConverter() {
+    public synchronized boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
+
         updateScheduler = Executors.newSingleThreadScheduledExecutor();
 
         if (initializeConverterServer()) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -33,6 +33,7 @@ import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.openhab.binding.zigbee.internal.converter.config.ZclOnOffSwitchConfig;
 import org.openhab.binding.zigbee.internal.converter.config.ZclReportingConfig;
 import org.slf4j.Logger;
@@ -133,7 +134,8 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         updateScheduler = Executors.newSingleThreadScheduledExecutor();
 
         clusterOnOffClient = (ZclOnOffCluster) endpoint.getOutputCluster(ZclOnOffCluster.CLUSTER_ID);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
@@ -22,6 +22,7 @@ import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,7 +93,8 @@ public class ZigBeeConverterTemperature extends ZigBeeBaseChannelConverter imple
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         cluster = (ZclTemperatureMeasurementCluster) endpoint
                 .getInputCluster(ZclTemperatureMeasurementCluster.CLUSTER_ID);
         if (cluster != null) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatLocalTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatLocalTemperature.java
@@ -21,6 +21,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,7 +85,8 @@ public class ZigBeeConverterThermostatLocalTemperature extends ZigBeeBaseChannel
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         cluster = (ZclThermostatCluster) endpoint.getInputCluster(ZclThermostatCluster.CLUSTER_ID);
         if (cluster == null) {
             logger.error("{}: Error opening device thermostat cluster", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
@@ -22,6 +22,7 @@ import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,7 +87,8 @@ public class ZigBeeConverterThermostatOccupiedCooling extends ZigBeeBaseChannelC
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         cluster = (ZclThermostatCluster) endpoint.getInputCluster(ZclThermostatCluster.CLUSTER_ID);
         if (cluster == null) {
             logger.error("{}: Error opening device thermostat cluster", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedHeating.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedHeating.java
@@ -22,6 +22,7 @@ import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,7 +83,8 @@ public class ZigBeeConverterThermostatOccupiedHeating extends ZigBeeBaseChannelC
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         cluster = (ZclThermostatCluster) endpoint.getInputCluster(ZclThermostatCluster.CLUSTER_ID);
         if (cluster == null) {
             logger.error("{}: Error opening device thermostat cluster", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
@@ -21,6 +21,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,7 +83,8 @@ public class ZigBeeConverterThermostatOutdoorTemperature extends ZigBeeBaseChann
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         cluster = (ZclThermostatCluster) endpoint.getInputCluster(ZclThermostatCluster.CLUSTER_ID);
         if (cluster == null) {
             logger.error("{}: Error opening device thermostat cluster", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
@@ -22,6 +22,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,7 +89,8 @@ public class ZigBeeConverterThermostatRunningMode extends ZigBeeBaseChannelConve
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         cluster = (ZclThermostatCluster) endpoint.getInputCluster(ZclThermostatCluster.CLUSTER_ID);
         if (cluster == null) {
             logger.error("{}: Error opening device thermostat cluster", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
@@ -29,6 +29,7 @@ import org.eclipse.smarthome.core.types.StateDescription;
 import org.eclipse.smarthome.core.types.StateOption;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,7 +96,8 @@ public class ZigBeeConverterThermostatSystemMode extends ZigBeeBaseChannelConver
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         cluster = (ZclThermostatCluster) endpoint.getInputCluster(ZclThermostatCluster.CLUSTER_ID);
         if (cluster == null) {
             logger.error("{}: Error opening device thermostat cluster", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
@@ -22,6 +22,7 @@ import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,7 +84,8 @@ public class ZigBeeConverterThermostatUnoccupiedCooling extends ZigBeeBaseChanne
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         cluster = (ZclThermostatCluster) endpoint.getInputCluster(ZclThermostatCluster.CLUSTER_ID);
         if (cluster == null) {
             logger.error("{}: Error opening device thermostat cluster", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
@@ -22,6 +22,7 @@ import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,7 +86,8 @@ public class ZigBeeConverterThermostatUnoccupiedHeating extends ZigBeeBaseChanne
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         cluster = (ZclThermostatCluster) endpoint.getInputCluster(ZclThermostatCluster.CLUSTER_ID);
         if (cluster == null) {
             logger.error("{}: Error opening device thermostat cluster", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterWindowCoveringLift.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterWindowCoveringLift.java
@@ -27,6 +27,7 @@ import org.eclipse.smarthome.core.thing.type.AutoUpdatePolicy;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.openhab.binding.zigbee.internal.converter.config.ZclReportingConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,7 +101,8 @@ public class ZigBeeConverterWindowCoveringLift extends ZigBeeBaseChannelConverte
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         clusterServer = (ZclWindowCoveringCluster) endpoint.getInputCluster(ZclWindowCoveringCluster.CLUSTER_ID);
         if (clusterServer == null) {
             logger.error("{}: Error opening device window covering controls", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/warningdevice/ZigBeeConverterWarningDevice.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/warningdevice/ZigBeeConverterWarningDevice.java
@@ -33,6 +33,7 @@ import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
 import org.openhab.binding.zigbee.converter.warningdevice.SquawkType;
 import org.openhab.binding.zigbee.converter.warningdevice.WarningType;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +70,8 @@ public class ZigBeeConverterWarningDevice extends ZigBeeBaseChannelConverter {
     }
 
     @Override
-    public boolean initializeConverter() {
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
         iasWdCluster = (ZclIasWdCluster) endpoint.getInputCluster(ZclIasWdCluster.CLUSTER_ID);
         if (iasWdCluster == null) {
             logger.error("{}: Error opening warning device controls", endpoint.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandlerTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandlerTest.java
@@ -183,9 +183,8 @@ public class ZigBeeThingHandlerTest {
     private ZigBeeChannelConverterFactory mockZigBeeChannelConverterFactory(
             ZigBeeBaseChannelConverter zigBeeChannelConverter) {
         ZigBeeChannelConverterFactory zigBeeChannelConverterFactory = mock(ZigBeeChannelConverterFactory.class);
-        when(zigBeeChannelConverterFactory.createConverter(any(ZigBeeThingHandler.class), any(Channel.class),
-                any(ZigBeeCoordinatorHandler.class), any(IeeeAddress.class), any(int.class)))
-                        .thenReturn(zigBeeChannelConverter);
+        when(zigBeeChannelConverterFactory.createConverter(any(Channel.class), any(ZigBeeCoordinatorHandler.class),
+                any(IeeeAddress.class), any(int.class))).thenReturn(zigBeeChannelConverter);
 
         return zigBeeChannelConverterFactory;
     }
@@ -193,7 +192,7 @@ public class ZigBeeThingHandlerTest {
     private ZigBeeBaseChannelConverter mockZigBeeBaseChannelConverterSuccessfull() {
         ZigBeeBaseChannelConverter zigBeeChannelConverter = mock(ZigBeeBaseChannelConverter.class);
         when(zigBeeChannelConverter.initializeDevice()).thenReturn(true);
-        when(zigBeeChannelConverter.initializeConverter()).thenReturn(true);
+        when(zigBeeChannelConverter.initializeConverter(any(ZigBeeThingHandler.class))).thenReturn(true);
 
         return zigBeeChannelConverter;
     }

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressureTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressureTest.java
@@ -56,7 +56,8 @@ public class ZigBeeConverterAtmosphericPressureTest {
         ArgumentCaptor<State> stateCapture = ArgumentCaptor.forClass(State.class);
         ZigBeeThingHandler thingHandler = Mockito.mock(ZigBeeThingHandler.class);
         Channel channel = ChannelBuilder.create(new ChannelUID("a:b:c:d"), "").build();
-        converter.initialize(thingHandler, channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initialize(channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initializeConverter(thingHandler);
 
         ZclAttribute attributeMeasuredVal = Mockito.mock(ZclAttribute.class);
         Mockito.when(attributeMeasuredVal.getCluster()).thenReturn(ZclClusterType.PRESSURE_MEASUREMENT);

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarmTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarmTest.java
@@ -60,7 +60,8 @@ public class ZigBeeConverterBatteryAlarmTest {
         when(coordinatorHandler.getEndpoint(ieeeAddress, endpointId)).thenReturn(endpoint);
 
         converter = new ZigBeeConverterBatteryAlarm();
-        converter.initialize(thingHandler, channel, coordinatorHandler, ieeeAddress, endpointId);
+        converter.initialize(channel, coordinatorHandler, ieeeAddress, endpointId);
+        converter.initializeConverter(thingHandler);
     }
 
     @Test

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColorTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColorTest.java
@@ -58,7 +58,8 @@ public class ZigBeeConverterColorColorTest {
         ArgumentCaptor<State> stateCapture = ArgumentCaptor.forClass(State.class);
         ZigBeeThingHandler thingHandler = Mockito.mock(ZigBeeThingHandler.class);
         Channel channel = ChannelBuilder.create(new ChannelUID("a:b:c:d"), "").build();
-        converter.initialize(thingHandler, channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initialize(channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initializeConverter(thingHandler);
 
         ZclAttribute onAttribute = new ZclAttribute(new ZclOnOffCluster(endpoint), 0, "OnOff", ZclDataType.BOOLEAN,
                 false, false, false, false);
@@ -122,7 +123,8 @@ public class ZigBeeConverterColorColorTest {
         ArgumentCaptor<State> stateCapture = ArgumentCaptor.forClass(State.class);
         ZigBeeThingHandler thingHandler = Mockito.mock(ZigBeeThingHandler.class);
         Channel channel = ChannelBuilder.create(new ChannelUID("a:b:c:d"), "").build();
-        converter.initialize(thingHandler, channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initialize(channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initializeConverter(thingHandler);
 
         ZclAttribute colorModeAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 8, "ColorMode",
                 ZclDataType.ENUMERATION_8_BIT, false, false, false, false);

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperatureTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperatureTest.java
@@ -133,7 +133,8 @@ public class ZigBeeConverterColorTemperatureTest {
         ArgumentCaptor<State> stateCapture = ArgumentCaptor.forClass(State.class);
         ZigBeeThingHandler thingHandler = Mockito.mock(ZigBeeThingHandler.class);
         Channel channel = ChannelBuilder.create(new ChannelUID("a:b:c:d"), "").build();
-        converter.initialize(thingHandler, channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initialize(channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initializeConverter(thingHandler);
 
         ZclAttribute colorModeAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 8, "ColorMode",
                 ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, false, false);
@@ -179,7 +180,8 @@ public class ZigBeeConverterColorTemperatureTest {
         ArgumentCaptor<State> stateCapture = ArgumentCaptor.forClass(State.class);
         ZigBeeThingHandler thingHandler = Mockito.mock(ZigBeeThingHandler.class);
         Channel channel = ChannelBuilder.create(new ChannelUID("a:b:c:d"), "").build();
-        converter.initialize(thingHandler, channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initialize(channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initializeConverter(thingHandler);
 
         ZclAttribute colorTemperatureAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 7,
                 "ColorTemperature", ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, false, false);
@@ -206,7 +208,8 @@ public class ZigBeeConverterColorTemperatureTest {
         ArgumentCaptor<State> stateCapture = ArgumentCaptor.forClass(State.class);
         ZigBeeThingHandler thingHandler = Mockito.mock(ZigBeeThingHandler.class);
         Channel channel = ChannelBuilder.create(new ChannelUID("a:b:c:d"), "").build();
-        converter.initialize(thingHandler, channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initialize(channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initializeConverter(thingHandler);
 
         ZclAttribute colorModeAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 8, "ColorMode",
                 ZclDataType.ENUMERATION_8_BIT, false, false, false, false);

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButtonTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterGenericButtonTest.java
@@ -77,7 +77,7 @@ public class ZigBeeConverterGenericButtonTest {
         when(coordinatorHandler.getLocalEndpointId(ArgumentMatchers.any(ZigBeeProfileType.class))).thenReturn(1);
 
         converter = new ZigBeeConverterGenericButton();
-        converter.initialize(thingHandler, channel, coordinatorHandler, ieeeAddress, endpointId);
+        converter.initialize(channel, coordinatorHandler, ieeeAddress, endpointId);
     }
 
     @Test
@@ -87,7 +87,7 @@ public class ZigBeeConverterGenericButtonTest {
 
         ZclCluster cluster = mockCluster(8);
 
-        boolean initResult = converter.initializeConverter();
+        boolean initResult = converter.initializeConverter(thingHandler);
 
         assertTrue(initResult);
         verify(cluster, times(1)).addCommandListener(converter);
@@ -102,7 +102,7 @@ public class ZigBeeConverterGenericButtonTest {
 
         ZclCluster cluster = mockCluster(8);
 
-        boolean initResult = converter.initializeConverter();
+        boolean initResult = converter.initializeConverter(thingHandler);
 
         assertTrue(initResult);
         verify(cluster, times(1)).addAttributeListener(converter);
@@ -123,7 +123,7 @@ public class ZigBeeConverterGenericButtonTest {
         ZclCluster cluster8 = mockCluster(8);
         ZclCluster cluster9 = mockCluster(9);
 
-        boolean initResult = converter.initializeConverter();
+        boolean initResult = converter.initializeConverter(thingHandler);
 
         assertTrue(initResult);
         verify(cluster8, times(1)).addCommandListener(converter);
@@ -133,7 +133,7 @@ public class ZigBeeConverterGenericButtonTest {
     @Test
     public void converterInitializationClusterIdIsMandatory() {
         channelProperties.put("zigbee_shortpress_command_id", "0x0017");
-        boolean initResult = converter.initializeConverter();
+        boolean initResult = converter.initializeConverter(thingHandler);
         assertFalse(initResult);
     }
 
@@ -141,7 +141,7 @@ public class ZigBeeConverterGenericButtonTest {
     public void converterInitializationCommandIdOrAttributeIsMandatory() {
         channelProperties.put("zigbee_shortpress_cluster_id", "0x008");
         mockCluster(8);
-        boolean initResult = converter.initializeConverter();
+        boolean initResult = converter.initializeConverter(thingHandler);
         assertFalse(initResult);
     }
 
@@ -149,7 +149,7 @@ public class ZigBeeConverterGenericButtonTest {
     public void converterCannotInitializeWithUnparseableClusterId() {
         channelProperties.put("zigbee_shortpress_cluster_id", "0xEFGH");
         channelProperties.put("zigbee_shortpress_command_id", "123");
-        boolean initResult = converter.initializeConverter();
+        boolean initResult = converter.initializeConverter(thingHandler);
         assertFalse(initResult);
     }
 
@@ -158,7 +158,7 @@ public class ZigBeeConverterGenericButtonTest {
         channelProperties.put("zigbee_shortpress_cluster_id", "0x8");
         channelProperties.put("zigbee_shortpress_command_id", "abc");
         mockCluster(8);
-        boolean initResult = converter.initializeConverter();
+        boolean initResult = converter.initializeConverter(thingHandler);
         assertFalse(initResult);
     }
 
@@ -168,7 +168,7 @@ public class ZigBeeConverterGenericButtonTest {
         channelProperties.put("zigbee_shortpress_attribute_id", "abc");
         channelProperties.put("zigbee_shortpress_attribute_value", "abc");
         mockCluster(8);
-        boolean initResult = converter.initializeConverter();
+        boolean initResult = converter.initializeConverter(thingHandler);
         assertFalse(initResult);
     }
 
@@ -178,7 +178,7 @@ public class ZigBeeConverterGenericButtonTest {
         channelProperties.put("zigbee_shortpress_command_id", "0xabc");
         channelProperties.put("zigbee_shortpress_parameter_name", "mode");
         mockCluster(8);
-        boolean initResult = converter.initializeConverter();
+        boolean initResult = converter.initializeConverter(thingHandler);
         assertFalse(initResult);
     }
 
@@ -188,7 +188,7 @@ public class ZigBeeConverterGenericButtonTest {
         channelProperties.put("zigbee_shortpress_command_id", "0xabc");
         channelProperties.put("zigbee_shortpress_parameter_value", "1");
         mockCluster(8);
-        boolean initResult = converter.initializeConverter();
+        boolean initResult = converter.initializeConverter(thingHandler);
         assertFalse(initResult);
     }
 
@@ -197,7 +197,7 @@ public class ZigBeeConverterGenericButtonTest {
         channelProperties.put("zigbee_shortpress_cluster_id", "0x8");
         channelProperties.put("zigbee_shortpress_attribute_id", "1");
         mockCluster(8);
-        boolean initResult = converter.initializeConverter();
+        boolean initResult = converter.initializeConverter(thingHandler);
         assertFalse(initResult);
     }
 
@@ -208,7 +208,7 @@ public class ZigBeeConverterGenericButtonTest {
         channelProperties.put("zigbee_shortpress_attribute_id", "1");
         channelProperties.put("zigbee_shortpress_attribute_value", "2");
         mockCluster(8);
-        boolean initResult = converter.initializeConverter();
+        boolean initResult = converter.initializeConverter(thingHandler);
         assertFalse(initResult);
     }
 
@@ -223,7 +223,7 @@ public class ZigBeeConverterGenericButtonTest {
         channelProperties.put("zigbee_shortpress_command_id", "0x0017");
         ZclCluster cluster = mockCluster(8);
 
-        converter.initializeConverter();
+        converter.initializeConverter(thingHandler);
         converter.disposeConverter();
 
         verify(cluster, times(1)).removeCommandListener(converter);
@@ -237,7 +237,7 @@ public class ZigBeeConverterGenericButtonTest {
         channelProperties.put("zigbee_shortpress_attribute_value", "2");
         ZclCluster cluster = mockCluster(8);
 
-        converter.initializeConverter();
+        converter.initializeConverter(thingHandler);
         converter.disposeConverter();
 
         verify(cluster, times(1)).removeAttributeListener(converter);
@@ -249,7 +249,7 @@ public class ZigBeeConverterGenericButtonTest {
         channelProperties.put("zigbee_shortpress_cluster_id", "768");
         channelProperties.put("zigbee_shortpress_command_id", "0x01");
         mockCluster(768);
-        converter.initializeConverter();
+        converter.initializeConverter(thingHandler);
 
         converter.commandReceived(new MoveHueCommand());
 
@@ -265,7 +265,7 @@ public class ZigBeeConverterGenericButtonTest {
         channelProperties.put("zigbee_shortpress_parameter_name", "moveMode");
         channelProperties.put("zigbee_shortpress_parameter_value", "1");
         mockCluster(768);
-        converter.initializeConverter();
+        converter.initializeConverter(thingHandler);
 
         MoveHueCommand moveHueCommand = new MoveHueCommand();
         moveHueCommand.setMoveMode(1);
@@ -282,7 +282,7 @@ public class ZigBeeConverterGenericButtonTest {
         channelProperties.put("zigbee_shortpress_attribute_id", "85");
         channelProperties.put("zigbee_shortpress_attribute_value", "1");
         mockCluster(768);
-        converter.initializeConverter();
+        converter.initializeConverter(thingHandler);
 
         ZclAttribute attribute = new ZclAttribute(new ZclMultistateInputBasicCluster(endpoint), 85, "foo",
                 ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, true, true);
@@ -302,7 +302,7 @@ public class ZigBeeConverterGenericButtonTest {
         channelProperties.put("zigbee_shortpress_parameter_name", "blueMode");
         channelProperties.put("zigbee_shortpress_parameter_value", "1");
         mockCluster(768);
-        converter.initializeConverter();
+        converter.initializeConverter(thingHandler);
 
         MoveHueCommand moveHueCommand = new MoveHueCommand();
         moveHueCommand.setMoveMode(1);
@@ -320,7 +320,7 @@ public class ZigBeeConverterGenericButtonTest {
         channelProperties.put("zigbee_shortpress_parameter_name", "moveMode");
         channelProperties.put("zigbee_shortpress_parameter_value", "1");
         mockCluster(768);
-        converter.initializeConverter();
+        converter.initializeConverter(thingHandler);
 
         MoveHueCommand moveHueCommand = new MoveHueCommand();
         moveHueCommand.setMoveMode(0);
@@ -337,7 +337,7 @@ public class ZigBeeConverterGenericButtonTest {
         channelProperties.put("zigbee_shortpress_attribute_id", "85");
         channelProperties.put("zigbee_shortpress_attribute_value", "1");
         mockCluster(768);
-        converter.initializeConverter();
+        converter.initializeConverter(thingHandler);
 
         ZclAttribute attribute = new ZclAttribute(new ZclMultistateInputBasicCluster(endpoint), 85, "foo",
                 ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, true, true);
@@ -361,7 +361,7 @@ public class ZigBeeConverterGenericButtonTest {
         channelProperties.put("zigbee_doublepress_command_id", "0x0017");
 
         mockCluster(768);
-        converter.initializeConverter();
+        converter.initializeConverter(thingHandler);
 
         converter.commandReceived(new MoveHueCommand());
 
@@ -385,7 +385,7 @@ public class ZigBeeConverterGenericButtonTest {
         channelProperties.put("zigbee_doublepress_attribute_value", "0x03");
 
         mockCluster(768);
-        converter.initializeConverter();
+        converter.initializeConverter(thingHandler);
 
         ZclAttribute attribute = new ZclAttribute(new ZclMultistateInputBasicCluster(endpoint), 0x17, "foo",
                 ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, true, true);

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasTamperTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIasTamperTest.java
@@ -77,8 +77,8 @@ public class ZigBeeConverterIasTamperTest {
         when(coordinatorHandler.getEndpoint(ieeeAddress, endpointId)).thenReturn(endpoint);
 
         converter = new ZigBeeConverterIasTamper();
-        converter.initialize(thingHandler, channel, coordinatorHandler, ieeeAddress, endpointId);
-        converter.initializeConverter();
+        converter.initialize(channel, coordinatorHandler, ieeeAddress, endpointId);
+        converter.initializeConverter(thingHandler);
     }
 
     @Test

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevelTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevelTest.java
@@ -54,7 +54,8 @@ public class ZigBeeConverterSwitchLevelTest {
         ArgumentCaptor<State> stateCapture = ArgumentCaptor.forClass(State.class);
         ZigBeeThingHandler thingHandler = Mockito.mock(ZigBeeThingHandler.class);
         Channel channel = ChannelBuilder.create(new ChannelUID("a:b:c:d"), "").build();
-        converter.initialize(thingHandler, channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initialize(channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initializeConverter(thingHandler);
 
         ZclAttribute onAttribute = new ZclAttribute(new ZclOnOffCluster(endpoint), 0, "OnOff", ZclDataType.BOOLEAN,
                 false, false, false, false);

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoffTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoffTest.java
@@ -51,7 +51,8 @@ public class ZigBeeConverterSwitchOnoffTest {
         ArgumentCaptor<State> stateCapture = ArgumentCaptor.forClass(State.class);
         ZigBeeThingHandler thingHandler = Mockito.mock(ZigBeeThingHandler.class);
         Channel channel = new Channel(new ChannelUID("a:b:c:d"), "");
-        converter.initialize(thingHandler, channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initialize(channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initializeConverter(thingHandler);
         ZclAttribute attribute = new ZclAttribute(new ZclOnOffCluster(endpoint), 0, "OnOff", ZclDataType.BOOLEAN, false,
                 false, false, false);
         converter.attributeUpdated(attribute, attribute.getLastValue());

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperatureTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperatureTest.java
@@ -50,12 +50,16 @@ public class ZigBeeConverterTemperatureTest {
         Mockito.when(coordinatorHandler.getEndpoint(ArgumentMatchers.any(IeeeAddress.class), ArgumentMatchers.anyInt()))
                 .thenReturn(endpoint);
 
+        ZclTemperatureMeasurementCluster cluster = Mockito.mock(ZclTemperatureMeasurementCluster.class);
+        Mockito.when(endpoint.getInputCluster(ZclClusterType.TEMPERATURE_MEASUREMENT.getId())).thenReturn(cluster);
+
         ZigBeeConverterTemperature converter = new ZigBeeConverterTemperature();
         ArgumentCaptor<ChannelUID> channelCapture = ArgumentCaptor.forClass(ChannelUID.class);
         ArgumentCaptor<State> stateCapture = ArgumentCaptor.forClass(State.class);
         ZigBeeThingHandler thingHandler = Mockito.mock(ZigBeeThingHandler.class);
         Channel channel = ChannelBuilder.create(new ChannelUID("a:b:c:d"), "").build();
-        converter.initialize(thingHandler, channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initialize(channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
+        converter.initializeConverter(thingHandler);
 
         ZclAttribute attribute = Mockito.mock(ZclAttribute.class);
         Mockito.when(attribute.getCluster()).thenReturn(ZclClusterType.TEMPERATURE_MEASUREMENT);

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/warningdevice/ZigBeeConverterWarningDeviceTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/warningdevice/ZigBeeConverterWarningDeviceTest.java
@@ -66,9 +66,9 @@ public class ZigBeeConverterWarningDeviceTest {
         when(endpoint.getInputCluster(ZclIasWdCluster.CLUSTER_ID)).thenReturn(cluster);
 
         converter = new ZigBeeConverterWarningDevice();
-        converter.initialize(thingHandler, channel, coordinatorHandler, ieeeAddress, endpointId);
+        converter.initialize(channel, coordinatorHandler, ieeeAddress, endpointId);
 
-        assertTrue(converter.initializeConverter());
+        assertTrue(converter.initializeConverter(thingHandler));
     }
 
     @Test


### PR DESCRIPTION
This refactors the converters to allow the initialisation to be performed during discovery while devices are awake. This is necessary as channel discovery at a later time (ie once the thing is created) may fail for sleepy devices if the period between discovery and the thing creation is more than a few seconds (which is highly likely!).

In itself, this works, however as OH provides no way to parse the dynamic channels from the discovery handler to the new thing, when the thing handler is created the binding will again perform the channel discovery.  For devices that are sleeping, this will fail - possibly this is ok, although it will likely indicate that the initialisation fails which may increase polling.  In any case, the reporting should have been configured during discovery, so this should be working fine.

Ultimately to fully resolve this, the full discovery, including the static thing definition, all needs to be performed during discovery, and then there needs to be a way to parse this information to the thing handler.

This could be done using json encoded properties. Ideally OH would provide the ability to pass channel information to the `DiscoveryResultBuilder` (but it seems unlikely that OH would want to add this!). 

Alternatively we could look to provide this support in the device storage - needs more thought, but this PR provides an initial intermediate step.

Adds partial support for #527.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>