### PR TITLE
Fix incorrectly named temperature channel in SmartThings motionv4

### DIFF
--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/smartthings/motionv4.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/smartthings/motionv4.xml
@@ -8,7 +8,7 @@
         <description>SmartThings Motion and Temperature Sensor</description>
 
         <channels>
-            <channel id="illuminance" typeId="measurement_temperature">
+            <channel id="temperature" typeId="measurement_temperature">
                 <properties>
                     <property name="zigbee_endpoint">1</property>
                 </properties>


### PR DESCRIPTION
Signed-off-by: Chris Jackson <chris@cd-jackson.com>