### PR TITLE
Update ZSS library to 1.4.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <report.fail.on.error>false</report.fail.on.error>
-    <zsmartsystems.version>1.4.7</zsmartsystems.version>
+    <zsmartsystems.version>1.4.11</zsmartsystems.version>
     <spotless.version>2.0.3</spotless.version>
     <spotless.check.skip>true</spotless.check.skip> <!-- Spotless disabled for now -->
     <sat.version>0.13.0</sat.version>


### PR DESCRIPTION
Bump the Zigbee libraries to the latest version. This fixes a few bugs and adds support for newer versions of the Silabs firmware.

@kaikreuzer when you get a chance can you update the distro and merge this.  Thanks.