### PR TITLE
Change SLZB06 socket uptime to seconds

### DIFF
--- a/org.openhab.binding.zigbee.slzb06/src/main/java/org/openhab/binding/zigbee/slzb06/handler/Slzb06Handler.java
+++ b/org.openhab.binding.zigbee.slzb06/src/main/java/org/openhab/binding/zigbee/slzb06/handler/Slzb06Handler.java
@@ -162,19 +162,20 @@ public class Slzb06Handler extends ZigBeeCoordinatorHandler {
                     if (communicator != null) {
                         try {
                             Slzb06Sensors sensors = communicator.getSensors();
-                            if (isLinked(Slzb06BindingConstants.CHANNEL_ESP32TEMP)) {
+                            if (isLinked(Slzb06BindingConstants.CHANNEL_ESP32TEMP) && sensors.esp32_temp != null) {
                                 updateState(Slzb06BindingConstants.CHANNEL_ESP32TEMP,
                                         new DecimalType(sensors.esp32_temp));
                             }
-                            if (isLinked(Slzb06BindingConstants.CHANNEL_ZBTEMP)) {
+                            if (isLinked(Slzb06BindingConstants.CHANNEL_ZBTEMP) && sensors.zb_temp != null) {
                                 updateState(Slzb06BindingConstants.CHANNEL_ZBTEMP, new DecimalType(sensors.zb_temp));
                             }
-                            if (isLinked(Slzb06BindingConstants.CHANNEL_UPTIME)) {
+                            if (isLinked(Slzb06BindingConstants.CHANNEL_UPTIME) && sensors.uptime != null) {
                                 updateState(Slzb06BindingConstants.CHANNEL_UPTIME, new DecimalType(sensors.uptime));
                             }
-                            if (isLinked(Slzb06BindingConstants.CHANNEL_SOCKETUPTIME)) {
+                            if (isLinked(Slzb06BindingConstants.CHANNEL_SOCKETUPTIME)
+                                    && sensors.socket_uptime != null) {
                                 updateState(Slzb06BindingConstants.CHANNEL_SOCKETUPTIME,
-                                        new DecimalType(sensors.socket_uptime));
+                                        new DecimalType(sensors.socket_uptime / 1000));
                             }
                         } catch (Exception e) {
                             logger.error("SLZB06: retreiving API information: {}", e.getMessage());

--- a/org.openhab.binding.zigbee.slzb06/src/main/java/org/openhab/binding/zigbee/slzb06/internal/Slzb06NetworkPort.java
+++ b/org.openhab.binding.zigbee.slzb06/src/main/java/org/openhab/binding/zigbee/slzb06/internal/Slzb06NetworkPort.java
@@ -112,7 +112,7 @@ public class Slzb06NetworkPort implements ZigBeePort {
     @Override
     public boolean open() {
         try {
-            logger.debug("Connecting to network port [{}:{}]", serverName, serverPort);
+            logger.debug("SLZB06 Connecting to network port [{}:{}]", serverName, serverPort);
 
             Socket localSocket = new Socket();
             localSocket.connect(new InetSocketAddress(serverName, serverPort), 1000);
@@ -129,8 +129,8 @@ public class Slzb06NetworkPort implements ZigBeePort {
 
             return true;
         } catch (RuntimeException | IOException e) {
-            logger.error("Network Error: Device cannot be opened on [{}:{}]. Caused by '{}'", serverName, serverPort,
-                    e.getMessage());
+            logger.error("SLZB06 Network Error: Device cannot be opened on [{}:{}]. Caused by '{}'", serverName,
+                    serverPort, e.getMessage());
             return false;
         }
     }
@@ -163,6 +163,8 @@ public class Slzb06NetworkPort implements ZigBeePort {
             }
         } catch (Exception e) {
             logger.error("SLZB06 '{}': Error closing network port ", serverName, e);
+            socket = null;
+            this.notify();
         }
     }
 


### PR DESCRIPTION
SLZB06 uptime is in seconds so this PR changes the socket uptime to seconds for consistency (rather than milliseconds as it's supplied from the device).

There are also a few small changes to logging included.