### PR TITLE
Simplify colour channel initialisation to improve compatibility with non-standard devices

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeNodePropertyDiscoverer.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeNodePropertyDiscoverer.java
@@ -13,8 +13,8 @@
 package org.openhab.binding.zigbee.discovery;
 
 import static com.zsmartsystems.zigbee.zcl.clusters.ZclBasicCluster.*;
-import static org.openhab.core.thing.Thing.*;
 import static org.openhab.binding.zigbee.ZigBeeBindingConstants.*;
+import static org.openhab.core.thing.Thing.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,8 +26,8 @@ import java.util.concurrent.ExecutionException;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.thing.Thing;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.core.thing.Thing;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
@@ -419,44 +419,22 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
             return null;
         }
 
-        try {
-            if (!clusterColorControl.discoverAttributes(false).get()) {
-                // Device is not supporting attribute reporting - instead, just read the attributes
-                Integer capabilities = (Integer) clusterColorControl
-                        .getAttribute(ZclColorControlCluster.ATTR_COLORCAPABILITIES).readValue(Long.MAX_VALUE);
-                if (capabilities == null
-                        && clusterColorControl.getAttribute(ZclColorControlCluster.ATTR_CURRENTX)
-                                .readValue(Long.MAX_VALUE) == null
-                        && clusterColorControl.getAttribute(ZclColorControlCluster.ATTR_CURRENTHUE)
-                                .readValue(Long.MAX_VALUE) == null) {
-                    logger.trace("{}: Color control XY and Hue returned null", endpoint.getIeeeAddress());
-                    return null;
-                }
-                if (capabilities != null && ((capabilities & (ColorCapabilitiesEnum.HUE_AND_SATURATION.getKey()
-                        | ColorCapabilitiesEnum.XY_ATTRIBUTE.getKey())) == 0)) {
-                    // No support for hue or XY
-                    logger.trace("{}: Color control XY and Hue capabilities not supported", endpoint.getIeeeAddress());
-                    return null;
-                }
-            } else if (clusterColorControl.isAttributeSupported(ZclColorControlCluster.ATTR_COLORCAPABILITIES)) {
-                // If the device is reporting its capabilities, then use this over attribute detection
-                // The color control cluster is required to always support XY attributes, so a non-color bulb is still
-                // detected as a color bulb in this case.
-                Integer capabilities = (Integer) clusterColorControl
-                        .getAttribute(ZclColorControlCluster.ATTR_COLORCAPABILITIES).readValue(Long.MAX_VALUE);
-                if ((capabilities != null) && (capabilities & (ColorCapabilitiesEnum.HUE_AND_SATURATION.getKey()
-                        | ColorCapabilitiesEnum.XY_ATTRIBUTE.getKey())) == 0) {
-                    // No support for hue or XY
-                    logger.trace("{}: Color control XY and Hue capabilities not supported", endpoint.getIeeeAddress());
-                    return null;
-                }
-            } else if (!clusterColorControl.isAttributeSupported(ZclColorControlCluster.ATTR_CURRENTHUE)
-                    && !clusterColorControl.isAttributeSupported(ZclColorControlCluster.ATTR_CURRENTX)) {
-                logger.trace("{}: Color control XY and Hue attributes not supported", endpoint.getIeeeAddress());
-                return null;
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.warn("{}: Exception discovering attributes in color control cluster", endpoint.getIeeeAddress(), e);
+        // Device is not supporting attribute reporting - instead, just read the attributes
+        Integer capabilities = (Integer) clusterColorControl.getAttribute(ZclColorControlCluster.ATTR_COLORCAPABILITIES)
+                .readValue(Long.MAX_VALUE);
+        if (capabilities == null
+                && clusterColorControl.getAttribute(ZclColorControlCluster.ATTR_CURRENTX)
+                        .readValue(Long.MAX_VALUE) == null
+                && clusterColorControl.getAttribute(ZclColorControlCluster.ATTR_CURRENTHUE)
+                        .readValue(Long.MAX_VALUE) == null) {
+            logger.trace("{}: Color control XY and Hue returned null", endpoint.getIeeeAddress());
+            return null;
+        }
+        if (capabilities != null && ((capabilities & (ColorCapabilitiesEnum.HUE_AND_SATURATION.getKey()
+                | ColorCapabilitiesEnum.XY_ATTRIBUTE.getKey())) == 0)) {
+            // No support for hue or XY
+            logger.trace("{}: Color control XY and Hue capabilities not supported", endpoint.getIeeeAddress());
+            return null;
         }
 
         return ChannelBuilder

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
@@ -153,41 +153,19 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
             return null;
         }
 
-        try {
-            if (!clusterColorControl.discoverAttributes(false).get()) {
-                // Device is not supporting attribute reporting - instead, just read the attributes
-                Integer capabilities = (Integer) clusterColorControl
-                        .getAttribute(ZclColorControlCluster.ATTR_COLORCAPABILITIES).readValue(Long.MAX_VALUE);
-                if (capabilities == null && clusterColorControl
-                        .getAttribute(ZclColorControlCluster.ATTR_COLORTEMPERATURE).readValue(Long.MAX_VALUE) == null) {
-                    logger.trace("{}: Color control color temperature attribute returned null on endpoint {}",
-                            endpoint.getIeeeAddress(), endpoint.getEndpointId());
-                    return null;
-                }
-                if (capabilities != null && (capabilities & ColorCapabilitiesEnum.COLOR_TEMPERATURE.getKey()) == 0) {
-                    // No support for color temperature
-                    logger.trace("{}: Color control color temperature capability not supported on endpoint {}",
-                            endpoint.getIeeeAddress(), endpoint.getEndpointId());
-                    return null;
-                }
-            } else if (clusterColorControl.isAttributeSupported(ZclColorControlCluster.ATTR_COLORCAPABILITIES)) {
-                // If the device is reporting is capabilities, then use this over attribute detection
-                Integer capabilities = (Integer) clusterColorControl
-                        .getAttribute(ZclColorControlCluster.ATTR_COLORCAPABILITIES).readValue(Long.MAX_VALUE);
-                if (capabilities != null && (capabilities & ColorCapabilitiesEnum.COLOR_TEMPERATURE.getKey()) == 0) {
-                    // No support for color temperature
-                    logger.trace("{}: Color control color temperature capability not supported on endpoint {}",
-                            endpoint.getIeeeAddress(), endpoint.getEndpointId());
-                    return null;
-                }
-            } else if (!clusterColorControl.isAttributeSupported(ZclColorControlCluster.ATTR_COLORTEMPERATURE)) {
-                logger.trace("{}: Color control color temperature attribute not supported on endpoint {}",
-                        endpoint.getIeeeAddress(), endpoint.getEndpointId());
-                return null;
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            logger.warn(String.format("%s: Exception discovering attributes in color control cluster on endpoint %d",
-                    endpoint.getIeeeAddress(), endpoint.getEndpointId()), e);
+        Integer capabilities = (Integer) clusterColorControl.getAttribute(ZclColorControlCluster.ATTR_COLORCAPABILITIES)
+                .readValue(Long.MAX_VALUE);
+        if (capabilities == null && clusterColorControl.getAttribute(ZclColorControlCluster.ATTR_COLORTEMPERATURE)
+                .readValue(Long.MAX_VALUE) == null) {
+            logger.trace("{}: Color control color temperature attribute returned null on endpoint {}",
+                    endpoint.getIeeeAddress(), endpoint.getEndpointId());
+            return null;
+        }
+        if (capabilities != null && (capabilities & ColorCapabilitiesEnum.COLOR_TEMPERATURE.getKey()) == 0) {
+            // No support for color temperature
+            logger.trace("{}: Color control color temperature capability not supported on endpoint {}",
+                    endpoint.getIeeeAddress(), endpoint.getEndpointId());
+            return null;
         }
 
         return ChannelBuilder


### PR DESCRIPTION
This removes the request to ask devices what attributes they support, and just reads the attributes. This should make the binding more tolerant to non-standard devices.

Closes #730 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>