### PR TITLE
Added firmware upgrade instructions for some Ember

### DIFF
--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -201,7 +201,9 @@ If the usb dongle is not recognized, it might be necessary to make the dongle's 
 ##### Flashing/Upgrading on Linux
 
 Some Ember EZSP NCP coordinators can be flashed to upgrade the firmware using walthowd/husbzb-firmware (https://github.com/walthowd/husbzb-firmware).
-It has been tested with the HUSZBZ-1 and Telegesis ETRX357USB and may work with other coordinators based on similar EM358x/EM3581, ETRX35x/ETRX357, and EFR32MGxx MCU chips from Silicon Labs.
+It has been tested with the HUSZBZ-1 and Telegesis ETRX357USB and may work with other coordinators. 
+You are responsible to ensure you load the correct firmware for your device. 
+Loading the wrong firmware may render your device inoperable
 
 Review the `husbzb-firmware` readme for detailed instructions.
 Using docker to upgrade a HUSZBZ-1 is as follows:

--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -198,6 +198,28 @@ If the usb dongle is not recognized, it might be necessary to make the dongle's 
   ```
 - Plug in the dongle. It should now be recognized properly as ttyUSBx.
 
+##### Flashing/Upgrading on Linux
+
+Some Ember EZSP NCP coordinators can be flashed to upgrade the firmware using walthowd/husbzb-firmware (https://github.com/walthowd/husbzb-firmware).
+It has been tested with the HUSZBZ-1 and Telegesis ETRX357USB and may work with other coordinators based on similar EM358x/EM3581, ETRX35x/ETRX357, and EFR32MGxx MCU chips from Silicon Labs.
+
+Review the `husbzb-firmware` readme for detailed instructions.
+Using docker to upgrade a HUSZBZ-1 is as follows:
+
+- Shutdown openHAB
+- `docker run --rm --device=/dev/ttyUSB1:/dev/ttyUSB1 -it walthowd/husbzb-firmware bash`
+- `./ncp.py scan`
+- Verify output shows which version of firmware the coordinator is running.
+  ```
+  {"ports": [{"port": "/dev/ttyUSB1", "vid": "10C4", "pid": "8A2A", "deviceType": "zigbee", "stackVersion": "5.4.1-194"}]}
+  ```
+- `./ncp.py flash -p /dev/ttyUSB1 -f ncp-uart-sw-6.7.8.ebl`
+- Wait for the flashing to complete and the coordinator to reboot.
+- `./ncp.py scan`
+  ```
+  {"ports": [{"port": "/dev/ttyUSB1", "vid": "10C4", "pid": "8A2A", "deviceType": "zigbee", "stackVersion": "6.7.8-373"}]}
+  ```
+
 #### Telegesis ETRX3
 
 The thing type is `coordinator_telegesis`. Note that this dongle may not support all Zigbee 3.0 devices.


### PR DESCRIPTION
Added instruction for upgrading the firmware for HUSBZB-1 and Telegesis ETRX357USB and perhaps other Ember based controllers using https://github.com/walthowd/husbzb-firmware. I tested these instructions on a HUSBZB-1.

As far as I can tell this tool is Linux only and, even if it did support Windows I don't have a Windows machine to test it on so would not be comfortable writing that section.