### PR TITLE
Update to ZSS 1.4.0

### DIFF
--- a/org.openhab.binding.zigbee.console.ember/src/main/java/org/openhab/binding/zigbee/console/ember/internal/EmberZigBeeConsoleCommandProvider.java
+++ b/org.openhab.binding.zigbee.console.ember/src/main/java/org/openhab/binding/zigbee/console/ember/internal/EmberZigBeeConsoleCommandProvider.java
@@ -22,8 +22,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.binding.zigbee.console.ZigBeeConsoleCommandProvider;
+import org.openhab.core.thing.ThingTypeUID;
 import org.osgi.service.component.annotations.Component;
 
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleCommand;
@@ -32,8 +32,10 @@ import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpChildrenCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpConfigurationCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpCountersCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpPolicyCommand;
+import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpRoutingCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpScanCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpStateCommand;
+import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpTokenCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpValueCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpVersionCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleSecurityStateCommand;
@@ -43,17 +45,19 @@ import com.zsmartsystems.zigbee.console.ember.EmberConsoleTransientKeyCommand;
  * This class provides ZigBee console commands for Ember dongles.
  *
  * @author Henning Sudbrock - initial contribution
+ * @author Chris Jackson - added commands
  */
 @Component(immediate = true)
 public class EmberZigBeeConsoleCommandProvider implements ZigBeeConsoleCommandProvider {
 
-    public static final List<ZigBeeConsoleCommand> EMBER_COMMANDS = unmodifiableList(
-            asList(new EmberConsoleMmoHashCommand(), new EmberConsoleNcpChildrenCommand(),
-                    new EmberConsoleNcpConfigurationCommand(), new EmberConsoleNcpCountersCommand(),
-                    new EmberConsoleNcpPolicyCommand(), new EmberConsoleNcpScanCommand(),
-                    new EmberConsoleSecurityStateCommand(), new EmberConsoleNcpStateCommand(),
-                    new EmberConsoleTransientKeyCommand(), new EmberConsoleNcpValueCommand(),
-                    new EmberConsoleNcpVersionCommand()));
+    @SuppressWarnings("null")
+    public static final List<ZigBeeConsoleCommand> EMBER_COMMANDS = unmodifiableList(asList(
+            new EmberConsoleMmoHashCommand(), new EmberConsoleNcpChildrenCommand(),
+            new EmberConsoleNcpConfigurationCommand(), new EmberConsoleNcpCountersCommand(),
+            new EmberConsoleNcpPolicyCommand(), new EmberConsoleNcpScanCommand(), new EmberConsoleNcpRoutingCommand(),
+            new EmberConsoleNcpScanCommand(), new EmberConsoleSecurityStateCommand(), new EmberConsoleNcpStateCommand(),
+            new EmberConsoleNcpTokenCommand(), new EmberConsoleTransientKeyCommand(), new EmberConsoleNcpValueCommand(),
+            new EmberConsoleNcpVersionCommand()));
 
     private Map<String, ZigBeeConsoleCommand> emberCommands = EMBER_COMMANDS.stream()
             .collect(toMap(ZigBeeConsoleCommand::getCommand, identity()));

--- a/org.openhab.binding.zigbee.console/src/main/java/org/openhab/binding/zigbee/console/internal/GeneralZigBeeConsoleCommandProvider.java
+++ b/org.openhab.binding.zigbee.console/src/main/java/org/openhab/binding/zigbee/console/internal/GeneralZigBeeConsoleCommandProvider.java
@@ -21,8 +21,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.binding.zigbee.console.ZigBeeConsoleCommandProvider;
+import org.openhab.core.thing.ThingTypeUID;
 import org.osgi.service.component.annotations.Component;
 
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleAttributeReadCommand;
@@ -36,6 +36,7 @@ import com.zsmartsystems.zigbee.console.ZigBeeConsoleDescribeEndpointCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleDescribeNodeCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleDeviceFingerprintCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleDeviceInformationCommand;
+import com.zsmartsystems.zigbee.console.ZigBeeConsoleGroupCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleInstallKeyCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleLinkKeyCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleNetworkBackupCommand;
@@ -47,6 +48,7 @@ import com.zsmartsystems.zigbee.console.ZigBeeConsoleReportingConfigCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleReportingSubscribeCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleReportingUnsubscribeCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleRoutingTableCommand;
+import com.zsmartsystems.zigbee.console.ZigBeeConsoleSceneCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleUnbindCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleWindowCoveringCommand;
 
@@ -59,19 +61,20 @@ import com.zsmartsystems.zigbee.console.ZigBeeConsoleWindowCoveringCommand;
 @Component
 public class GeneralZigBeeConsoleCommandProvider implements ZigBeeConsoleCommandProvider {
 
-    public static final List<ZigBeeConsoleCommand> GENERAL_COMMANDS = unmodifiableList(
-            asList(new ZigBeeConsoleAttributeReadCommand(), new ZigBeeConsoleAttributeSupportedCommand(),
-                    new ZigBeeConsoleAttributeWriteCommand(), new ZigBeeConsoleBindCommand(),
-                    new ZigBeeConsoleBindingTableCommand(), new ZigBeeConsoleCommandsSupportedCommand(),
-                    new ZigBeeConsoleDescribeEndpointCommand(), new ZigBeeConsoleDescribeNodeCommand(),
-                    new ZigBeeConsoleDeviceFingerprintCommand(), new ZigBeeConsoleDeviceInformationCommand(),
-                    new ZigBeeConsoleInstallKeyCommand(), new ZigBeeConsoleLinkKeyCommand(),
-                    new ZigBeeConsoleNetworkBackupCommand(), new ZigBeeConsoleNetworkJoinCommand(),
-                    new ZigBeeConsoleNetworkLeaveCommand(), new ZigBeeConsoleNodeListCommand(),
-                    new ZigBeeConsoleOtaUpgradeCommand(), new ZigBeeConsoleReportingConfigCommand(),
-                    new ZigBeeConsoleReportingSubscribeCommand(), new ZigBeeConsoleReportingUnsubscribeCommand(),
-                    new ZigBeeConsoleRoutingTableCommand(), new ZigBeeConsoleUnbindCommand(),
-                    new ZigBeeConsoleWindowCoveringCommand()));
+    @SuppressWarnings("null")
+    public static final List<ZigBeeConsoleCommand> GENERAL_COMMANDS = unmodifiableList(asList(
+            new ZigBeeConsoleAttributeReadCommand(), new ZigBeeConsoleAttributeSupportedCommand(),
+            new ZigBeeConsoleAttributeWriteCommand(), new ZigBeeConsoleBindCommand(),
+            new ZigBeeConsoleBindingTableCommand(), new ZigBeeConsoleCommandsSupportedCommand(),
+            new ZigBeeConsoleDescribeEndpointCommand(), new ZigBeeConsoleDescribeNodeCommand(),
+            new ZigBeeConsoleDeviceFingerprintCommand(), new ZigBeeConsoleDeviceInformationCommand(),
+            new ZigBeeConsoleGroupCommand(), new ZigBeeConsoleInstallKeyCommand(), new ZigBeeConsoleLinkKeyCommand(),
+            new ZigBeeConsoleNetworkBackupCommand(), new ZigBeeConsoleNetworkJoinCommand(),
+            new ZigBeeConsoleNetworkLeaveCommand(), new ZigBeeConsoleNodeListCommand(),
+            new ZigBeeConsoleOtaUpgradeCommand(), new ZigBeeConsoleSceneCommand(),
+            new ZigBeeConsoleReportingConfigCommand(), new ZigBeeConsoleReportingSubscribeCommand(),
+            new ZigBeeConsoleReportingUnsubscribeCommand(), new ZigBeeConsoleRoutingTableCommand(),
+            new ZigBeeConsoleUnbindCommand(), new ZigBeeConsoleWindowCoveringCommand()));
 
     private Map<String, ZigBeeConsoleCommand> generalCommands = GENERAL_COMMANDS.stream()
             .collect(toMap(ZigBeeConsoleCommand::getCommand, identity()));

--- a/org.openhab.binding.zigbee.serial/src/main/java/org/openhab/binding/zigbee/serial/ZigBeeSerialPort.java
+++ b/org.openhab.binding.zigbee.serial/src/main/java/org/openhab/binding/zigbee/serial/ZigBeeSerialPort.java
@@ -246,6 +246,22 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
     }
 
     @Override
+    public void write(int[] outArray) {
+        if (outputStream == null) {
+            return;
+        }
+        byte[] bytes = new byte[outArray.length];
+        int cnt = 0;
+        for (int value : outArray) {
+            bytes[cnt++] = (byte) value;
+        }
+        try {
+            outputStream.write(bytes);
+        } catch (IOException e) {
+        }
+    }
+
+    @Override
     public int read() {
         return read(9999999);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <report.fail.on.error>false</report.fail.on.error>
-    <zsmartsystems.version>1.3.10</zsmartsystems.version>
+    <zsmartsystems.version>1.4.0</zsmartsystems.version>
     <spotless.version>2.0.3</spotless.version>
     <spotless.check.skip>true</spotless.check.skip> <!-- Spotless disabled for now -->
     <sat.version>0.10.0</sat.version>
@@ -309,18 +309,6 @@
       </releases>
       <snapshots>
         <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>snapshots-zsmartsystems-com.zsmartsystems</id>
-      <name>zsmartsystems-com.zsmartsystems</name>
-      <url>https://oss.jfrog.org/artifactory/oss-snapshot-local/</url>
-      <releases>
-          <enabled>false</enabled>
-          <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-          <enabled>true</enabled>
       </snapshots>
     </repository>
   </repositories>


### PR DESCRIPTION
Updates to Z-Smart Systems library v 1.4.0. This changes the serial methods to use array writes rather than character writes, and also adds some new console commands for group and scene management, and Ember console commands to print the routing table and tokens.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>