### PR TITLE
Remove deprecated XStream.setupDefaultSecurity call

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeDataStore.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeDataStore.java
@@ -77,7 +77,6 @@ public class ZigBeeDataStore implements ZigBeeNetworkDataStore {
 
     private XStream openStream() {
         XStream stream = new XStream(new StaxDriver());
-        XStream.setupDefaultSecurity(stream);
         stream.allowTypesByWildcard(new String[] { ZigBeeNode.class.getPackageName() + ".**" });
         stream.setClassLoader(this.getClass().getClassLoader());
 


### PR DESCRIPTION
The XStream.setupDefaultSecurity method is deprecated since XStream 1.4.18.
It no longer does anything, because this is the default in newer XStream versions.