### PR TITLE
Add support for round Xiaomi Mijia wireless switch.

### DIFF
--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -297,6 +297,7 @@ The following devices have been tested by openHAB users with the binding. This l
 | Xiaomi Aqara Wireless Mini Switch              | _[Known issues](#xiaomi-devices)_                            |
 | Xiaomi Aqara Wired Wall Switch                 | _[Known issues](#xiaomi-devices)_                            |
 | Xiaomi Aqara Wireless Remote Switch            | Double Rocker variant _[Known issues](#xiaomi-devices)_      |
+| Xiaomi Mijia Smart Switch                      | Round Button _[Known issues](#xiaomi-devices)_               |
 
 <a name="note1"></a> _Note 1: Some devices may not work with the Telegesis dongle._
 

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/xiaomi_lumisensor-switch.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/xiaomi_lumisensor-switch.xml
@@ -8,7 +8,7 @@
 
 	<thing-type id="xiaomi_lumisensor-switch" listed="false">
 		<label>Xiaomi LUMI Mijia Button</label>
-		<description>Xiaomi LUMI Mijia Button (round)</description>
+		<description>Single battery operated button (round model)</description>
 
 		<channels>
 			<channel id="switch" typeId="switch_onoff">

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/xiaomi_lumisensor-switch.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/xiaomi_lumisensor-switch.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zigbee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<!-- These devices do not correctly report their clusters, so they need a static thing definition for the binding to inject the correct clusters into the ZigBeeNode -->
+
+	<thing-type id="xiaomi_lumisensor-switch" listed="false">
+		<label>Xiaomi LUMI Mijia Button</label>
+		<description>Xiaomi LUMI Mijia Button (round)</description>
+
+		<channels>
+			<channel id="switch" typeId="switch_onoff">
+				<properties>
+					<property name="zigbee_endpoint">1</property>
+					<property name="zigbee_inputclusters">6</property>
+				</properties>
+			</channel>
+		</channels>
+
+		<properties>
+			<property name="vendor">Xiaomi</property>
+			<property name="modelId">lumi.sensor_switch</property>
+			<property name="zigbee_logicaltype">END_DEVICE</property>
+		</properties>
+
+		<representation-property>zigbee_macaddress</representation-property>
+
+		<config-description>
+			<parameter name="zigbee_macaddress" type="text" readOnly="true" required="true">
+				<label>MAC Address</label>
+			</parameter>
+		</config-description>
+	</thing-type>
+</thing:thing-descriptions>

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/xiaomi_lumisensor-switch.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/xiaomi_lumisensor-switch.xml
@@ -4,7 +4,16 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<!-- These devices do not correctly report their clusters, so they need a static thing definition for the binding to inject the correct clusters into the ZigBeeNode -->
+	<!-- These devices do not correctly report their clusters, so they need a static thing definition for the binding to inject the correct clusters into the ZigBeeNode
+		They will detect as a generic zigbee:device quickly on scan but remain unusable in that state 
+		because they will not have gotten endpoint/channel/cluster linkaages.  
+
+		This thing description takes effect when the modelId is detected as lumi.sensor_switch.  
+		At that time sufficient details have been passed thru the binding to allow you to stop 
+		the pairing attempts when coupled with this static channel definition.
+
+		To pair just keep pairing and pressing the link button until the device detects as lumi:sensor_switch 
+		instead of as a generic zigbee:device.  Then add the device in openhab and wait a bit for it to come online.  -->
 
 	<thing-type id="xiaomi_lumisensor-switch" listed="false">
 		<label>Xiaomi LUMI Mijia Button</label>
@@ -14,6 +23,7 @@
 			<channel id="switch" typeId="switch_onoff">
 				<properties>
 					<property name="zigbee_endpoint">1</property>
+					<property name="zigbee_inputclusters">6</property>
 				</properties>
 			</channel>
 		</channels>

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/xiaomi_lumisensor-switch.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/xiaomi_lumisensor-switch.xml
@@ -14,16 +14,9 @@
 			<channel id="switch" typeId="switch_onoff">
 				<properties>
 					<property name="zigbee_endpoint">1</property>
-					<property name="zigbee_inputclusters">6</property>
 				</properties>
 			</channel>
 		</channels>
-
-		<properties>
-			<property name="vendor">Xiaomi</property>
-			<property name="modelId">lumi.sensor_switch</property>
-			<property name="zigbee_logicaltype">END_DEVICE</property>
-		</properties>
 
 		<representation-property>zigbee_macaddress</representation-property>
 

--- a/org.openhab.binding.zigbee/src/main/resources/discovery.txt
+++ b/org.openhab.binding.zigbee/src/main/resources/discovery.txt
@@ -7,6 +7,7 @@ xiaomi_lumisensorht,modelId=lumi.sensor_ht
 xiaomi_lumisensor-motion,modelId=lumi.sensor_motion
 xiaomi_lumiremoteb286acn01,modelId=lumi.remote.b286acn01
 xiaomi_lumisensor86sw2,modelId=lumi.sensor_86sw2
+xiaomi_lumisensor-switch,modelId=lumi.sensor_switch
 xiaomi_lumisensor-switchaq2,modelId=lumi.sensor_switch.aq2
 xiaomi_lumisensorwaterleak,modelId=lumi.sensor_wleak.aq1
 xiaomi_lumisensormagnet,modelId=lumi.sensor_magnet


### PR DESCRIPTION
The Xiaomi Mijia wireless switch is a round button.  Like a lot of the
other LUMI devices, it does not report its clusters correctly and needs
to be defined via xml to register correctly.  This patterns an xml file
based on the other similar Xiaomi devices.

I verified that it works with a Xiaomi Mijia button that I have.

Signed-off-by: Chris Elford <elfman03@gmail.com> (github: elfman03)
Signed-off-by: Chris Elford <elfman03@gmail.com>