### PR TITLE
Ensure node exists when handler is disposed

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -577,16 +577,17 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
 
         stopPolling();
 
-        if (nodeIeeeAddress != null) {
-            if (coordinatorHandler != null) {
+        if (coordinatorHandler != null) {
+            coordinatorHandler.removeNetworkNodeListener(this);
+            coordinatorHandler.removeAnnounceListener(this);
+
+            if (nodeIeeeAddress != null && coordinatorHandler.getNode(nodeIeeeAddress) != null) {
                 ZclOtaUpgradeServer otaServer = getOtaServer(coordinatorHandler.getNode(nodeIeeeAddress));
                 if (otaServer != null) {
                     otaServer.removeListener(this);
                 }
-
-                coordinatorHandler.removeNetworkNodeListener(this);
-                coordinatorHandler.removeAnnounceListener(this);
             }
+
             nodeIeeeAddress = null;
         }
 


### PR DESCRIPTION
Prevents potential NPE if the node was removed prior to the handler being disposed.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>