### PR TITLE
Don't reinitialise multiple times

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -554,6 +554,10 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
             logger.error("Error updating configuration ", e);
         }
 
+        // Set initializeNetwork to false to ensure that if communications to the dongle restarts, we don't reinitialise
+        // the network again!
+        initializeNetwork = false;
+
         initializeDongleSpecific();
     }
 


### PR DESCRIPTION
Fixes a bug where which may cause the dongle to be reinitialised multiple times if the serial connection, or link to the NCP is not reliable. If during the current session the dongle was initialised, and the dongle link goes down/up, then it may be reinitialised again.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>