### PR TITLE
Provide option to invert level control and level reports

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclLevelControlConfig.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclLevelControlConfig.java
@@ -27,6 +27,8 @@ import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.config.core.ParameterOption;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.types.Command;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,9 +51,13 @@ public class ZclLevelControlConfig implements ZclClusterConfigHandler {
     private static final String CONFIG_OFFTRANSITIONTIME = CONFIG_ID + "transitiontimeoff";
     private static final String CONFIG_ONLEVEL = CONFIG_ID + "onlevel";
     private static final String CONFIG_DEFAULTMOVERATE = CONFIG_ID + "defaultrate";
+    private static final String CONFIG_INVERTCONTROL = CONFIG_ID + "invertcontrol";
+    private static final String CONFIG_INVERTREPORT = CONFIG_ID + "invertreport";
 
     private ZclLevelControlCluster levelControlCluster;
     private int defaultTransitionTime = 10;
+    private boolean invertControl = false;
+    private boolean invertReport = false;
 
     private final List<ConfigDescriptionParameter> parameters = new ArrayList<>();
 
@@ -77,6 +83,16 @@ public class ZclLevelControlConfig implements ZclClusterConfigHandler {
                 .withDescription("Default time in 100ms intervals to transition between ON and OFF").withDefault("0")
                 .withMinimum(new BigDecimal(0)).withMaximum(new BigDecimal(60000)).withOptions(options)
                 .withLimitToOptions(false).build());
+
+        options = new ArrayList<ParameterOption>();
+        parameters.add(ConfigDescriptionParameterBuilder.create(CONFIG_INVERTCONTROL, Type.BOOLEAN)
+                .withLabel("Invert Level Commands")
+                .withDescription("Invert all level control commands sent to the device").withDefault("false").build());
+
+        parameters.add(ConfigDescriptionParameterBuilder.create(CONFIG_INVERTCONTROL, Type.BOOLEAN)
+                .withLabel("Invert Level Reports")
+                .withDescription("Invert all level control reports received from the device").withDefault("false")
+                .build());
 
         if (levelControlCluster.isAttributeSupported(ZclLevelControlCluster.ATTR_ONOFFTRANSITIONTIME)) {
             options = new ArrayList<ParameterOption>();
@@ -176,6 +192,12 @@ public class ZclLevelControlConfig implements ZclClusterConfigHandler {
                 case CONFIG_DEFAULTTRANSITIONTIME:
                     defaultTransitionTime = ((BigDecimal) (configurationParameter.getValue())).intValue();
                     break;
+                case CONFIG_INVERTCONTROL:
+                    invertControl = ((Boolean) (configurationParameter.getValue())).booleanValue();
+                    break;
+                case CONFIG_INVERTREPORT:
+                    invertReport = ((Boolean) (configurationParameter.getValue())).booleanValue();
+                    break;
                 default:
                     logger.warn("{}: Unhandled configuration property {}", levelControlCluster.getZigBeeAddress(),
                             configurationParameter.getKey());
@@ -198,5 +220,33 @@ public class ZclLevelControlConfig implements ZclClusterConfigHandler {
      */
     public int getDefaultTransitionTime() {
         return defaultTransitionTime;
+    }
+
+    /**
+     * Handles the inversion of the command as required
+     *
+     * @param command
+     * @return
+     */
+    public Command handleInvertControl(Command command) {
+        if (command instanceof PercentType) {
+            if (invertControl) {
+                return new PercentType(100 - ((PercentType) command).intValue());
+            }
+        }
+        return command;
+    }
+
+    /**
+     * Handles the inversion of the report as required
+     *
+     * @param lastLevel
+     * @return
+     */
+    public PercentType handleInvertReport(PercentType Level) {
+        if (invertReport) {
+            return new PercentType(100 - Level.intValue());
+        }
+        return Level;
     }
 }

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/config/ZclLevelControlConfigTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/config/ZclLevelControlConfigTest.java
@@ -28,6 +28,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.types.PercentType;
 
 import com.zsmartsystems.zigbee.zcl.clusters.ZclLevelControlCluster;
 
@@ -38,6 +39,8 @@ import com.zsmartsystems.zigbee.zcl.clusters.ZclLevelControlCluster;
  */
 public class ZclLevelControlConfigTest {
     private final String CONFIG_DEFAULTTRANSITIONTIME = "zigbee_levelcontrol_transitiontimedefault";
+    private final String CONFIG_INVERTCONTROL = "zigbee_levelcontrol_invertcontrol";
+    private final String CONFIG_INVERTREPORT = "zigbee_levelcontrol_invertreport";
 
     @Test
     public void getConfiguration() {
@@ -49,7 +52,7 @@ public class ZclLevelControlConfigTest {
         config.initialize(cluster);
         List<ConfigDescriptionParameter> configuration = config.getConfiguration();
 
-        assertEquals(6, configuration.size());
+        assertEquals(8, configuration.size());
         ConfigDescriptionParameter cfg = configuration.get(0);
         assertEquals(CONFIG_DEFAULTTRANSITIONTIME, cfg.getName());
     }
@@ -65,13 +68,69 @@ public class ZclLevelControlConfigTest {
         config.getConfiguration();
 
         Configuration configuration = new Configuration();
-
         Map<String, Object> parameters = new HashMap<>();
         parameters.put(CONFIG_DEFAULTTRANSITIONTIME, new BigDecimal(45));
-
         config.updateConfiguration(configuration, parameters);
 
         assertEquals(45, config.getDefaultTransitionTime());
+    }
+
+    @Test
+    public void handleInvertControl() {
+        ZclLevelControlCluster cluster = Mockito.mock(ZclLevelControlCluster.class);
+        Mockito.when(cluster.discoverAttributes(ArgumentMatchers.anyBoolean())).thenReturn(new MockedBooleanFuture());
+        Mockito.when(cluster.isAttributeSupported(ArgumentMatchers.anyInt())).thenReturn(true);
+
+        ZclLevelControlConfig config = new ZclLevelControlConfig();
+        config.initialize(cluster);
+        config.getConfiguration();
+
+        assertEquals((new PercentType(75)), config.handleInvertControl(new PercentType(75)));
+
+        Configuration configuration = new Configuration();
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(CONFIG_INVERTCONTROL, Boolean.TRUE);
+        config.updateConfiguration(configuration, parameters);
+
+        assertEquals((new PercentType(25)), config.handleInvertControl(new PercentType(75)));
+        assertEquals((new PercentType(0)), config.handleInvertControl((new PercentType(100))));
+        assertEquals((new PercentType(99)), config.handleInvertControl((new PercentType(1))));
+
+        parameters.put(CONFIG_INVERTCONTROL, Boolean.FALSE);
+        config.updateConfiguration(configuration, parameters);
+
+        assertEquals((new PercentType(75)), config.handleInvertControl(new PercentType(75)));
+        assertEquals((new PercentType(100)), config.handleInvertControl((new PercentType(100))));
+        assertEquals((new PercentType(1)), config.handleInvertControl((new PercentType(1))));
+    }
+
+    @Test
+    public void handleInvertReport() {
+        ZclLevelControlCluster cluster = Mockito.mock(ZclLevelControlCluster.class);
+        Mockito.when(cluster.discoverAttributes(ArgumentMatchers.anyBoolean())).thenReturn(new MockedBooleanFuture());
+        Mockito.when(cluster.isAttributeSupported(ArgumentMatchers.anyInt())).thenReturn(true);
+
+        ZclLevelControlConfig config = new ZclLevelControlConfig();
+        config.initialize(cluster);
+        config.getConfiguration();
+
+        assertEquals((new PercentType(75)), config.handleInvertReport(new PercentType(75)));
+
+        Configuration configuration = new Configuration();
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(CONFIG_INVERTREPORT, Boolean.TRUE);
+        config.updateConfiguration(configuration, parameters);
+
+        assertEquals((new PercentType(25)), config.handleInvertReport(new PercentType(75)));
+        assertEquals((new PercentType(0)), config.handleInvertReport((new PercentType(100))));
+        assertEquals((new PercentType(99)), config.handleInvertReport((new PercentType(1))));
+
+        parameters.put(CONFIG_INVERTREPORT, Boolean.FALSE);
+        config.updateConfiguration(configuration, parameters);
+
+        assertEquals((new PercentType(75)), config.handleInvertReport(new PercentType(75)));
+        assertEquals((new PercentType(100)), config.handleInvertReport((new PercentType(100))));
+        assertEquals((new PercentType(1)), config.handleInvertReport((new PercentType(1))));
     }
 
     class MockedBooleanFuture implements Future<Boolean> {


### PR DESCRIPTION
Adds an option to invert the level control cluster command. Currently does not support the MOVE commands.

Closes #681 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>