### PR TITLE
Simplify mechanism to detect thermostat channels

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatLocalTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatLocalTemperature.java
@@ -16,12 +16,12 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
-import org.openhab.core.thing.Channel;
-import org.openhab.core.thing.ThingUID;
-import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
 import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,20 +116,12 @@ public class ZigBeeConverterThermostatLocalTemperature extends ZigBeeBaseChannel
             return null;
         }
 
-        try {
-            if (!cluster.discoverAttributes(false).get()) {
-                // Device is not supporting attribute reporting - instead, just read the attributes
-                Integer capabilities = cluster.getLocalTemperature(Long.MAX_VALUE);
-                if (capabilities == null) {
-                    logger.trace("{}: Thermostat local temperature returned null", endpoint.getIeeeAddress());
-                    return null;
-                }
-            } else if (!cluster.isAttributeSupported(ZclThermostatCluster.ATTR_LOCALTEMPERATURE)) {
-                logger.trace("{}: Thermostat local temperature not supported", endpoint.getIeeeAddress());
-                return null;
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.warn("{}: Exception discovering attributes in thermostat cluster", endpoint.getIeeeAddress(), e);
+        // Try to read the setpoint attribute
+        ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_LOCALTEMPERATURE);
+        Object value = attribute.readValue(Long.MAX_VALUE);
+        if (value == null) {
+            logger.trace("{}: Thermostat local temperature returned null", endpoint.getIeeeAddress());
+            return null;
         }
 
         return ChannelBuilder

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
@@ -16,13 +16,13 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.types.Command;
-import org.openhab.binding.zigbee.ZigBeeBindingConstants;
-import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
-import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -138,20 +138,12 @@ public class ZigBeeConverterThermostatOccupiedCooling extends ZigBeeBaseChannelC
             return null;
         }
 
-        try {
-            if (!cluster.discoverAttributes(false).get()) {
-                // Device is not supporting attribute reporting - instead, just read the attributes
-                Integer capabilities = cluster.getOccupiedCoolingSetpoint(Long.MAX_VALUE);
-                if (capabilities == null) {
-                    logger.trace("{}: Thermostat occupied cooling setpoint returned null", endpoint.getIeeeAddress());
-                    return null;
-                }
-            } else if (!cluster.isAttributeSupported(ZclThermostatCluster.ATTR_OCCUPIEDCOOLINGSETPOINT)) {
-                logger.trace("{}: Thermostat occupied cooling setpoint not supported", endpoint.getIeeeAddress());
-                return null;
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.warn("{}: Exception discovering attributes in thermostat cluster", endpoint.getIeeeAddress(), e);
+        // Try to read the setpoint attribute
+        ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_OCCUPIEDCOOLINGSETPOINT);
+        Object value = attribute.readValue(Long.MAX_VALUE);
+        if (value == null) {
+            logger.trace("{}: Thermostat occupied cooling setpoint returned null", endpoint.getIeeeAddress());
+            return null;
         }
 
         return ChannelBuilder

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
@@ -16,12 +16,12 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
-import org.openhab.core.thing.Channel;
-import org.openhab.core.thing.ThingUID;
-import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
 import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,20 +121,12 @@ public class ZigBeeConverterThermostatOutdoorTemperature extends ZigBeeBaseChann
             return null;
         }
 
-        try {
-            if (!cluster.discoverAttributes(false).get()) {
-                // Device is not supporting attribute reporting - instead, just read the attributes
-                Integer capabilities = cluster.getOutdoorTemperature(Long.MAX_VALUE);
-                if (capabilities == null) {
-                    logger.trace("{}: Thermostat outdoor temperature returned null", endpoint.getIeeeAddress());
-                    return null;
-                }
-            } else if (!cluster.isAttributeSupported(ZclThermostatCluster.ATTR_OUTDOORTEMPERATURE)) {
-                logger.trace("{}: Thermostat outdoor temperature not supported", endpoint.getIeeeAddress());
-                return null;
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.warn("{}: Exception discovering attributes in thermostat cluster", endpoint.getIeeeAddress(), e);
+        // Try to read the setpoint attribute
+        ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_OUTDOORTEMPERATURE);
+        Object value = attribute.readValue(Long.MAX_VALUE);
+        if (value == null) {
+            logger.trace("{}: Thermostat outdoor temperature returned null", endpoint.getIeeeAddress());
+            return null;
         }
 
         return ChannelBuilder

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
@@ -16,13 +16,13 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
-import org.openhab.binding.zigbee.ZigBeeBindingConstants;
-import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
-import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,20 +120,12 @@ public class ZigBeeConverterThermostatRunningMode extends ZigBeeBaseChannelConve
             return null;
         }
 
-        try {
-            if (!cluster.discoverAttributes(false).get()) {
-                // Device is not supporting attribute reporting - instead, just read the attributes
-                Integer capabilities = cluster.getThermostatRunningMode(Long.MAX_VALUE);
-                if (capabilities == null) {
-                    logger.trace("{}: Thermostat running mode returned null", endpoint.getIeeeAddress());
-                    return null;
-                }
-            } else if (!cluster.isAttributeSupported(ZclThermostatCluster.ATTR_THERMOSTATRUNNINGMODE)) {
-                logger.trace("{}: Thermostat running mode not supported", endpoint.getIeeeAddress());
-                return null;
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.warn("{}: Exception discovering attributes in thermostat cluster", endpoint.getIeeeAddress(), e);
+        // Try to read the setpoint attribute
+        ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_THERMOSTATRUNNINGMODE);
+        Object value = attribute.readValue(Long.MAX_VALUE);
+        if (value == null) {
+            logger.trace("{}: Thermostat running mode returned null", endpoint.getIeeeAddress());
+            return null;
         }
 
         return ChannelBuilder

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
@@ -180,20 +180,12 @@ public class ZigBeeConverterThermostatSystemMode extends ZigBeeBaseChannelConver
             return null;
         }
 
-        try {
-            if (!cluster.discoverAttributes(false).get()) {
-                // Device is not supporting attribute reporting - instead, just read the attributes
-                Integer capabilities = cluster.getSystemMode(Long.MAX_VALUE);
-                if (capabilities == null) {
-                    logger.trace("{}: Thermostat system mode returned null", endpoint.getIeeeAddress());
-                    return null;
-                }
-            } else if (!cluster.isAttributeSupported(ZclThermostatCluster.ATTR_SYSTEMMODE)) {
-                logger.trace("{}: Thermostat system mode not supported", endpoint.getIeeeAddress());
-                return null;
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.warn("{}: Exception discovering attributes in thermostat cluster", endpoint.getIeeeAddress(), e);
+        // Try to read the setpoint attribute
+        ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_SYSTEMMODE);
+        Object value = attribute.readValue(Long.MAX_VALUE);
+        if (value == null) {
+            logger.trace("{}: Thermostat system mode returned null", endpoint.getIeeeAddress());
+            return null;
         }
 
         return ChannelBuilder

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
@@ -16,13 +16,13 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.types.Command;
-import org.openhab.binding.zigbee.ZigBeeBindingConstants;
-import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
-import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,20 +135,12 @@ public class ZigBeeConverterThermostatUnoccupiedCooling extends ZigBeeBaseChanne
             return null;
         }
 
-        try {
-            if (!cluster.discoverAttributes(false).get()) {
-                // Device is not supporting attribute reporting - instead, just read the attributes
-                Integer capabilities = cluster.getUnoccupiedCoolingSetpoint(Long.MAX_VALUE);
-                if (capabilities == null) {
-                    logger.trace("{}: Thermostat unoccupied cooling setpoint returned null", endpoint.getIeeeAddress());
-                    return null;
-                }
-            } else if (!cluster.isAttributeSupported(ZclThermostatCluster.ATTR_UNOCCUPIEDCOOLINGSETPOINT)) {
-                logger.trace("{}: Thermostat unoccupied cooling setpoint not supported", endpoint.getIeeeAddress());
-                return null;
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.warn("{}: Exception discovering attributes in thermostat cluster", endpoint.getIeeeAddress(), e);
+        // Try to read the setpoint attribute
+        ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_UNOCCUPIEDCOOLINGSETPOINT);
+        Object value = attribute.readValue(Long.MAX_VALUE);
+        if (value == null) {
+            logger.trace("{}: Thermostat unoccupied cooling setpoint returned null", endpoint.getIeeeAddress());
+            return null;
         }
 
         return ChannelBuilder

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
@@ -16,13 +16,13 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.types.Command;
-import org.openhab.binding.zigbee.ZigBeeBindingConstants;
-import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
-import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -137,20 +137,12 @@ public class ZigBeeConverterThermostatUnoccupiedHeating extends ZigBeeBaseChanne
             return null;
         }
 
-        try {
-            if (!cluster.discoverAttributes(false).get()) {
-                // Device is not supporting attribute reporting - instead, just read the attributes
-                Integer capabilities = cluster.getUnoccupiedHeatingSetpoint(Long.MAX_VALUE);
-                if (capabilities == null) {
-                    logger.trace("{}: Thermostat unoccupied heating setpoint returned null", endpoint.getIeeeAddress());
-                    return null;
-                }
-            } else if (!cluster.isAttributeSupported(ZclThermostatCluster.ATTR_UNOCCUPIEDHEATINGSETPOINT)) {
-                logger.trace("{}: Thermostat unoccupied heating setpoint not supported", endpoint.getIeeeAddress());
-                return null;
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.warn("{}: Exception discovering attributes in thermostat cluster", endpoint.getIeeeAddress(), e);
+        // Try to read the setpoint attribute
+        ZclAttribute attribute = cluster.getAttribute(ZclThermostatCluster.ATTR_UNOCCUPIEDHEATINGSETPOINT);
+        Object value = attribute.readValue(Long.MAX_VALUE);
+        if (value == null) {
+            logger.trace("{}: Thermostat unoccupied heating setpoint returned null", endpoint.getIeeeAddress());
+            return null;
         }
 
         return ChannelBuilder


### PR DESCRIPTION
This changes the thermostat channel detection to just rely on reading the attributes rather than requesting the supported attributes list from the device. This should make the detection more robust as we have seen a thermostat that incorrectly reports the supported attributes.

The downside of this is that more requests are made to the device - 8 requests rather than 1. However this is only required during initialisation, and it seems that robustness is probably a stronger requirement here.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>