### PR TITLE
Add time extension support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <report.fail.on.error>false</report.fail.on.error>
-    <zsmartsystems.version>1.4.7</zsmartsystems.version>
+    <zsmartsystems.version>1.4.10-SNAPSHOT</zsmartsystems.version>
     <spotless.version>2.0.3</spotless.version>
     <spotless.check.skip>true</spotless.check.skip> <!-- Spotless disabled for now -->
     <sat.version>0.13.0</sat.version>


### PR DESCRIPTION
This adds the `ZigBeeTimeExtension` support which should provide a time server that devices can interview to get the current system time.

This requires https://github.com/zsmartsystems/com.zsmartsystems.zigbee/pull/1371

@dschall you might like to give this a go to see if it resolves the issues you have with the Tuya device that keeps requesting the time. To build/run this, you will need to compile the SNAPSHOT of the library using the branch linked above to get the time support.  I've not really done any testing on this as I've not got a device that currently requires this, so I welcome any feedback.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>