### PR TITLE
Improve state consistency in level control converter

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -40,6 +40,7 @@ import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -381,7 +382,12 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
 
         // Some functionality (eg IncreaseDecrease) requires that we know the last command received
         lastCommand = localCommand;
-        monitorCommandResponse(localCommand, responseFuture);
+        monitorCommandResponse(localCommand, responseFuture, cmd -> {
+            updateChannelState((State) cmd);
+            if (cmd instanceof PercentType) {
+                lastLevel = ((PercentType) cmd);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
This adds support for lambda expression in the base converter class to allow the converter to manage what it does when a command completes.

It then changes the way the level control converter works as it needs to manage the local variables that maintain the current state to avoid the level being set to a new, then old level when a command is sent.

Closes #768 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>