### PR TITLE
Add "not recommended" + more info about CC2530 in Zigbee binding docs.

### DIFF
--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -146,7 +146,7 @@ The following coordinators are known to be supported.
 
 | Name and Link              | Coordinator | Configuration | Comment |
 |----------------------------|-------------|---------------|---------|
-|[Texas Instruments CC2531EMK](http://www.ti.com/tool/cc2531emk)|[CC2531](#cc2531-coordinator)||Needs extra hardware and correct firmware (might be hard to find) for flashing.<br>There are also cheap copies of the CC2531 Stick available on eBay, Aliexpress, etc. like [this](https://de.aliexpress.com/item/Drahtlose-Zigbee-CC2531-Sniffer-software-protokoll-analyse-Bareboard-Paket-Protokoll-Analyzer-Modul-Usb-schnittstelle-Dongle-Erfassen/32852226435.html) and a module to flash the firmware like [this](https://de.aliexpress.com/item/SmartRF04EB-CC1110-CC2530-ZigBee-Module-USB-Downloader-Emulator-MCU-M100/32673666126.html) including a [connector board](https://de.aliexpress.com/item/CC2531-CC2540-Zigbee-Sniffer-software-protokoll-analyse-Wireless-Board-Bluetooth-BLE-4-0-Dongle-Capture-Modul/32869263224.html)<br>Also CC2530, CC2538 or CC2650 may work with the correct firmware but are not suggested|
+|[Texas Instruments CC2531EMK](http://www.ti.com/tool/cc2531emk)|[CC2531](#cc2531-coordinator)||CC2531 is not recommended for more then 15 devices due to its less powerful MCU. Also needs extra [hardware and Z-Stack Home 1.2 firmware flashed](https://www.zigbee2mqtt.io/information/flashing_the_cc2531.html). CC2530 and CC2538 may work too with Z-Stack Home 1.2 compatible firmware.|
 |[Bitron Video ZigBee USB Funkstick](http://www.bitronvideo.eu/index.php/produkte/smart-home-produkte/zb-funkstick/)|[Ember](#ember-ezsp-ncp-coordinator)|57600bps<br>Software&nbsp;flow&nbsp;control<br>High RAM||
 |[Elelabs ELU013/ELR023](https://elelabs.com/shop/)|[Ember](#ember-ezsp-ncp-coordinator)|115200bps<br>Hardware&nbsp;flow&nbsp;control<br>High RAM| Both the stick and the hat can be upgraded without additional hardware, firmware available [here](https://github.com/Elelabs/elelabs-zigbee-ezsp-utility).|
 |[Cortet EM358 USB Stick](https://www.cortet.com/iot-hardware/cortet-usb-sticks/em358-usb-stick)|[Ember](#ember-ezsp-ncp-coordinator)|57600bps<br>Software&nbsp;flow&nbsp;control<br>High RAM| |
@@ -157,16 +157,16 @@ The following coordinators are known to be supported.
 
 #### CC2531 Coordinator
 
-This is the Texas Instruments ZNP stack. The thing type is `coordinator_cc2531`.
+Z-Stack Home 1.2 is the Texas Instruments ZNP stack for Zigbee Home Automation 1.2 networks. The thing type is `coordinator_cc2531`. 
 
 ##### CC2531 - Firmware
 
-The CC2531 USB dongle must be flashed with the correct firmware in order to work with this binding.
-The file can be downloaded from TI website archives (http://www.ti.com/tool/z-stack-archive) as part
+The CC2531 USB dongle must be flashed with Z-Stack Home 1.2 firmware firmware in order to work with this binding. Flashing CC2531 requires extra hardware.
+Original firmware can be downloaded from TI website archives (http://www.ti.com/tool/z-stack-archive) as part
 of the `Z-STACK-HOME v.1.2.2a` package.
 The file name is `CC2531ZNP-Pro-Secure_Standard.hex` and its sha256 is `3cc5dc571ef0f49e3f42c6c2ca076d6f8fef33a945c71e6f951b839ba0599d3c`.
 
-The custom firmware from [Zigbee2MQTT](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_Home_1.2/bin) can also be used, and has been reported working by some users.
+Custom Z-Stack Home 1.2 firmware from [Zigbee2MQTT](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_Home_1.2/bin) can also be used, and has been reported working by some users.
 
 ##### Flashing on Linux
 


### PR DESCRIPTION
Add a "**_not recommended for Zigbee networks with more than 15 devices_**" note to CC2531 hardware in Zigbee bindings docs.

The reason for adding this specific "not recommended" note is that now very old Texas Instruments CC2531 (and CC2530) less powerful hardware Zigbee adapter hardware are the least expensive and most commonly available so many people make the mistake of buying this older hardware and then risk having a bad experience with Zigbee due to the CC2530/CC2531 hardware limitations.

This is the reason ZHA developers elected in https://github.com/home-assistant/core/pull/55298 to not whitelist "TI CC2531" for USB adapter ZHA discovery.

zigpy developers now also list the same recommendation for CC2530/C2531 in zigpy-znp readme file:

https://github.com/zigpy/zigpy-znp#hardware-requirements

FYI, Zigbee2MQTT as well added "not recommended" notes to both CC2530 and CC2531 in their official supported adapters list:

https://www.zigbee2mqtt.io/information/supported_adapters

 - _Texas Instruments CC2531 (**not recommended**)_
 - _Texas Instruments CC2530 (**not recommended**)_

https://www.zigbee2mqtt.io/information/supported_adapters#notes

_Adapters based on the CC2530 or CC2531 chip are not powerful and not recommended for networks larger than 20 devices._

Also, Zigbee2MQTT / zigbee-herdsman developer Koenkk noted why Z-Stack 3.0.x firmware is not recommended on C2530/C2531:

https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator#im-using-a-cc2530-or-cc2531-which-firmware-should-i-use

### _I'm using a CC2530 or CC2531, which firmware should I use?_
_This depends:_
- _Zigbee 3.0 firmwares are **not** recommended for the CC2530 and CC2531 (since those are not powerful enough)_
- _If you have a network of 1 - 15 devices, the Z-Stack_Home_1.2 **default** firmware is recommended._
- _If you have a network of 15+ devices, the Z-Stack_Home_1.2 **source routing** firmware is recommended._
- _Note that the **source routing** firmware only supports 5 direct children, therefore you need to have routers in range of the coordinator._