### PR TITLE
Revert channel link test to use ChannelUID

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -590,21 +590,20 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
             @Override
             public void run() {
                 try {
-                    logger.debug("{}: Polling {} channels...", nodeIeeeAddress, channels.keySet().size());
+                    logger.debug("{}: Polling {} channels", nodeIeeeAddress, channels.keySet().size());
 
                     for (ChannelUID channelUid : channels.keySet()) {
-                        if (isLinked(channelUid.getId())) {
+                        if (!isLinked(channelUid)) {
                             // Don't poll if this channel isn't linked
-                            logger.debug("{}: Not polling {} - unlinked", nodeIeeeAddress, channelUid.getId());
+                            logger.debug("{}: Not polling {} - channel is not linked", nodeIeeeAddress, channelUid);
                             continue;
                         }
 
                         ZigBeeBaseChannelConverter converter = channels.get(channelUid);
                         if (converter == null) {
-                            logger.debug("{}: Not polling {} - no converter found", nodeIeeeAddress,
-                                    channelUid.getId());
+                            logger.debug("{}: Not polling {} - no converter found", nodeIeeeAddress, channelUid);
                         } else {
-                            logger.debug("{}: Polling {}", nodeIeeeAddress, channelUid.getId());
+                            logger.debug("{}: Polling {}", nodeIeeeAddress, channelUid);
                             converter.handleRefresh();
                         }
                     }


### PR DESCRIPTION
In the base handler the call to the registry use the UID so it seems best to continue to use this here.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>