### PR TITLE
Add device type to label in LevelControl and OnOff converters

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.ZigBeeDeviceType;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.ZigBeeProfileType;
 import com.zsmartsystems.zigbee.zcl.ZclCluster;
@@ -423,6 +424,27 @@ public abstract class ZigBeeBaseChannelConverter {
      */
     protected QuantityType valueToTemperature(int value) {
         return new QuantityType<>(BigDecimal.valueOf(value, 2), SIUnits.CELSIUS);
+    }
+
+    /**
+     * Gets a {@link String} of the device type for the {@link ZigBeeEndpoint} to be used in device labels.
+     *
+     * @param endpoint the {@link ZigBeeEndpoint}
+     * @return the {@link String} of the device type
+     */
+    protected String getDeviceTypeLabel(ZigBeeEndpoint endpoint) {
+        ZigBeeProfileType profileType = ZigBeeProfileType.getByValue(endpoint.getProfileId());
+        if (profileType == null) {
+            profileType = ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION;
+        }
+
+        ZigBeeDeviceType deviceType = ZigBeeDeviceType.getByValue(profileType, endpoint.getDeviceId());
+
+        if (deviceType == null) {
+            return String.format("Unknown Device Type %04X", endpoint.getDeviceId());
+        }
+
+        return deviceType.toString();
     }
 
     /**

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -463,8 +463,8 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
                 .create(createChannelUID(thingUID, endpoint, ZigBeeBindingConstants.CHANNEL_NAME_SWITCH_LEVEL),
                         ZigBeeBindingConstants.ITEM_TYPE_DIMMER)
                 .withType(ZigBeeBindingConstants.CHANNEL_SWITCH_LEVEL)
-                .withLabel(ZigBeeBindingConstants.CHANNEL_LABEL_SWITCH_LEVEL).withProperties(createProperties(endpoint))
-                .build();
+                .withLabel(getDeviceTypeLabel(endpoint) + ": " + ZigBeeBindingConstants.CHANNEL_LABEL_SWITCH_LEVEL)
+                .withProperties(createProperties(endpoint)).build();
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -24,6 +24,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
+import org.openhab.binding.zigbee.internal.converter.config.ZclOnOffSwitchConfig;
+import org.openhab.binding.zigbee.internal.converter.config.ZclReportingConfig;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
@@ -31,11 +36,6 @@ import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.types.Command;
-import org.openhab.binding.zigbee.ZigBeeBindingConstants;
-import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
-import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
-import org.openhab.binding.zigbee.internal.converter.config.ZclOnOffSwitchConfig;
-import org.openhab.binding.zigbee.internal.converter.config.ZclReportingConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -246,8 +246,8 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
                 .create(createChannelUID(thingUID, endpoint, ZigBeeBindingConstants.CHANNEL_NAME_SWITCH_ONOFF),
                         ZigBeeBindingConstants.ITEM_TYPE_SWITCH)
                 .withType(ZigBeeBindingConstants.CHANNEL_SWITCH_ONOFF)
-                .withLabel(ZigBeeBindingConstants.CHANNEL_LABEL_SWITCH_ONOFF).withProperties(createProperties(endpoint))
-                .build();
+                .withLabel(getDeviceTypeLabel(endpoint) + ": " + ZigBeeBindingConstants.CHANNEL_LABEL_SWITCH_ONOFF)
+                .withProperties(createProperties(endpoint)).build();
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverterTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverterTest.java
@@ -15,12 +15,16 @@ package org.openhab.binding.zigbee.converter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.openhab.binding.zigbee.internal.converter.ZigBeeConverterSwitchLevel;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.ImperialUnits;
 import org.openhab.core.library.unit.SIUnits;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.ZigBeeProfileType;
 
 /**
  * Test of the ZigBeeBaseChannelConverter
@@ -44,6 +48,23 @@ public class ZigBeeBaseChannelConverterTest {
 
         assertEquals(PercentType.ZERO, converter.levelToPercent(0));
         assertEquals(PercentType.HUNDRED, converter.levelToPercent(254));
+    }
+
+    @Test
+    public void getDeviceTypeLabel() {
+        ZigBeeBaseChannelConverter converter = new ZigBeeConverterSwitchLevel();
+
+        ZigBeeEndpoint endpoint = Mockito.mock(ZigBeeEndpoint.class);
+        Mockito.when(endpoint.getDeviceId()).thenReturn(1);
+        assertEquals("LEVEL_CONTROL_SWITCH", converter.getDeviceTypeLabel(endpoint));
+
+        Mockito.when(endpoint.getProfileId()).thenReturn(ZigBeeProfileType.ZIGBEE_LIGHT_LINK.getKey());
+
+        Mockito.when(endpoint.getDeviceId()).thenReturn(0);
+        assertEquals("ZLL_ON_OFF_LIGHT", converter.getDeviceTypeLabel(endpoint));
+
+        Mockito.when(endpoint.getDeviceId()).thenReturn(65535);
+        assertEquals("Unknown Device Type FFFF", converter.getDeviceTypeLabel(endpoint));
     }
 
     @Test


### PR DESCRIPTION
This adds the device type to the OnOff and LevelControl converters. This can be useful where a device might support both a client and server in two different endpoints as it allows the user to differentiate the channels, and potentially identify the function.
Closes #684 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>