### PR TITLE
Fix Zigbee name stylization

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 Delete this section in your issue...
 
-This issue list is to report bugs or enhancements for the openHAB ZigBee binding. If you're not sure about something, please consider discussing it on the [forum](http://community.openhab.org) before raising an issue - more people follow the forum than monitor the issues list, so if you are having trouble with a device, or want to ask a question, you will have a much larger audience there.
+This issue list is to report bugs or enhancements for the openHAB Zigbee binding. If you're not sure about something, please consider discussing it on the [forum](http://community.openhab.org) before raising an issue - more people follow the forum than monitor the issues list, so if you are having trouble with a device, or want to ask a question, you will have a much larger audience there.
 
 Please provide a debug log file. You can enable debug logging with the following Karaf commands -:
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>org.openhab.addons.bom.zigbee</artifactId>
   <packaging>pom</packaging>
 
-  <name>openHAB ZigBee :: BOM :: openHAB ZigBee Binding</name>
+  <name>openHAB Zigbee :: BOM :: openHAB Zigbee Binding</name>
 
   <dependencies>
     <dependency>

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -14,7 +14,7 @@
 	<artifactId>openhab-binding-zigbee</artifactId>
 	<packaging>feature</packaging>
 
-	<name>openHAB Add-ons :: Features :: Karaf :: openHAB ZigBee Binding</name>
+	<name>openHAB Add-ons :: Features :: Karaf :: openHAB Zigbee Binding</name>
 
 	<dependencies>
 		<dependency>

--- a/feature/src/main/feature/feature.xml
+++ b/feature/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.2.1" name="feature">
-    <feature name="openhab-binding-zigbee" description="openHAB ZigBee Binding" version="${project.version}">
+    <feature name="openhab-binding-zigbee" description="openHAB Zigbee Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-serial</feature>
     </feature>

--- a/org.openhab.binding.zigbee.cc2531/pom.xml
+++ b/org.openhab.binding.zigbee.cc2531/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>org.openhab.binding.zigbee.cc2531</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: ZigBee CC2531 Bridge</name>
+  <name>openHAB Add-ons :: Bundles :: Zigbee CC2531 Bridge</name>
 
   <dependencies>
     <dependency>

--- a/org.openhab.binding.zigbee.cc2531/src/main/java/org/openhab/binding/zigbee/cc2531/handler/CC2531Handler.java
+++ b/org.openhab.binding.zigbee.cc2531/src/main/java/org/openhab/binding/zigbee/cc2531/handler/CC2531Handler.java
@@ -54,7 +54,7 @@ public class CC2531Handler extends ZigBeeCoordinatorHandler {
 
     @Override
     protected void initializeDongle() {
-        logger.debug("Initializing ZigBee CC2531 serial bridge handler.");
+        logger.debug("Initializing Zigbee CC2531 serial bridge handler.");
 
         CC2531Configuration config = getConfigAs(CC2531Configuration.class);
         ZigBeeTransportTransmit dongle = createDongle(config);
@@ -69,7 +69,7 @@ public class CC2531Handler extends ZigBeeCoordinatorHandler {
 
         ZigBeeTransportTransmit dongle = new ZigBeeDongleTiCc2531(serialPort);
 
-        logger.debug("ZigBee CC2531 Coordinator opening Port:'{}' PAN:{}, EPAN:{}, Channel:{}", config.zigbee_port,
+        logger.debug("Zigbee CC2531 Coordinator opening Port:'{}' PAN:{}, EPAN:{}, Channel:{}", config.zigbee_port,
                 Integer.toHexString(panId), extendedPanId, Integer.toString(channelId));
 
         return dongle;

--- a/org.openhab.binding.zigbee.cc2531/src/main/resources/OH-INF/thing/controller_ti2351.xml
+++ b/org.openhab.binding.zigbee.cc2531/src/main/resources/OH-INF/thing/controller_ti2351.xml
@@ -11,7 +11,7 @@
         <config-description>
             <parameter-group name="network">
                 <context></context>
-                <label>ZigBee Network Configuration</label>
+                <label>Zigbee Network Configuration</label>
                 <description></description>
             </parameter-group>
 

--- a/org.openhab.binding.zigbee.console.ember/pom.xml
+++ b/org.openhab.binding.zigbee.console.ember/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>org.openhab.binding.zigbee.console.ember</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: ZigBee Console Ember</name>
+  <name>openHAB Add-ons :: Bundles :: Zigbee Console Ember</name>
 
   <dependencies>
     <dependency>

--- a/org.openhab.binding.zigbee.console.ember/src/main/java/org/openhab/binding/zigbee/console/ember/internal/EmberZigBeeConsoleCommandProvider.java
+++ b/org.openhab.binding.zigbee.console.ember/src/main/java/org/openhab/binding/zigbee/console/ember/internal/EmberZigBeeConsoleCommandProvider.java
@@ -43,7 +43,7 @@ import com.zsmartsystems.zigbee.console.ember.EmberConsoleSecurityStateCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleTransientKeyCommand;
 
 /**
- * This class provides ZigBee console commands for Ember dongles.
+ * This class provides Zigbee console commands for Ember dongles.
  *
  * @author Henning Sudbrock - initial contribution
  * @author Chris Jackson - added commands

--- a/org.openhab.binding.zigbee.console.telegesis/pom.xml
+++ b/org.openhab.binding.zigbee.console.telegesis/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>org.openhab.binding.zigbee.console.telegesis</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: ZigBee Console Telegesis</name>
+  <name>openHAB Add-ons :: Bundles :: Zigbee Console Telegesis</name>
 
   <dependencies>
     <dependency>

--- a/org.openhab.binding.zigbee.console.telegesis/src/main/java/org/openhab/binding/zigbee/console/telegesis/internal/TelegesisZigBeeConsoleCommandProvider.java
+++ b/org.openhab.binding.zigbee.console.telegesis/src/main/java/org/openhab/binding/zigbee/console/telegesis/internal/TelegesisZigBeeConsoleCommandProvider.java
@@ -30,7 +30,7 @@ import com.zsmartsystems.zigbee.console.ZigBeeConsoleCommand;
 import com.zsmartsystems.zigbee.console.telegesis.TelegesisConsoleSecurityStateCommand;
 
 /**
- * This class provides ZigBee console commands for Telegesis dongles.
+ * This class provides Zigbee console commands for Telegesis dongles.
  *
  * @author Henning Sudbrock - initial contribution
  */

--- a/org.openhab.binding.zigbee.console/pom.xml
+++ b/org.openhab.binding.zigbee.console/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>org.openhab.binding.zigbee.console</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: ZigBee Console</name>
+  <name>openHAB Add-ons :: Bundles :: Zigbee Console</name>
 
   <dependencies>
     <dependency>

--- a/org.openhab.binding.zigbee.console/src/main/java/org/openhab/binding/zigbee/console/internal/GeneralZigBeeConsoleCommandProvider.java
+++ b/org.openhab.binding.zigbee.console/src/main/java/org/openhab/binding/zigbee/console/internal/GeneralZigBeeConsoleCommandProvider.java
@@ -58,7 +58,7 @@ import com.zsmartsystems.zigbee.console.ZigBeeConsoleUnbindCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleWindowCoveringCommand;
 
 /**
- * This class provides general ZigBee console commands that are not tied to a specific ZigBee dongle.
+ * This class provides general Zigbee console commands that are not tied to a specific Zigbee dongle.
  *
  * @author Henning Sudbrock - initial contribution
  * @author Chris Jackson - added commands

--- a/org.openhab.binding.zigbee.console/src/main/java/org/openhab/binding/zigbee/console/internal/ZigBeeConsoleCommandExtension.java
+++ b/org.openhab.binding.zigbee.console/src/main/java/org/openhab/binding/zigbee/console/internal/ZigBeeConsoleCommandExtension.java
@@ -43,7 +43,7 @@ import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleCommand;
 
 /**
- * Console command extension that delegates commands to the ZigBee console of the underlying ZigBee core framework.
+ * Console command extension that delegates commands to the Zigbee console of the underlying Zigbee core framework.
  *
  * @author Henning Sudbrock - initial contribution
  */
@@ -57,7 +57,7 @@ public class ZigBeeConsoleCommandExtension extends AbstractConsoleCommandExtensi
     private ThingUID bridgeUID;
 
     public ZigBeeConsoleCommandExtension() {
-        super("zigbee", "ZigBee console commands");
+        super("zigbee", "Zigbee console commands");
     }
 
     @Reference
@@ -174,10 +174,10 @@ public class ZigBeeConsoleCommandExtension extends AbstractConsoleCommandExtensi
                     thing -> BINDING_ID.equals(thing.getThingTypeUID().getBindingId()) && thing instanceof Bridge)
                     .collect(toList());
             if (bridges.isEmpty()) {
-                throw new CommandExecutionException("No ZigBee bridge found");
+                throw new CommandExecutionException("No Zigbee bridge found");
             } else if (bridges.size() > 1) {
                 throw new CommandExecutionException(
-                        "Multiple ZigBee bridges found; please select one using the setBridgeUid command");
+                        "Multiple Zigbee bridges found; please select one using the setBridgeUid command");
             } else {
                 return (Bridge) bridges.get(0);
             }

--- a/org.openhab.binding.zigbee.ember/pom.xml
+++ b/org.openhab.binding.zigbee.ember/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>org.openhab.binding.zigbee.ember</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: ZigBee Ember Bridge</name>
+  <name>openHAB Add-ons :: Bundles :: Zigbee Ember Bridge</name>
 
   <dependencies>
     <dependency>

--- a/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
+++ b/org.openhab.binding.zigbee.ember/src/main/java/org/openhab/binding/zigbee/ember/handler/EmberHandler.java
@@ -284,7 +284,7 @@ public class EmberHandler extends ZigBeeCoordinatorHandler implements FirmwareUp
                 config.zigbee_port, config.zigbee_baud, flowControl);
         final ZigBeeDongleEzsp dongle = new ZigBeeDongleEzsp(serialPort);
 
-        logger.debug("ZigBee Ember Coordinator opening Port:'{}' PAN:{}, EPAN:{}, Channel:{}", config.zigbee_port,
+        logger.debug("Zigbee Ember Coordinator opening Port:'{}' PAN:{}, EPAN:{}, Channel:{}", config.zigbee_port,
                 Integer.toHexString(panId), extendedPanId, Integer.toString(channelId));
 
         dongle.updateDefaultConfiguration(EzspConfigId.EZSP_CONFIG_ADDRESS_TABLE_SIZE, config.zigbee_networksize);
@@ -366,7 +366,7 @@ public class EmberHandler extends ZigBeeCoordinatorHandler implements FirmwareUp
             return;
         }
 
-        logger.debug("ZigBee Ember Coordinator group registration is {}", groupsString);
+        logger.debug("Zigbee Ember Coordinator group registration is {}", groupsString);
         ZigBeeDongleEzsp dongle = (ZigBeeDongleEzsp) zigbeeTransport;
         EmberNcp ncp = dongle.getEmberNcp();
 
@@ -383,7 +383,7 @@ public class EmberHandler extends ZigBeeCoordinatorHandler implements FirmwareUp
         } else if (multicastTableSize > GROUPS_MAXIMUM) {
             multicastTableSize = GROUPS_MAXIMUM;
         }
-        logger.debug("ZigBee Ember Coordinator multicast table size set to {}", multicastTableSize);
+        logger.debug("Zigbee Ember Coordinator multicast table size set to {}", multicastTableSize);
         dongle.updateDefaultConfiguration(EzspConfigId.EZSP_CONFIG_MULTICAST_TABLE_SIZE, multicastTableSize);
 
         int index = 0;
@@ -394,7 +394,7 @@ public class EmberHandler extends ZigBeeCoordinatorHandler implements FirmwareUp
             entry.setMulticastId(group);
             EmberStatus result = ncp.setMulticastTableEntry(index, entry);
 
-            logger.debug("ZigBee Ember Coordinator multicast table index {} updated with {}, result {}", index, entry,
+            logger.debug("Zigbee Ember Coordinator multicast table index {} updated with {}, result {}", index, entry,
                     result);
 
             index++;

--- a/org.openhab.binding.zigbee.ember/src/main/resources/OH-INF/thing/controller_ember.xml
+++ b/org.openhab.binding.zigbee.ember/src/main/resources/OH-INF/thing/controller_ember.xml
@@ -20,7 +20,7 @@
 		<config-description>
 			<parameter-group name="network">
 				<context></context>
-				<label>ZigBee Network Configuration</label>
+				<label>Zigbee Network Configuration</label>
 				<description></description>
 			</parameter-group>
 

--- a/org.openhab.binding.zigbee.firmware/pom.xml
+++ b/org.openhab.binding.zigbee.firmware/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>org.openhab.binding.zigbee.firmware</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: ZigBee Firmware Provider</name>
+  <name>openHAB Add-ons :: Bundles :: Zigbee Firmware Provider</name>
 
   <dependencies>
     <dependency>

--- a/org.openhab.binding.zigbee.firmware/src/main/java/org/openhab/binding/zigbee/firmware/ZigBeeFirmwareProvider.java
+++ b/org.openhab.binding.zigbee.firmware/src/main/java/org/openhab/binding/zigbee/firmware/ZigBeeFirmwareProvider.java
@@ -53,20 +53,20 @@ public class ZigBeeFirmwareProvider implements FirmwareProvider {
 
     @Activate
     protected void activate() {
-        logger.debug("ZigBee Firmware Provider: Activated");
+        logger.debug("Zigbee Firmware Provider: Activated");
         String folder = OpenHAB.getUserDataFolder() + File.separator + "firmware" + File.separator;
         directoryReader = new GithubLibraryReader(folder);
         try {
             directoryReader.create("https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master");
             directoryReader.updateRemoteDirectory();
         } catch (Exception e) {
-            logger.error("Exception activating ZigBee firmware provider ", e);
+            logger.error("Exception activating Zigbee firmware provider ", e);
         }
     }
 
     @Deactivate
     protected void deactivate() {
-        logger.debug("ZigBee Firmware Provider: Deactivated");
+        logger.debug("Zigbee Firmware Provider: Deactivated");
     }
 
     @Override
@@ -115,7 +115,7 @@ public class ZigBeeFirmwareProvider implements FirmwareProvider {
     }
 
     private ZigBeeFirmwareVersion getRequestedVersionFromThing(@NonNull Thing thing) {
-        // We only deal in ZigBee devices here
+        // We only deal in Zigbee devices here
         if (!(thing.getHandler() instanceof ZigBeeThingHandler)) {
             return null;
         }

--- a/org.openhab.binding.zigbee.firmware/src/main/java/org/openhab/binding/zigbee/firmware/internal/GithubLibraryReader.java
+++ b/org.openhab.binding.zigbee.firmware/src/main/java/org/openhab/binding/zigbee/firmware/internal/GithubLibraryReader.java
@@ -79,7 +79,7 @@ public class GithubLibraryReader {
     }
 
     public boolean create(String repositoryAddress) throws Exception {
-        logger.debug("ZigBee Firmware Provider: Creating directory at {}", repositoryAddress);
+        logger.debug("Zigbee Firmware Provider: Creating directory at {}", repositoryAddress);
         String localAddress;
         if (repositoryAddress.endsWith("/")) {
             localAddress = repositoryAddress.substring(0, repositoryAddress.length() - 1);
@@ -102,19 +102,19 @@ public class GithubLibraryReader {
         try {
             this.httpClient.start();
         } catch (Exception e) {
-            logger.debug("ZigBee Firmware Provider: Cannot start HttpClient for GitHub connection!");
+            logger.debug("Zigbee Firmware Provider: Cannot start HttpClient for GitHub connection!");
             return false;
         }
 
-        logger.debug("ZigBee Firmware Provider communicator created for {}", this.repositoryAddress);
+        logger.debug("Zigbee Firmware Provider communicator created for {}", this.repositoryAddress);
 
         File folder = new File(OpenHAB.getUserDataFolder() + File.separator + ZigBeeBindingConstants.BINDING_ID
                 + File.separator + PATH_TO_FIRMWARE);
 
         if (!folder.exists()) {
-            logger.debug("ZigBee Firmware Provider creating firmware folder {}", folder);
+            logger.debug("Zigbee Firmware Provider creating firmware folder {}", folder);
             if (!folder.mkdirs()) {
-                logger.error("ZigBee Firmware Provider error creating firmware folder {}", folder);
+                logger.error("Zigbee Firmware Provider error creating firmware folder {}", folder);
             }
         }
 
@@ -131,12 +131,12 @@ public class GithubLibraryReader {
     }
 
     public void updateRemoteDirectory() {
-        logger.debug("ZigBee Firmware Provider: Scheduling update from remote");
+        logger.debug("Zigbee Firmware Provider: Scheduling update from remote");
 
         Runnable commandHandler = new Runnable() {
             @Override
             public void run() {
-                logger.debug("ZigBee Firmware Provider: Starting update from remote");
+                logger.debug("Zigbee Firmware Provider: Starting update from remote");
                 List<DirectoryFileEntry> newDirectory = getIndex();
 
                 processDirectory(newDirectory);
@@ -151,12 +151,12 @@ public class GithubLibraryReader {
         for (DirectoryFileEntry entry : newDirectory) {
             File localFile = getLocalFile(entry);
             if (localFile.exists()) {
-                logger.debug("ZigBee Firmware Provider found local file '{}'", localFile);
+                logger.debug("Zigbee Firmware Provider found local file '{}'", localFile);
 
                 // Check hash and delete local file if invalid
                 InputStream stream = getInputStream(entry);
                 if (stream == null) {
-                    logger.debug("ZigBee Firmware Provider local file '{}' failed hash check and is deleted",
+                    logger.debug("Zigbee Firmware Provider local file '{}' failed hash check and is deleted",
                             localFile);
                     localFile.delete();
                 } else {
@@ -165,7 +165,7 @@ public class GithubLibraryReader {
                         stream.close();
                         createMd5Hash(data, entry);
                     } catch (IOException | NoSuchAlgorithmException e) {
-                        logger.debug("ZigBee Firmware Provider local file '{}' failed hash check and is deleted: {}",
+                        logger.debug("Zigbee Firmware Provider local file '{}' failed hash check and is deleted: {}",
                                 localFile, e.getLocalizedMessage());
                         localFile.delete();
                     }
@@ -174,7 +174,7 @@ public class GithubLibraryReader {
         }
 
         if (newDirectory == null) {
-            logger.debug("ZigBee Firmware Provider directory update from GitHub failed!");
+            logger.debug("Zigbee Firmware Provider directory update from GitHub failed!");
             return;
         }
 
@@ -192,21 +192,21 @@ public class GithubLibraryReader {
         // Download from remote
         String url = entry.getUrl();
 
-        logger.debug("ZigBee Firmware Provider: Requesting GitHub request: {}", url);
+        logger.debug("Zigbee Firmware Provider: Requesting GitHub request: {}", url);
         ContentResponse response;
 
         try {
             response = httpClient.newRequest(url).method(GET).timeout(HTTP_TIMEOUT, TimeUnit.SECONDS).send();
             if (response.getStatus() != HttpURLConnection.HTTP_OK) {
-                logger.warn("ZigBee Firmware Provider return status other than HTTP_OK : {}", response.getStatus());
+                logger.warn("Zigbee Firmware Provider return status other than HTTP_OK : {}", response.getStatus());
                 return false;
             }
 
         } catch (TimeoutException | ExecutionException | NullPointerException e) {
-            logger.warn("ZigBee Firmware Provider could not connect to server with exception: ", e);
+            logger.warn("Zigbee Firmware Provider could not connect to server with exception: ", e);
             return false;
         } catch (InterruptedException e) {
-            logger.warn("ZigBee Firmware Provider connect to server interrupted: ", e);
+            logger.warn("Zigbee Firmware Provider connect to server interrupted: ", e);
             Thread.currentThread().interrupt();
             return false;
         }
@@ -268,21 +268,21 @@ public class GithubLibraryReader {
     private synchronized List<DirectoryFileEntry> getIndex() {
         String url = "https://" + repositoryAddress + INDEX_JSON;
 
-        logger.debug("ZigBee Firmware Provider: Performing GitHub request: {}", url);
+        logger.debug("Zigbee Firmware Provider: Performing GitHub request: {}", url);
         ContentResponse response;
 
         try {
             response = httpClient.newRequest(url).method(GET).timeout(HTTP_TIMEOUT, TimeUnit.SECONDS).send();
             if (response.getStatus() != HttpURLConnection.HTTP_OK) {
-                logger.warn("ZigBee Firmware Provider server return status other than HTTP_OK : {}",
+                logger.warn("Zigbee Firmware Provider server return status other than HTTP_OK : {}",
                         response.getStatus());
                 return null;
             }
         } catch (TimeoutException | ExecutionException | NullPointerException e) {
-            logger.warn("ZigBee Firmware Provider could not connect to server with exception: ", e);
+            logger.warn("Zigbee Firmware Provider could not connect to server with exception: ", e);
             return null;
         } catch (InterruptedException e) {
-            logger.warn("ZigBee Firmware Provider connection to server interrupted: ", e);
+            logger.warn("Zigbee Firmware Provider connection to server interrupted: ", e);
             Thread.currentThread().interrupt();
             return null;
         }
@@ -303,13 +303,13 @@ public class GithubLibraryReader {
 
             String hash = hashToString(messageDigest);
             if (!entry.getSha512().equalsIgnoreCase(hash)) {
-                logger.warn("ZigBee Firmware Provider SHA512 hash check on file {} failed", entry.getUrl());
+                logger.warn("Zigbee Firmware Provider SHA512 hash check on file {} failed", entry.getUrl());
                 return false;
             }
 
             return true;
         } catch (NoSuchAlgorithmException e) {
-            logger.warn("ZigBee Firmware Provider error checking hash on file {}: ", entry.getUrl(), e);
+            logger.warn("Zigbee Firmware Provider error checking hash on file {}: ", entry.getUrl(), e);
         }
 
         return false;

--- a/org.openhab.binding.zigbee.serial/pom.xml
+++ b/org.openhab.binding.zigbee.serial/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>org.openhab.binding.zigbee.serial</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: ZigBee Serial Driver</name>
+  <name>openHAB Add-ons :: Bundles :: Zigbee Serial Driver</name>
 
   <dependencies>
     <dependency>

--- a/org.openhab.binding.zigbee.telegesis/pom.xml
+++ b/org.openhab.binding.zigbee.telegesis/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>org.openhab.binding.zigbee.telegesis</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: ZigBee Telegesis Bridge</name>
+  <name>openHAB Add-ons :: Bundles :: Zigbee Telegesis Bridge</name>
 
   <dependencies>
     <dependency>

--- a/org.openhab.binding.zigbee.telegesis/src/main/java/org/openhab/binding/zigbee/telegesis/handler/TelegesisHandler.java
+++ b/org.openhab.binding.zigbee.telegesis/src/main/java/org/openhab/binding/zigbee/telegesis/handler/TelegesisHandler.java
@@ -149,7 +149,7 @@ public class TelegesisHandler extends ZigBeeCoordinatorHandler implements Firmwa
                 FlowControl.FLOWCONTROL_OUT_NONE);
         final ZigBeeDongleTelegesis dongle = new ZigBeeDongleTelegesis(serialPort);
 
-        logger.debug("ZigBee Telegesis Coordinator opening Port:'{}' PAN:{}, EPAN:{}, Channel:{}", config.zigbee_port,
+        logger.debug("Zigbee Telegesis Coordinator opening Port:'{}' PAN:{}, EPAN:{}, Channel:{}", config.zigbee_port,
                 Integer.toHexString(panId), extendedPanId, Integer.toString(channelId));
 
         dongle.setTelegesisPassword(config.zigbee_password);

--- a/org.openhab.binding.zigbee.telegesis/src/main/resources/OH-INF/thing/controller_telegesis.xml
+++ b/org.openhab.binding.zigbee.telegesis/src/main/resources/OH-INF/thing/controller_telegesis.xml
@@ -11,7 +11,7 @@
         <config-description>
             <parameter-group name="network">
                 <context></context>
-                <label>ZigBee Network Configuration</label>
+                <label>Zigbee Network Configuration</label>
                 <description></description>
             </parameter-group>
 

--- a/org.openhab.binding.zigbee.xbee/pom.xml
+++ b/org.openhab.binding.zigbee.xbee/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>org.openhab.binding.zigbee.xbee</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: ZigBee XBee Bridge</name>
+  <name>openHAB Add-ons :: Bundles :: Zigbee XBee Bridge</name>
 
   <dependencies>
     <dependency>

--- a/org.openhab.binding.zigbee.xbee/src/main/java/org/openhab/binding/zigbee/xbee/handler/XBeeHandler.java
+++ b/org.openhab.binding.zigbee.xbee/src/main/java/org/openhab/binding/zigbee/xbee/handler/XBeeHandler.java
@@ -51,7 +51,7 @@ public class XBeeHandler extends ZigBeeCoordinatorHandler {
 
     @Override
     public void initializeDongle() {
-        logger.debug("Initializing ZigBee XBee serial bridge handler.");
+        logger.debug("Initializing Zigbee XBee serial bridge handler.");
 
         XBeeConfiguration config = getConfigAs(XBeeConfiguration.class);
         ZigBeeTransportTransmit dongle = createDongle(config);
@@ -66,7 +66,7 @@ public class XBeeHandler extends ZigBeeCoordinatorHandler {
                 flowControl);
         ZigBeeTransportTransmit dongle = new ZigBeeDongleXBee(serialPort);
 
-        logger.debug("ZigBee XBee Coordinator opening Port:'{}' PAN:{}, EPAN:{}, Channel:{}", config.zigbee_port,
+        logger.debug("Zigbee XBee Coordinator opening Port:'{}' PAN:{}, EPAN:{}, Channel:{}", config.zigbee_port,
                 Integer.toHexString(panId), extendedPanId, Integer.toString(channelId));
 
         return dongle;

--- a/org.openhab.binding.zigbee.xbee/src/main/resources/OH-INF/thing/controller_xbee.xml
+++ b/org.openhab.binding.zigbee.xbee/src/main/resources/OH-INF/thing/controller_xbee.xml
@@ -11,7 +11,7 @@
         <config-description>
             <parameter-group name="network">
                 <context></context>
-                <label>ZigBee Network Configuration</label>
+                <label>Zigbee Network Configuration</label>
                 <description></description>
             </parameter-group>
 

--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -1,12 +1,12 @@
-# ZigBee Binding
+# Zigbee Binding
 
-The ZigBee binding supports an interface to a wireless ZigBee home automation network and allows ZigBee devices from numerous manufacturers to be used without a system specific gateway. It should be compatible with a broad range of devices that implement and meet the Zigbee standards including lights, alarms, switches, sensors, etc.
+The Zigbee binding supports an interface to a wireless Zigbee home automation network and allows Zigbee devices from numerous manufacturers to be used without a system specific gateway. It should be compatible with a broad range of devices that implement and meet the Zigbee standards including lights, alarms, switches, sensors, etc.
 
 ## Supported Things
 
 ### Coordinators
 
-A ZigBee Coordinator is the network controller, and is therefore the heart of the ZigBee network. It also acts as the trust centre to control security access to the network.
+A Zigbee Coordinator is the network controller, and is therefore the heart of the Zigbee network. It also acts as the trust centre to control security access to the network.
 
 #### Configuring a coordinator
 
@@ -58,7 +58,7 @@ Note that not all configuration parameters are available with all coordinators.
 
 ##### Link Key (zigbee_linkkey)
 
-The key is defined as 16 hexadecimal values. If not defined, this will default to the well known ZigBee HA link key which is required for ZigBee HA 1.2 devices. Do not alter this key if using with a ZigBee HA 1.2 network unless you fully understand the impact.
+The key is defined as 16 hexadecimal values. If not defined, this will default to the well known Zigbee HA link key which is required for Zigbee HA 1.2 devices. Do not alter this key if using with a Zigbee HA 1.2 network unless you fully understand the impact.
 
 If defined with the word `INSTALLCODE:` before the key, this will create a link key from an install code which may be shorter than 16 bytes.
 
@@ -71,11 +71,11 @@ The key is defined as 16 hexadecimal values. If not defined, a random key will b
 
 ##### Child Aging (zigbee_childtimeout)
 
-ZigBee routers (and the coordinator) only have room to allow a certain number of devices to join the network via each router - once the child table in a router is full, devices will need to join via another router (assuming the child can communicate via another router). To avoid the child table becoming full of devices that no longer exist, routers will age out children that do not contact them within a specified period of time.
+Zigbee routers (and the coordinator) only have room to allow a certain number of devices to join the network via each router - once the child table in a router is full, devices will need to join via another router (assuming the child can communicate via another router). To avoid the child table becoming full of devices that no longer exist, routers will age out children that do not contact them within a specified period of time.
 
 Once a child is removed from the child table of a router, it will be asked to rejoin if it tries to communicate with the parent again. Setting this time too large may mean that the router fills its tables with devices that no longer exist, while setting it too small can mean devices unnecessarily rejoining the network.
 
-Note that ZigBee compliant devices should rejoin the network seamlessly, however some non-compliant devices may not rejoin which may leave them unusable without a manual rejoin.
+Note that Zigbee compliant devices should rejoin the network seamlessly, however some non-compliant devices may not rejoin which may leave them unusable without a manual rejoin.
 
 **Values:** Timeout time in seconds. The table below lists the options that are shown in PaperUI and the equivalent values that can be set in a configuration file:
 
@@ -97,7 +97,7 @@ Note that this value should be given as a number in the configuration file, with
 
 ##### Concentrator Type (zigbee_concentrator)
 
-The Concentrator is used to improve routing within a ZigBee network, and is especially useful in a network where much of the traffic is sent to or from a central coordinator. If the coordinator has sufficient memory, it can store routing information, thus reducing network traffic.
+The Concentrator is used to improve routing within a Zigbee network, and is especially useful in a network where much of the traffic is sent to or from a central coordinator. If the coordinator has sufficient memory, it can store routing information, thus reducing network traffic.
 
 If supported, the High RAM concentrator should be used.
 
@@ -159,8 +159,8 @@ The following coordinators are known to be supported.
 | [POPP ZB-STICK 701554](https://www.popp.eu/zb-stick/) and [POPP ZB-SHIELD 701561](https://www.popp.eu/zb-shield/) (rebranded Elelabs ELU013 and ELR023)| [Ember](#ember-ezsp-ncp-coordinator) | 115200bps<br>Hardware&nbsp;flow&nbsp;control<br>High RAM | Based on Silicon Labs EFR32MG13P MCU. Both the stick and the shield can be upgraded without additional hardware, firmware available [here](https://github.com/Elelabs/elelabs-zigbee-ezsp-utility).                                                                                                                                      |
 | [Bitron Video AV2010/10 Funkstick (also sold as SMaBiT AV2010/10)](https://bv.smabit.eu/index.php/smart-home-produkte/zb-funkstick/)                                           | [Ember](#ember-ezsp-ncp-coordinator) | 57600bps<br>Software&nbsp;flow&nbsp;control<br>High RAM  | Based on Silicon Labs EM3587.                                                                                                                                                                                                                                                         |
 | [CEL Cortet MeshConnect USB Sticks (EM358, ZM357S-USB, ZM3588S-USB models)](https://www.cel.com/product/)                                                       | [Ember](#ember-ezsp-ncp-coordinator) |  | Based on Silicon Labs EM358, EM357, and EM3588 MCUs respectivly. Requires specific drivers that may not work on MacOS Monterey.                                                                                                                                                                                                                                                         |
-| [Nortek GoControl QuickStick Combo Model HUSBZB-1](https://nortekcontrol.com/products/2gig/husbzb-1-gocontrol-quickstick-combo/)                                    | [Ember](#ember-ezsp-ncp-coordinator) | 57600bps<br>Software&nbsp;flow&nbsp;control<br>High RAM  | Based on Silicon Labs EM3581 MCU. Stick contains both Z-Wave and ZigBee.                                                                                                                                                                                                                                                         |
-| [Telegesis ETRX357USB, ETRX357USB+8M, and ETRX357USB-LRS ZigBee USB Stick](https://www.silabs.com/products/wireless/mesh-networking/telegesis-modules-gateways/etrx3-zigbee-usb-sticks) | [Telegesis](#telegesis-etrx3)        |                                                          | Based on Silicon Labs EM357 MCU. Not supported for ZigBee 3.0                                                                                                                                                                                                                                                                                               |
+| [Nortek GoControl QuickStick Combo Model HUSBZB-1](https://nortekcontrol.com/products/2gig/husbzb-1-gocontrol-quickstick-combo/)                                    | [Ember](#ember-ezsp-ncp-coordinator) | 57600bps<br>Software&nbsp;flow&nbsp;control<br>High RAM  | Based on Silicon Labs EM3581 MCU. Stick contains both Z-Wave and Zigbee.                                                                                                                                                                                                                                                         |
+| [Telegesis ETRX357USB, ETRX357USB+8M, and ETRX357USB-LRS Zigbee USB Stick](https://www.silabs.com/products/wireless/mesh-networking/telegesis-modules-gateways/etrx3-zigbee-usb-sticks) | [Telegesis](#telegesis-etrx3)        |                                                          | Based on Silicon Labs EM357 MCU. Not supported for Zigbee 3.0                                                                                                                                                                                                                                                                                               |
 | [QIVICON ZigBee-Funkstick](https://www.qivicon.com/de/produkte/produktinformationen/zigbee-funkstick/)                                                | [Telegesis](#telegesis-etrx3)        |                                                          | Only working on Linux devices                                                                                                                                                                                                                                                                  |
 | [Digi XStick (Digi XBee 3 USB Adapter)](https://www.digi.com/products/xbee-rf-solutions/boxed-rf-modems-adapters/xstick)                                                        | [XBee](#digi-xbee-x-stick)           |                                                          |                                                                                                                                                                                                                                                                                                |
 | [Texas Instruments CC2531EMK](http://www.ti.com/tool/cc2531emk)                                                                                     | [CC2531](#cc2531-coordinator)        |                                                          | CC2530 are not recommended for more then 15 devices due to its less powerful MCU. Also needs extra [hardware and Z-Stack Home 1.2 firmware flashed](https://www.zigbee2mqtt.io/guide/adapters/flashing/flashing_the_cc2531.html). CC2530 and CC2538 may work too with Z-Stack Home 1.2 compatible firmware. |
@@ -248,7 +248,7 @@ Extract and install the TI Flash Programmer, connect the CC-Debugger trough USB,
 
 ### Devices
 
-The following devices have been tested by openHAB users with the binding. This list is far from exhaustive, and the absence of a device in this list does not mean it will not work - **if the device is a standard ZigBee device similar to ones on this list, then it should work**. It should be noted that many "new" devices (approximately newer than 2020) will require coordinators that support ZigBee 3.0. If this is not supported, then devices may briefly join the network, and then leave when they find the network does not support the newer security requirements.
+The following devices have been tested by openHAB users with the binding. This list is far from exhaustive, and the absence of a device in this list does not mean it will not work - **if the device is a standard Zigbee device similar to ones on this list, then it should work**. It should be noted that many "new" devices (approximately newer than 2020) will require coordinators that support Zigbee 3.0. If this is not supported, then devices may briefly join the network, and then leave when they find the network does not support the newer security requirements.
 
 | Device                                         | Description                                                  |
 | ---------------------------------------------- | ------------------------------------------------------------ |
@@ -323,17 +323,17 @@ The following devices have been tested by openHAB users with the binding. This l
 
 Discovery is performed by putting the binding into join mode (by starting an thing search), and then putting the device into join mode. Generally, it is best to reset the device to do this. Resetting the device ensures that it is no longer joined to a previous network, will ensure it is awake if it is a battery device, and will restart any channel and network search that the device may perform. Consult the manual of the device at hand to see how to reset it, this differs from device to device.
 
-When the binding is put into discovery mode via the user interface, the network will have join enabled for 60 seconds. You can put it in discovery mode via the **Scan** button in the user interface. This can be found after you click the blue **+** button in the bottom right corder of the **Things** screen and then select the **ZigBee Binding**.
+When the binding is put into discovery mode via the user interface, the network will have join enabled for 60 seconds. You can put it in discovery mode via the **Scan** button in the user interface. This can be found after you click the blue **+** button in the bottom right corder of the **Things** screen and then select the **Zigbee Binding**.
 
-The binding will store the list of devices that have joined the network locally between restarts to allow them to be found again later. A ZigBee coordinator does not store a list of known devices, so rediscovery of devices following a restart may not be seemless if the dongle is moved to another system.
+The binding will store the list of devices that have joined the network locally between restarts to allow them to be found again later. A Zigbee coordinator does not store a list of known devices, so rediscovery of devices following a restart may not be seemless if the dongle is moved to another system.
 
-When a ZigBee device restarts (e.g. a bulb is powered on), it will send an announcement to advise the coordinator that it is on the network and this will allow the binding to rediscover devices that have become lost. Battery devices often have a button that may also perform this function.
+When a Zigbee device restarts (e.g. a bulb is powered on), it will send an announcement to advise the coordinator that it is on the network and this will allow the binding to rediscover devices that have become lost. Battery devices often have a button that may also perform this function.
 
 ### Install Codes
 
 Note: Currently only Ember coordinators support Zigbee 3.0, it does not look like the Telegesis coordinators will receive an update to support it.
 
-ZigBee 3.0 requires that devices use an install code to securely join the network. This must be added
+Zigbee 3.0 requires that devices use an install code to securely join the network. This must be added
 to the binding before the discovery starts. Install codes should be printed on the box the device came
 in, or possibly on the device itself. Note that there is no standard format for how these codes may be
 displayed on the device or its packaging. You may need to use a QR reader to read the code - again these
@@ -347,7 +347,7 @@ The format is `IEEE Address:Install Code` in the following format -:
 AAAAAAAAAAAAAAAA:CCCC-CCCC-CCCC-CCCC-CCCC-CCCC-CCCC-CCCC-DDDD
 ```
 
-ZigBee 3.0 requires the install code to be 16 bytes long (8 blocks of characters) but some older systems using
+Zigbee 3.0 requires the install code to be 16 bytes long (8 blocks of characters) but some older systems using
 this method may use less bytes, but it should still be formatted as 2, 4, or 8 groups of 4 values.
 Note that the last four characters in the install code are the checksum and may be provided separately.
 
@@ -361,7 +361,7 @@ The binding will attempt to automatically detect new devices, giving them a type
 
 ### Thing Types
 
-Most ZigBee things have the same thing type of `zigbee_device`. The binding will automatically discover the device features and provide channels linked to device functionality that it is able to support. A small number of devices that require a manual thing definition may be defined in the binding to support devices that have non-standard functionality, or do not support the autodiscovery functionality provided by ZigBee.
+Most Zigbee things have the same thing type of `zigbee_device`. The binding will automatically discover the device features and provide channels linked to device functionality that it is able to support. A small number of devices that require a manual thing definition may be defined in the binding to support devices that have non-standard functionality, or do not support the autodiscovery functionality provided by Zigbee.
 
 ### Channel Types
 
@@ -369,7 +369,7 @@ A set of channels will be created depending on what clusters and endpoints a dev
 
 The following channels are supported -:
 
-| Channel UID                  | ZigBee Cluster                           | Type                     | Description |
+| Channel UID                  | Zigbee Cluster                           | Type                     | Description |
 | ---------------------------- | ---------------------------------------- | ------------------------ | ----------- |
 | battery-level                | `POWER_CONFIGURATION` (0x0001)           | Number                   |             |
 | battery_voltage              | `POWER_CONFIGURATION` (0x0001)           | Number:ElectricPotential |             |
@@ -471,7 +471,7 @@ end
 
 ## Reporting and Polling
 
-ZigBee has a standard way of configuring how a device sends status reports to the binding - this is called Reporting. Reporting is configured using three pieces of information -:
+Zigbee has a standard way of configuring how a device sends status reports to the binding - this is called Reporting. Reporting is configured using three pieces of information -:
 
 - Minimum Reporting Period: This is the minimum time between reports that the device will send updates. So, if data is changing regularly, this will prevent the binding receiving a flood of reports.
 - Maximum Reporting Period: This is the maximum time between reports that the device will send updates. If the data never changes, then the device will still send an update at this rate. This is important so that the binding knows the device has not failed, so it should not be set too long (normally a couple of hours will be fine).
@@ -510,9 +510,9 @@ This will log data into the standard `openhab.log` file. There is an [online log
 
 Note that logs can only show what is happening at a high level - it can't show all data exchanges between the device and the coordinator - just what the coordinator sends to the binding. For this reason it can be difficult to debug issues where devices are not joining the network, or other low level issues need resolving. In such cases a network sniffer log is required, which requires additional hardware and software. Information and software required to use an Ember dongle as a sniffer can be found on the [OpenSmartHouse](https://opensmarthouse.org/blog/zigbee_network_sniffer) site.
 
-### ZigBee Console Commands
+### Zigbee Console Commands
 
-The openHAB command line interface provides a number of commands to interact with the ZigBee framework. These can provide useful options for debugging when things aren't going as planned, and can also provide advanced users a means to make changes that are not possible directly through the binding. This section will provide information on a few common issues that users may come up against, but is not an exhaustive user manual for low level ZigBee commands.
+The openHAB command line interface provides a number of commands to interact with the Zigbee framework. These can provide useful options for debugging when things aren't going as planned, and can also provide advanced users a means to make changes that are not possible directly through the binding. This section will provide information on a few common issues that users may come up against, but is not an exhaustive user manual for low level Zigbee commands.
 
 All commands described below must be preceded by the word `zigbee` on the command line. To keep the documentation concise this is omitted in the examples below.
 
@@ -524,11 +524,11 @@ In some instances a device may not work correctly, or you may wish to see more t
 
 #### Binding and Reporting
 
-The binding table is used within ZigBee to configure devices to send reports to the binding when their state changes. The binding will attempt to set the required ZigBee bindings during device initialisation, but sometimes this can fail. Often this may occur on older devices that have limited memory, and only have a small number of entries in the binding table, and then manual manipulation of the table may be required.
+The binding table is used within Zigbee to configure devices to send reports to the binding when their state changes. The binding will attempt to set the required Zigbee bindings during device initialisation, but sometimes this can fail. Often this may occur on older devices that have limited memory, and only have a small number of entries in the binding table, and then manual manipulation of the table may be required.
 
 The binding table for a node can be displayed with the `bindtable` command. It can then be updated with the `bind` command, and bindings can be removed with the `unbind` command.
 
-A second part to the binding and reporting system is the reporting. The binding table tells the device where it should send reports, but the actual reports must be configured as well. Many attributes in a ZigBee cluster can be configured to send reports if their state changes, or at a periodical rate if there have been no state updates within a certain time. Analogue values can be configured so that they report if the value changes by a certain amount so that the reports do not flood the system.  Care must be exercised when changing this configuration as it may interfere with the binding operation.
+A second part to the binding and reporting system is the reporting. The binding table tells the device where it should send reports, but the actual reports must be configured as well. Many attributes in a Zigbee cluster can be configured to send reports if their state changes, or at a periodical rate if there have been no state updates within a certain time. Analogue values can be configured so that they report if the value changes by a certain amount so that the reports do not flood the system.  Care must be exercised when changing this configuration as it may interfere with the binding operation.
 
 The exact command required to configure reporting can depend on whether the attribute is a binary or analogue type. The console commands `subscribe` and `unsubscribe` allow the user to manipulate the reporting of an attribute, and the `reportcfg` command can be used to display the current configuration.
 
@@ -601,7 +601,7 @@ The following commands are available if the transport layer is using the Silabs 
 
 ### Xiaomi devices
 
-Xiaomi/Aqara devices are not fully ZigBee compliant, and are known to suffer from multiple problems.
+Xiaomi/Aqara devices are not fully Zigbee compliant, and are known to suffer from multiple problems.
 
 #### Pairing
 

--- a/org.openhab.binding.zigbee/pom.xml
+++ b/org.openhab.binding.zigbee/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>org.openhab.binding.zigbee</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: ZigBee Binding</name>
+  <name>openHAB Add-ons :: Bundles :: Zigbee Binding</name>
 
   <dependencies>
     <dependency>

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
@@ -399,7 +399,7 @@ public abstract class ZigBeeBaseChannelConverter {
     }
 
     /**
-     * Converts a ZigBee 8 bit level as used in Level Control cluster and others to a percentage
+     * Converts a Zigbee 8 bit level as used in Level Control cluster and others to a percentage
      *
      * @param level an integer between 0 and 254
      * @return the scaled {@link PercentType}
@@ -420,7 +420,7 @@ public abstract class ZigBeeBaseChannelConverter {
 
     /**
      * Converts an integer value into a {@link QuantityType}. The temperature as an integer is assumed to be multiplied
-     * by 100 as per the ZigBee standard format.
+     * by 100 as per the Zigbee standard format.
      *
      * @param value the integer value to convert
      * @return the {@link QuantityType}
@@ -461,7 +461,7 @@ public abstract class ZigBeeBaseChannelConverter {
     }
 
     /**
-     * Converts a {@link Command} to a ZigBee temperature integer
+     * Converts a {@link Command} to a Zigbee temperature integer
      *
      * @param command the {@link Command} to convert
      * @return the {@link Command} or null if the conversion was not possible

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeDiscoveryService.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeDiscoveryService.java
@@ -273,7 +273,7 @@ public class ZigBeeDiscoveryService extends AbstractDiscoveryService {
                         String updatedLabel = nodeProperties.get(Thing.PROPERTY_VENDOR) + " "
                                 + nodeProperties.get(Thing.PROPERTY_MODEL_ID);
 
-                        logger.debug("{}: Update ZigBee device {} with bridge {}, label '{}'", node.getIeeeAddress(),
+                        logger.debug("{}: Update Zigbee device {} with bridge {}, label '{}'", node.getIeeeAddress(),
                                 defaultThingTypeUID, bridgeUID, updatedLabel);
 
                         DiscoveryResult updatedDiscoveryResult = DiscoveryResultBuilder.create(defaultThingUID)

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeNodePropertyDiscoverer.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeNodePropertyDiscoverer.java
@@ -103,13 +103,13 @@ public class ZigBeeNodePropertyDiscoverer {
      * @return a {@link Map} of properties or an empty map if there was an error
      */
     public Map<String, String> getProperties(final ZigBeeNode node) {
-        logger.debug("{}: ZigBee node property discovery start", node.getIeeeAddress());
+        logger.debug("{}: Zigbee node property discovery start", node.getIeeeAddress());
 
         addPropertiesFromNodeDescriptors(node);
         addPropertiesFromBasicCluster(node);
         addPropertiesFromOtaCluster(node);
 
-        logger.debug("{}: ZigBee node property discovery complete: {}", node.getIeeeAddress(), properties);
+        logger.debug("{}: Zigbee node property discovery complete: {}", node.getIeeeAddress(), properties);
 
         return properties;
     }
@@ -145,7 +145,7 @@ public class ZigBeeNodePropertyDiscoverer {
             return;
         }
 
-        logger.debug("{}: ZigBee node property discovery using basic cluster on endpoint {}", node.getIeeeAddress(),
+        logger.debug("{}: Zigbee node property discovery using basic cluster on endpoint {}", node.getIeeeAddress(),
                 basicCluster.getZigBeeAddress());
 
         // Attempt to read all properties with a single command.
@@ -246,7 +246,7 @@ public class ZigBeeNodePropertyDiscoverer {
                 .orElse(null);
 
         if (otaCluster != null) {
-            logger.debug("{}: ZigBee node property discovery using OTA cluster on endpoint {}", node.getIeeeAddress(),
+            logger.debug("{}: Zigbee node property discovery using OTA cluster on endpoint {}", node.getIeeeAddress(),
                     otaCluster.getZigBeeAddress());
 
             ZclAttribute attribute = otaCluster.getAttribute(ZclOtaUpgradeCluster.ATTR_CURRENTFILEVERSION);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/internal/ZigBeeDefaultDiscoveryParticipant.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/internal/ZigBeeDefaultDiscoveryParticipant.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Component;
 import com.zsmartsystems.zigbee.ZigBeeNode;
 
 /**
- * The default ZigBee discovery participant
+ * The default Zigbee discovery participant
  *
  * @author Chris Jackson
  *
@@ -57,7 +57,7 @@ public class ZigBeeDefaultDiscoveryParticipant implements ZigBeeDiscoveryPartici
         if ((properties.get(Thing.PROPERTY_VENDOR) != null) && (properties.get(Thing.PROPERTY_MODEL_ID) != null)) {
             label = properties.get(Thing.PROPERTY_VENDOR) + " " + properties.get(Thing.PROPERTY_MODEL_ID);
         } else {
-            label = "Unknown ZigBee Device";
+            label = "Unknown Zigbee Device";
         }
 
         return DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID).withProperties(properties)

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -359,7 +359,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
                 }
             }
 
-            // Shut down the ZigBee library
+            // Shut down the Zigbee library
             networkManager.shutdown();
         }
 
@@ -367,7 +367,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
             networkDataStore.delete();
         }
 
-        logger.debug("ZigBee network [{}] closed.", thing.getUID());
+        logger.debug("Zigbee network [{}] closed.", thing.getUID());
     }
 
     @Override
@@ -377,7 +377,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
     }
 
     /**
-     * Common initialisation point for all ZigBee coordinators.
+     * Common initialisation point for all Zigbee coordinators.
      * Called by bridge implementations after they have initialised their interfaces.
      *
      * @param zigbeeTransport a {@link ZigBeeTransportTransmit} interface instance
@@ -388,7 +388,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
     }
 
     /**
-     * Common initialisation point for all ZigBee coordinators.
+     * Common initialisation point for all Zigbee coordinators.
      * Called by bridge implementations after they have initialised their interfaces.
      *
      * @param zigbeeTransport a {@link ZigBeeTransportTransmit} interface instance
@@ -409,7 +409,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
     }
 
     /**
-     * Initialise the ZigBee network
+     * Initialise the Zigbee network
      *
      * synchronized to avoid executing this if a reconnect is still in progress
      */
@@ -535,7 +535,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
         currentChannel = networkManager.getZigBeeChannel();
         currentPanId = networkManager.getZigBeePanId();
         currentExtendedPanId = networkManager.getZigBeeExtendedPanId();
-        logger.debug("ZigBee initialise done. channel={}, PanId={}  EPanId={}", currentChannel, currentPanId,
+        logger.debug("Zigbee initialise done. channel={}, PanId={}  EPanId={}", currentChannel, currentPanId,
                 currentExtendedPanId);
 
         // Set initializeNetwork to false to ensure that if communications to the dongle restarts, we don't reinitialise
@@ -550,9 +550,9 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
     }
 
     private void startZigBeeNetwork() {
-        logger.debug("Scheduling ZigBee start");
+        logger.debug("Scheduling Zigbee start");
         restartJob = scheduler.schedule(() -> {
-            logger.debug("ZigBee network starting");
+            logger.debug("Zigbee network starting");
             restartJob = null;
             initialiseZigBee();
         }, 1, TimeUnit.SECONDS);
@@ -571,7 +571,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
                     return;
                 }
 
-                logger.info("ZigBee dongle inactivity timer. Reinitializing ZigBee");
+                logger.info("Zigbee dongle inactivity timer. Reinitializing Zigbee");
 
                 // Close everything that has been started prior to initializing the serial port
                 if (restartJob != null) {
@@ -1040,14 +1040,14 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
      * @param duration the duration of the join
      */
     public boolean permitJoin(@Nullable IeeeAddress address, int duration) {
-        logger.debug("{}: ZigBee join command", address);
+        logger.debug("{}: Zigbee join command", address);
         ZigBeeNode node = networkManager.getNode(address);
         if (node == null) {
-            logger.debug("{}: ZigBee join command - node not found", address);
+            logger.debug("{}: Zigbee join command - node not found", address);
             return false;
         }
 
-        logger.debug("{}: ZigBee join command to {}", address, node.getNetworkAddress());
+        logger.debug("{}: Zigbee join command to {}", address, node.getNetworkAddress());
 
         networkManager.permitJoin(new ZigBeeEndpointAddress(node.getNetworkAddress()), duration);
         return true;
@@ -1066,14 +1066,14 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
         // First we want to make sure that join is disabled
         networkManager.permitJoin(0);
 
-        logger.debug("{}: ZigBee leave command", address);
+        logger.debug("{}: Zigbee leave command", address);
         ZigBeeNode node = networkManager.getNode(address);
         if (node == null) {
-            logger.debug("{}: ZigBee leave command - node not found", address);
+            logger.debug("{}: Zigbee leave command - node not found", address);
             return false;
         }
 
-        logger.debug("{}: ZigBee leave command to {}", address, node.getNetworkAddress());
+        logger.debug("{}: Zigbee leave command to {}", address, node.getNetworkAddress());
 
         networkManager.leave(node.getNetworkAddress(), node.getIeeeAddress(), forceRemoval);
         return true;
@@ -1119,7 +1119,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
      */
     public void scanStart(int joinTime) {
         if (getThing().getStatus() != ThingStatus.ONLINE) {
-            logger.debug("ZigBee coordinator is offline - aborted scan for {}", getThing().getUID());
+            logger.debug("Zigbee coordinator is offline - aborted scan for {}", getThing().getUID());
             return;
         }
 
@@ -1127,7 +1127,7 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
     }
 
     /**
-     * Stops an active scan on the ZigBee coordinator
+     * Stops an active scan on the Zigbee coordinator
      */
     public void scanStop() {
         networkManager.permitJoin(0);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -89,7 +89,7 @@ import com.zsmartsystems.zigbee.zdo.field.NeighborTable;
 import com.zsmartsystems.zigbee.zdo.field.RoutingTable;
 
 /**
- * The standard ZigBee thing handler.
+ * The standard Zigbee thing handler.
  *
  * @author Chris Jackson - Initial Contribution
  * @author Thomas Höfer - Injected ZigBeeChannelConverterFactory via constructor
@@ -478,7 +478,7 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
 
         nodeInitialised = true;
 
-        logger.debug("{}: Done initialising ZigBee Thing handler", nodeIeeeAddress);
+        logger.debug("{}: Done initialising Zigbee Thing handler", nodeIeeeAddress);
 
         // Save the network state
         coordinatorHandler.serializeNetwork(node.getIeeeAddress());

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterAtmosphericPressure.java
@@ -157,7 +157,7 @@ public class ZigBeeConverterAtmosphericPressure extends ZigBeeBaseChannelConvert
 
     @Override
     public synchronized void attributeUpdated(ZclAttribute attribute, Object value) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() != ZclClusterType.PRESSURE_MEASUREMENT) {
             return;
         }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryAlarm.java
@@ -176,7 +176,7 @@ public class ZigBeeConverterBatteryAlarm extends ZigBeeBaseChannelConverter impl
         if (attribute.getClusterType() == ZclClusterType.POWER_CONFIGURATION
                 && attribute.getId() == ZclPowerConfigurationCluster.ATTR_BATTERYALARMSTATE) {
 
-            logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+            logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
 
             // The value is a 32-bit bitmap, represented by an Integer
             Integer value = (Integer) val;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryPercent.java
@@ -138,7 +138,7 @@ public class ZigBeeConverterBatteryPercent extends ZigBeeBaseChannelConverter im
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.POWER_CONFIGURATION
                 && attribute.getId() == ZclPowerConfigurationCluster.ATTR_BATTERYPERCENTAGEREMAINING) {
             Integer value = (Integer) val;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBatteryVoltage.java
@@ -135,7 +135,7 @@ public class ZigBeeConverterBatteryVoltage extends ZigBeeBaseChannelConverter im
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.POWER_CONFIGURATION
                 && attribute.getId() == ZclPowerConfigurationCluster.ATTR_BATTERYVOLTAGE) {
             Integer value = (Integer) val;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBinaryInput.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterBinaryInput.java
@@ -123,7 +123,7 @@ public class ZigBeeConverterBinaryInput extends ZigBeeBaseChannelConverter imple
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.BINARY_INPUT_BASIC
                 && attribute.getId() == ZclBinaryInputBasicCluster.ATTR_PRESENTVALUE) {
             Boolean value = (Boolean) val;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
@@ -516,7 +516,7 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
 
         synchronized (colorUpdateSync) {
             try {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
@@ -178,7 +178,7 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}  on endpoint {}", endpoint.getIeeeAddress(), attribute,
+        logger.debug("{}: Zigbee attribute reports {}  on endpoint {}", endpoint.getIeeeAddress(), attribute,
                 endpoint.getEndpointId());
         if (attribute.getClusterType() == ZclClusterType.COLOR_CONTROL
                 && attribute.getId() == ZclColorControlCluster.ATTR_COLORTEMPERATURE) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterDoorLock.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterDoorLock.java
@@ -144,7 +144,7 @@ public class ZigBeeConverterDoorLock extends ZigBeeBaseChannelConverter implemen
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.DOOR_LOCK
                 && attribute.getId() == ZclDoorLockCluster.ATTR_LOCKSTATE) {
             Integer value = (Integer) val;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterFanControl.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterFanControl.java
@@ -215,7 +215,7 @@ public class ZigBeeConverterFanControl extends ZigBeeBaseChannelConverter implem
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.FAN_CONTROL
                 && attribute.getId() == ZclFanControlCluster.ATTR_FANMODE) {
             Integer value = (Integer) val;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIas.java
@@ -181,7 +181,7 @@ public abstract class ZigBeeConverterIas extends ZigBeeBaseChannelConverter
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.IAS_ZONE
                 && attribute.getId() == ZclIasZoneCluster.ATTR_ZONESTATUS) {
             updateChannelState((Integer) val);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterIlluminance.java
@@ -171,7 +171,7 @@ public class ZigBeeConverterIlluminance extends ZigBeeBaseChannelConverter imple
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.ILLUMINANCE_MEASUREMENT
                 && attribute.getId() == ZclIlluminanceMeasurementCluster.ATTR_MEASUREDVALUE) {
             updateChannelState(new DecimalType(Math.pow(10.0, (Integer) val / 10000.0) - 1));

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
@@ -153,7 +153,7 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.ELECTRICAL_MEASUREMENT
                 && attribute.getId() == ZclElectricalMeasurementCluster.ATTR_ACTIVEPOWER) {
             Integer value = (Integer) val;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
@@ -38,7 +38,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.ZclElectricalMeasurementCluster;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
 
 /**
- * ZigBee channel converter for RMS current measurement
+ * Zigbee channel converter for RMS current measurement
  *
  * @author Chris Jackson - Initial Contribution
  *
@@ -156,7 +156,7 @@ public class ZigBeeConverterMeasurementRmsCurrent extends ZigBeeBaseChannelConve
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.ELECTRICAL_MEASUREMENT
                 && attribute.getId() == ZclElectricalMeasurementCluster.ATTR_RMSCURRENT) {
             Integer value = (Integer) val;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
@@ -38,7 +38,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.ZclElectricalMeasurementCluster;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
 
 /**
- * ZigBee channel converter for RMS voltage measurement
+ * Zigbee channel converter for RMS voltage measurement
  *
  * @author Chris Jackson - Initial Contribution
  *
@@ -156,7 +156,7 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.ELECTRICAL_MEASUREMENT
                 && attribute.getId() == ZclElectricalMeasurementCluster.ATTR_RMSVOLTAGE) {
             Integer value = (Integer) val;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeteringInstantaneousDemand.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeteringInstantaneousDemand.java
@@ -35,7 +35,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.ZclMeteringCluster;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
 
 /**
- * ZigBee channel converter for instantaneous demand measurement
+ * Zigbee channel converter for instantaneous demand measurement
  *
  * @author Chris Jackson - Initial Contribution
  *
@@ -157,7 +157,7 @@ public class ZigBeeConverterMeteringInstantaneousDemand extends ZigBeeBaseChanne
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.METERING
                 && attribute.getId() == ZclMeteringCluster.ATTR_INSTANTANEOUSDEMAND) {
             double value = (Integer) val;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeteringSummationDelivered.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeteringSummationDelivered.java
@@ -35,7 +35,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.ZclMeteringCluster;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
 
 /**
- * ZigBee channel converter for summation delivered measurement
+ * Zigbee channel converter for summation delivered measurement
  *
  * @author Chris Jackson - Initial Contribution
  *
@@ -156,7 +156,7 @@ public class ZigBeeConverterMeteringSummationDelivered extends ZigBeeBaseChannel
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.METERING
                 && attribute.getId() == ZclMeteringCluster.ATTR_CURRENTSUMMATIONDELIVERED) {
             double value = ((Long) val).intValue();

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeteringSummationReceived.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeteringSummationReceived.java
@@ -35,7 +35,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.ZclMeteringCluster;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
 
 /**
- * ZigBee channel converter for summation received measurement
+ * Zigbee channel converter for summation received measurement
  *
  * @author Chris Jackson - Initial Contribution
  *
@@ -156,7 +156,7 @@ public class ZigBeeConverterMeteringSummationReceived extends ZigBeeBaseChannelC
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.METERING
                 && attribute.getId() == ZclMeteringCluster.ATTR_CURRENTSUMMATIONRECEIVED) {
             double value = ((Long) val).intValue();

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterOccupancy.java
@@ -123,7 +123,7 @@ public class ZigBeeConverterOccupancy extends ZigBeeBaseChannelConverter impleme
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.OCCUPANCY_SENSING
                 && attribute.getId() == ZclOccupancySensingCluster.ATTR_OCCUPANCY) {
             Integer value = (Integer) val;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterRelativeHumidity.java
@@ -131,7 +131,7 @@ public class ZigBeeConverterRelativeHumidity extends ZigBeeBaseChannelConverter 
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.RELATIVE_HUMIDITY_MEASUREMENT
                 && attribute.getId() == ZclRelativeHumidityMeasurementCluster.ATTR_MEASUREDVALUE) {
             Integer value = (Integer) val;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -521,7 +521,7 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
 
     @Override
     public synchronized void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.LEVEL_CONTROL
                 && attribute.getId() == ZclLevelControlCluster.ATTR_CURRENTLEVEL) {
             lastLevel = levelToPercent((Integer) val);
@@ -543,7 +543,7 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
 
     @Override
     public boolean commandReceived(ZclCommand command) {
-        logger.debug("{}: ZigBee command received {}", endpoint.getIeeeAddress(), command);
+        logger.debug("{}: Zigbee command received {}", endpoint.getIeeeAddress(), command);
 
         // OnOff Cluster Commands
         if (command instanceof OnCommand) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchOnoff.java
@@ -275,7 +275,7 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.ON_OFF && attribute.getId() == ZclOnOffCluster.ATTR_ONOFF) {
             Boolean value = (Boolean) val;
             if (value != null && value) {
@@ -288,7 +288,7 @@ public class ZigBeeConverterSwitchOnoff extends ZigBeeBaseChannelConverter
 
     @Override
     public boolean commandReceived(ZclCommand command) {
-        logger.debug("{}: ZigBee command received {}", endpoint.getIeeeAddress(), command);
+        logger.debug("{}: Zigbee command received {}", endpoint.getIeeeAddress(), command);
         if (command instanceof OnCommand) {
             currentOnOffState.set(true);
             updateChannelState(OnOffType.ON);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTemperature.java
@@ -168,7 +168,7 @@ public class ZigBeeConverterTemperature extends ZigBeeBaseChannelConverter imple
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.TEMPERATURE_MEASUREMENT
                 && attribute.getId() == ZclTemperatureMeasurementCluster.ATTR_MEASUREDVALUE) {
             updateChannelState(valueToTemperature((Integer) val));

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatLocalTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatLocalTemperature.java
@@ -142,7 +142,7 @@ public class ZigBeeConverterThermostatLocalTemperature extends ZigBeeBaseChannel
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_LOCALTEMPERATURE) {
             Integer value = (Integer) val;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedCooling.java
@@ -157,7 +157,7 @@ public class ZigBeeConverterThermostatOccupiedCooling extends ZigBeeBaseChannelC
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_OCCUPIEDCOOLINGSETPOINT) {
             updateChannelState(valueToTemperature((Integer) val));

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedHeating.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOccupiedHeating.java
@@ -153,7 +153,7 @@ public class ZigBeeConverterThermostatOccupiedHeating extends ZigBeeBaseChannelC
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_OCCUPIEDHEATINGSETPOINT) {
             updateChannelState(valueToTemperature((Integer) val));

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatOutdoorTemperature.java
@@ -140,7 +140,7 @@ public class ZigBeeConverterThermostatOutdoorTemperature extends ZigBeeBaseChann
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_OUTDOORTEMPERATURE) {
             updateChannelState(valueToTemperature((Integer) val));

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatPiCoolingDemand.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatPiCoolingDemand.java
@@ -180,7 +180,7 @@ public class ZigBeeConverterThermostatPiCoolingDemand extends ZigBeeBaseChannelC
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_PICOOLINGDEMAND) {
             Integer value = (Integer) val;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatPiHeatingDemand.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatPiHeatingDemand.java
@@ -180,7 +180,7 @@ public class ZigBeeConverterThermostatPiHeatingDemand extends ZigBeeBaseChannelC
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_PIHEATINGDEMAND) {
             Integer value = (Integer) val;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatRunningMode.java
@@ -139,7 +139,7 @@ public class ZigBeeConverterThermostatRunningMode extends ZigBeeBaseChannelConve
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_THERMOSTATRUNNINGMODE) {
             Integer value = (Integer) val;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatSystemMode.java
@@ -198,7 +198,7 @@ public class ZigBeeConverterThermostatSystemMode extends ZigBeeBaseChannelConver
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_SYSTEMMODE) {
             Integer value = (Integer) val;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedCooling.java
@@ -154,7 +154,7 @@ public class ZigBeeConverterThermostatUnoccupiedCooling extends ZigBeeBaseChanne
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_UNOCCUPIEDCOOLINGSETPOINT) {
             updateChannelState(valueToTemperature((Integer) val));

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterThermostatUnoccupiedHeating.java
@@ -156,7 +156,7 @@ public class ZigBeeConverterThermostatUnoccupiedHeating extends ZigBeeBaseChanne
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getClusterType() == ZclClusterType.THERMOSTAT
                 && attribute.getId() == ZclThermostatCluster.ATTR_UNOCCUPIEDHEATINGSETPOINT) {
             updateChannelState(valueToTemperature((Integer) val));

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTuyaButton.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterTuyaButton.java
@@ -195,7 +195,7 @@ public class ZigBeeConverterTuyaButton extends ZigBeeBaseChannelConverter
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object val) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
     }
 
     private String getEventType(Integer pressType)

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterWindowCoveringLift.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterWindowCoveringLift.java
@@ -213,7 +213,7 @@ public class ZigBeeConverterWindowCoveringLift extends ZigBeeBaseChannelConverte
 
     @Override
     public void attributeUpdated(ZclAttribute attribute, Object value) {
-        logger.debug("{}: ZigBee attribute reports {}", endpoint.getIeeeAddress(), attribute);
+        logger.debug("{}: Zigbee attribute reports {}", endpoint.getIeeeAddress(), attribute);
         if (attribute.getId() == ZclWindowCoveringCluster.ATTR_CURRENTPOSITIONLIFTPERCENTAGE) {
             updateChannelState(new PercentType((Integer) value));
         }

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/binding/binding.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/binding/binding.xml
@@ -2,7 +2,7 @@
 <binding:binding id="zigbee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
 
-	<name>ZigBee Binding</name>
-	<description>This is the binding for ZigBee providing a vendor neutral ZigBee implementation supporting many different ZigBee devices.</description>
+	<name>Zigbee Binding</name>
+	<description>This is the binding for Zigbee providing a vendor neutral Zigbee implementation supporting many different Zigbee devices.</description>
 	<author>Chris Jackson</author>
 </binding:binding>

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/i18n/thingstate.properties
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/i18n/thingstate.properties
@@ -1,7 +1,7 @@
 zigbee.status.offline_commserror=Failed to open communications port
 zigbee.status.offline_badresponse=Bad response received from dongle
-zigbee.status.offline_initializefail=Failed to initialize ZigBee transport layer
-zigbee.status.offline_startupfail=Failed to startup ZigBee transport layer
+zigbee.status.offline_initializefail=Failed to initialize Zigbee transport layer
+zigbee.status.offline_startupfail=Failed to startup Zigbee transport layer
 zigbee.status.offline_notinitialized=Not initialized
 zigbee.status.offline_noaddress=Node address is not set
 zigbee.status.offline_nodenotfound=Node is not found on network

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/device.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/device.xml
@@ -5,8 +5,8 @@
         xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<thing-type id="device" listed="false">
-		<label>ZigBee Device</label>
-		<description>Generic ZigBee Device</description>
+		<label>Zigbee Device</label>
+		<description>Generic Zigbee Device</description>
 
         <config-description>
             <parameter name="zigbee_macaddress" type="text" readOnly="true" required="true">

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <version>3.4.0-SNAPSHOT</version>
   <!-- do not delete the version here as it is required by the release process -->
 
-  <name>openHAB Add-ons :: Bundles :: ZigBee Reactor</name>
+  <name>openHAB Add-ons :: Bundles :: Zigbee Reactor</name>
 
   <packaging>pom</packaging>
 


### PR DESCRIPTION
Name was changed some years ago from ZigBee to [Zigbee](https://en.wikipedia.org/wiki/Zigbee). Maybe it's time to adapt.

Changed spelling in:
- Documentation
- Code comments.
- Log entries.
- User-oriented texts.
- Bundle names and descriptions.

Did not change spelling in:
- Class names etc.
- "QIVICON ZigBee-Funkstick" as it seems like a product name (probably old).
- all the places I've missed...

See also openhab/openhab-addons#13954