### PR TITLE
[zigbee] Map colour temperature states to color HSB states

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
@@ -504,72 +504,78 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
 
         synchronized (colorUpdateSync) {
             try {
-                if (attribute.getClusterType().getId() == ZclOnOffCluster.CLUSTER_ID) {
-                    if (attribute.getId() == ZclOnOffCluster.ATTR_ONOFF) {
-                        Boolean value = (Boolean) val;
-                        OnOffType onoff = value ? OnOffType.ON : OnOffType.OFF;
-                        updateOnOff(onoff);
-                    }
-                } else if (attribute.getClusterType().getId() == ZclLevelControlCluster.CLUSTER_ID) {
-                    if (attribute.getId() == ZclLevelControlCluster.ATTR_CURRENTLEVEL) {
-                        PercentType brightness = levelToPercent((Integer) val);
-                        updateBrightness(brightness);
-                    }
-                } else if (attribute.getClusterType().getId() == ZclColorControlCluster.CLUSTER_ID) {
-                    switch (attribute.getId()) {
-                        case ZclColorControlCluster.ATTR_CURRENTHUE:
-                            int hue = (Integer) val;
-                            if (hue != lastHue) {
-                                lastHue = hue;
-                                hueChanged = true;
-                            }
-                            lastMired = -1;
-                            break;
+                switch (attribute.getClusterType().getId()) {
+                    case ZclOnOffCluster.CLUSTER_ID:
+                        if (attribute.getId() == ZclOnOffCluster.ATTR_ONOFF) {
+                            Boolean value = (Boolean) val;
+                            OnOffType onoff = value ? OnOffType.ON : OnOffType.OFF;
+                            updateOnOff(onoff);
+                        }
+                        break;
 
-                        case ZclColorControlCluster.ATTR_CURRENTSATURATION:
-                            int saturation = (Integer) val;
-                            if (saturation != lastSaturation) {
-                                lastSaturation = saturation;
-                                saturationChanged = true;
-                            }
-                            lastMired = -1;
-                            break;
+                    case ZclLevelControlCluster.CLUSTER_ID:
+                        if (attribute.getId() == ZclLevelControlCluster.ATTR_CURRENTLEVEL) {
+                            PercentType brightness = levelToPercent((Integer) val);
+                            updateBrightness(brightness);
+                        }
+                        break;
 
-                        case ZclColorControlCluster.ATTR_CURRENTX:
-                            int x = (Integer) val;
-                            if (x != lastX) {
-                                lastX = x;
-                                xChanged = true;
-                            }
-                            lastMired = -1;
-                            break;
-
-                        case ZclColorControlCluster.ATTR_CURRENTY:
-                            int y = (Integer) val;
-                            if (y != lastY) {
-                                lastY = y;
-                                yChanged = true;
-                            }
-                            lastMired = -1;
-                            break;
-
-                        case ZclColorControlCluster.ATTR_COLORTEMPERATURE:
-                            if (val instanceof Integer mired && mired != lastMired) {
-                                HSBType ctHSB = ColorUtil.xyToHsb(ColorUtil.kelvinToXY(1e6 / mired));
-                                lastHSB = new HSBType(ctHSB.getHue(), ctHSB.getSaturation(), lastHSB.getBrightness());
-                                updateChannelState(lastHSB);
-                                lastMired = mired;
-                            }
-                            break;
-
-                        case ZclColorControlCluster.ATTR_COLORMODE:
-                            Integer colorMode = (Integer) val;
-                            ColorModeEnum colorModeEnum = ColorModeEnum.getByValue(colorMode);
-                            if (colorModeEnum != ColorModeEnum.COLOR_TEMPERATURE) {
+                    case ZclColorControlCluster.CLUSTER_ID:
+                        switch (attribute.getId()) {
+                            case ZclColorControlCluster.ATTR_CURRENTHUE:
+                                int hue = (Integer) val;
+                                if (hue != lastHue) {
+                                    lastHue = hue;
+                                    hueChanged = true;
+                                }
                                 lastMired = -1;
-                            }
-                            break;
-                    }
+                                break;
+
+                            case ZclColorControlCluster.ATTR_CURRENTSATURATION:
+                                int saturation = (Integer) val;
+                                if (saturation != lastSaturation) {
+                                    lastSaturation = saturation;
+                                    saturationChanged = true;
+                                }
+                                lastMired = -1;
+                                break;
+
+                            case ZclColorControlCluster.ATTR_CURRENTX:
+                                int x = (Integer) val;
+                                if (x != lastX) {
+                                    lastX = x;
+                                    xChanged = true;
+                                }
+                                lastMired = -1;
+                                break;
+
+                            case ZclColorControlCluster.ATTR_CURRENTY:
+                                int y = (Integer) val;
+                                if (y != lastY) {
+                                    lastY = y;
+                                    yChanged = true;
+                                }
+                                lastMired = -1;
+                                break;
+
+                            case ZclColorControlCluster.ATTR_COLORTEMPERATURE:
+                                if (val instanceof Integer mired && mired != lastMired) {
+                                    HSBType ctHSB = ColorUtil.xyToHsb(ColorUtil.kelvinToXY(1e6 / mired));
+                                    lastHSB = new HSBType(ctHSB.getHue(), ctHSB.getSaturation(),
+                                            lastHSB.getBrightness());
+                                    updateChannelState(lastHSB);
+                                    lastMired = mired;
+                                }
+                                break;
+
+                            case ZclColorControlCluster.ATTR_COLORMODE:
+                                Integer colorMode = (Integer) val;
+                                ColorModeEnum colorModeEnum = ColorModeEnum.getByValue(colorMode);
+                                if (colorModeEnum != ColorModeEnum.COLOR_TEMPERATURE) {
+                                    lastMired = -1;
+                                }
+                                break;
+                        }
                 }
 
                 if (hueChanged || saturationChanged || xChanged || yChanged) {

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
@@ -610,7 +610,6 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                 logger.debug("{}: Exception in attribute update", endpoint.getIeeeAddress(), e);
             }
         }
-
     }
 
     /**

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
@@ -59,8 +59,6 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
     private double kelvinMax;
     private double kelvinRange;
 
-    private ColorModeEnum lastColorMode;
-
     // Default range of 2000K to 6500K
     private final Integer DEFAULT_MIN_TEMPERATURE_IN_KELVIN = 2000;
     private final Integer DEFAULT_MAX_TEMPERATURE_IN_KELVIN = 6500;
@@ -199,8 +197,8 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
 
                 case ZclColorControlCluster.ATTR_COLORMODE:
                     Integer colorMode = (Integer) val;
-                    lastColorMode = ColorModeEnum.getByValue(colorMode);
-                    if (lastColorMode == ColorModeEnum.COLOR_TEMPERATURE) {
+                    ColorModeEnum colorModeEnum = ColorModeEnum.getByValue(colorMode);
+                    if (colorModeEnum == ColorModeEnum.COLOR_TEMPERATURE) {
                         break;
                     }
                     // else fall through

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperature.java
@@ -34,9 +34,13 @@ import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.zcl.ZclAttribute;
 import com.zsmartsystems.zigbee.zcl.ZclAttributeListener;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclColorControlCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclOnOffCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.ColorCapabilitiesEnum;
 import com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.ColorModeEnum;
 import com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.MoveToColorTemperatureCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.onoff.OffCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.onoff.OnCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.onoff.ZclOnOffCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
 
 /**
@@ -49,6 +53,7 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
     private Logger logger = LoggerFactory.getLogger(ZigBeeConverterColorTemperature.class);
 
     private ZclColorControlCluster clusterColorControl;
+    private ZclOnOffCluster clusterOnOff;
 
     private double kelvinMin;
     private double kelvinMax;
@@ -111,6 +116,7 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
                     endpoint.getEndpointId());
             return false;
         }
+        clusterOnOff = (ZclOnOffCluster) endpoint.getInputCluster(ZclOnOffCluster.CLUSTER_ID);
 
         determineMinMaxTemperature(clusterColorControl);
 
@@ -133,8 +139,9 @@ public class ZigBeeConverterColorTemperature extends ZigBeeBaseChannelConverter 
         PercentType colorTemperaturePercentage = PercentType.ZERO;
         if (command instanceof PercentType) {
             colorTemperaturePercentage = (PercentType) command;
-        } else if (command instanceof OnOffType) {
-            // TODO: Should this turn the lamp on/off?
+        } else if (command instanceof OnOffType onOffCommand && clusterOnOff != null) {
+            ZclOnOffCommand zclOnOffCommand = OnOffType.ON == onOffCommand ? new OnCommand() : new OffCommand();
+            monitorCommandResponse(command, clusterOnOff.sendCommand(zclOnOffCommand));
             return;
         }
 

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColorTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColorTest.java
@@ -36,7 +36,6 @@ import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.types.State;
-import org.openhab.core.types.UnDefType;
 
 import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.IeeeAddress;
@@ -45,7 +44,6 @@ import com.zsmartsystems.zigbee.zcl.ZclAttribute;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclColorControlCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclLevelControlCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclOnOffCluster;
-import com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.ColorModeEnum;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -154,96 +152,22 @@ public class ZigBeeConverterColorColorTest {
         // No update here since state is OFF, but we remember the level (20%)...
         levelAttribute.updateValue(Integer.valueOf(101));
         converter.attributeUpdated(levelAttribute, levelAttribute.getLastValue());
-        Mockito.verify(thingHandler, Mockito.times(3)).setChannelState(channelCapture.capture(),
+        Mockito.verify(thingHandler, Mockito.times(4)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
 
         // When turned ON, we are set to the last level
         onAttribute.updateValue(Boolean.TRUE);
         converter.attributeUpdated(onAttribute, onAttribute.getLastValue());
-        Mockito.verify(thingHandler, Mockito.times(4)).setChannelState(channelCapture.capture(),
+        Mockito.verify(thingHandler, Mockito.times(5)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(new HSBType("0,0,40"), stateCapture.getValue());
 
         // Set the level and ensure it updates
         levelAttribute.updateValue(Integer.valueOf(50));
         converter.attributeUpdated(levelAttribute, levelAttribute.getLastValue());
-        Mockito.verify(thingHandler, Mockito.times(5)).setChannelState(channelCapture.capture(),
+        Mockito.verify(thingHandler, Mockito.times(6)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(new HSBType("0,0,20"), stateCapture.getValue());
-    }
-
-    @Test
-    public void testAttributeNotUpdatedWhenColorModeIsColorTemperature() {
-        ZigBeeEndpoint endpoint = Mockito.mock(ZigBeeEndpoint.class);
-        ZigBeeCoordinatorHandler coordinatorHandler = Mockito.mock(ZigBeeCoordinatorHandler.class);
-        Mockito.when(coordinatorHandler.getEndpoint(ArgumentMatchers.any(IeeeAddress.class), ArgumentMatchers.anyInt()))
-                .thenReturn(endpoint);
-
-        ZigBeeConverterColorColor converter = new ZigBeeConverterColorColor();
-        ArgumentCaptor<ChannelUID> channelCapture = ArgumentCaptor.forClass(ChannelUID.class);
-        ArgumentCaptor<State> stateCapture = ArgumentCaptor.forClass(State.class);
-        ZigBeeThingHandler thingHandler = Mockito.mock(ZigBeeThingHandler.class);
-        Channel channel = ChannelBuilder.create(new ChannelUID("a:b:c:d"), "").build();
-        converter.initialize(channel, coordinatorHandler, new IeeeAddress("1234567890ABCDEF"), 1);
-        converter.initializeConverter(thingHandler);
-
-        ZclAttribute colorModeAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 8, "ColorMode",
-                ZclDataType.ENUMERATION_8_BIT, false, false, false, false);
-        ZclAttribute onAttribute = new ZclAttribute(new ZclOnOffCluster(endpoint), 0, "OnOff", ZclDataType.BOOLEAN,
-                false, false, false, false);
-        ZclAttribute levelAttribute = new ZclAttribute(new ZclLevelControlCluster(endpoint), 0, "Level",
-                ZclDataType.BOOLEAN, false, false, false, false);
-        ZclAttribute currentHueAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 0, "CurrentHue",
-                ZclDataType.UNSIGNED_8_BIT_INTEGER, false, false, false, false);
-        ZclAttribute currentSaturationAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 1,
-                "CurrentSaturation", ZclDataType.UNSIGNED_8_BIT_INTEGER, false, false, false, false);
-        ZclAttribute currentXAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 3, "CurrentX",
-                ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, false, false);
-        ZclAttribute currentYAttribute = new ZclAttribute(new ZclColorControlCluster(endpoint), 4, "CurrentY",
-                ZclDataType.UNSIGNED_16_BIT_INTEGER, false, false, false, false);
-
-        // Update the color mode to COLOR_TEMPERATURE and ensure that the state is set to UNDEF
-        colorModeAttribute.updateValue(ColorModeEnum.COLOR_TEMPERATURE.getKey());
-        converter.attributeUpdated(colorModeAttribute, colorModeAttribute.getLastValue());
-        Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
-                stateCapture.capture());
-        assertEquals(UnDefType.UNDEF, stateCapture.getValue());
-
-        // Turn ON and ensure that the channel is not set
-        onAttribute.updateValue(Boolean.TRUE);
-        converter.attributeUpdated(onAttribute, onAttribute.getLastValue());
-        Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
-                stateCapture.capture());
-
-        // Set the level and ensure that the channel is not set
-        levelAttribute.updateValue(Integer.valueOf(50));
-        converter.attributeUpdated(levelAttribute, levelAttribute.getLastValue());
-        Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
-                stateCapture.capture());
-
-        // Set the hue and ensure that the channel is not set
-        currentHueAttribute.updateValue(Integer.valueOf(10));
-        converter.attributeUpdated(currentHueAttribute, currentHueAttribute.getLastValue());
-        Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
-                stateCapture.capture());
-
-        // Set the saturation and ensure that the channel is not set
-        currentSaturationAttribute.updateValue(Integer.valueOf(10));
-        converter.attributeUpdated(currentSaturationAttribute, currentSaturationAttribute.getLastValue());
-        Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
-                stateCapture.capture());
-
-        // Set the currentX and ensure that the channel is not set
-        currentXAttribute.updateValue(Integer.valueOf(10));
-        converter.attributeUpdated(currentXAttribute, currentXAttribute.getLastValue());
-        Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
-                stateCapture.capture());
-
-        // Set the level and ensure that the channel is not set
-        currentYAttribute.updateValue(Integer.valueOf(10));
-        converter.attributeUpdated(currentYAttribute, currentYAttribute.getLastValue());
-        Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
-                stateCapture.capture());
     }
 
     @Disabled
@@ -277,5 +201,4 @@ public class ZigBeeConverterColorColorTest {
 
         converter.initializeDevice();
     }
-
 }

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperatureTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorTemperatureTest.java
@@ -148,24 +148,12 @@ public class ZigBeeConverterColorTemperatureTest {
                 stateCapture.capture());
         assertEquals(UnDefType.UNDEF, stateCapture.getValue());
 
-        // Set the color temperature and ensure that the channel is not set
-        colorTemperatureAttribute.updateValue(Integer.valueOf(100));
-        converter.attributeUpdated(colorTemperatureAttribute, colorTemperatureAttribute.getLastValue());
-        Mockito.verify(thingHandler, Mockito.times(1)).setChannelState(channelCapture.capture(),
-                stateCapture.capture());
-
         // Update the color mode to CURRENTX_AND_CURRENTY and ensure that the state is set to UNDEF
         colorModeAttribute.updateValue(ColorModeEnum.CURRENT_X_AND_CURRENT_Y.getKey());
         converter.attributeUpdated(colorModeAttribute, colorModeAttribute.getLastValue());
         Mockito.verify(thingHandler, Mockito.times(2)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(UnDefType.UNDEF, stateCapture.getValue());
-
-        // Set the color temperature and ensure that the channel is not set
-        colorTemperatureAttribute.updateValue(Integer.valueOf(100));
-        converter.attributeUpdated(colorTemperatureAttribute, colorTemperatureAttribute.getLastValue());
-        Mockito.verify(thingHandler, Mockito.times(2)).setChannelState(channelCapture.capture(),
-                stateCapture.capture());
     }
 
     @Test


### PR DESCRIPTION
Previously, when a lamp device was operated in color temperature mode, the color channel/item state within OH and its respective UIs would be shown as UNDEF.

Now, with this PR when a lamp is operated in color temperature mode, the respective color temperature is converted to an actual valid color that is derived from the color temperature point on the color temperature locus on the CIE color xy chart. See curved line on CIE chart below.

**NOTA BENE**: this calculated HSB state is **NOT** sent to the remote device (since that would lead to a feedback loop) -- the state is used solely within OH and its respective UIs. However I think it may be be necessary to set `autoUpdate=false` on the respective color channel (or implement another mechanism) in order to definitively rule out feedback loops.

![image](https://github.com/user-attachments/assets/c9ec7862-13cb-491d-ac09-c0e4a9e5f32d)

The initial aim of this PR was simply to resolve #853 (which it probably does). However it also (therefore) eliminates a lot of state setting that was previously conditionally required due to the UNDEF state when in color temperature mode. And (therefore) it also eliminates the JUnit tests that previously tested that conditional state setting code.

As this change is a little more radical than others might have anticipated, I am putting this PR up here, with the request that you kindly let me have your thoughts on it. We may need a few iterations..

This PR depends on https://github.com/openhab/openhab-core/pull/4367

Signed-off-by: AndrewFG <software@whitebear.ch>