### PR TITLE
Fix XStream security framework not initialized warnings

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeDataStore.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeDataStore.java
@@ -36,6 +36,7 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.PrettyPrintWriter;
 import com.thoughtworks.xstream.io.xml.StaxDriver;
 import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.ZigBeeNode;
 import com.zsmartsystems.zigbee.database.ZclAttributeDao;
 import com.zsmartsystems.zigbee.database.ZclClusterDao;
 import com.zsmartsystems.zigbee.database.ZigBeeEndpointDao;
@@ -76,6 +77,8 @@ public class ZigBeeDataStore implements ZigBeeNetworkDataStore {
 
     private XStream openStream() {
         XStream stream = new XStream(new StaxDriver());
+        XStream.setupDefaultSecurity(stream);
+        stream.allowTypesByWildcard(new String[] { ZigBeeNode.class.getPackageName() + ".**" });
         stream.setClassLoader(this.getClass().getClassLoader());
 
         stream.alias("ZigBeeNode", ZigBeeNodeDao.class);


### PR DESCRIPTION
Cherry picks #633 onto 3.0.x.