### PR TITLE
Avoid running multiple polling threads per device

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -629,7 +629,7 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
             // Polling starts almost immediately to get an immediate refresh
             // Add some random element to the period so that all things aren't synchronised
             int pollingPeriodMs = pollingPeriod * 1000 + new Random().nextInt(pollingPeriod * 100);
-            pollingJob = scheduler.scheduleAtFixedRate(pollingRunnable, new Random().nextInt(pollingPeriodMs),
+            pollingJob = scheduler.scheduleWithFixedDelay(pollingRunnable, new Random().nextInt(pollingPeriodMs),
                     pollingPeriodMs, TimeUnit.MILLISECONDS);
             logger.debug("{}: Polling initialised at {}ms", nodeIeeeAddress, pollingPeriodMs);
         }


### PR DESCRIPTION
As discussed in #389 we should avoid having multiple polling threads running at once. This simply changes to use the `scheduleWithFixedDelay` method.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>