### PR TITLE
Add reporting configuration options to some power measurement channels

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
@@ -484,6 +484,8 @@ public abstract class ZigBeeBaseChannelConverter {
         } else if (command instanceof Number) {
             // No scale, so assumed to be Celsius
             value = BigDecimal.valueOf(((Number) command).doubleValue());
+        } else {
+            return 0;
         }
         return value.setScale(2, RoundingMode.CEILING).multiply(TEMPERATURE_MULTIPLIER).intValue();
     }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementPower.java
@@ -209,7 +209,7 @@ public class ZigBeeConverterMeasurementPower extends ZigBeeBaseChannelConverter 
 
         divisor = (Integer) divAttribute.readValue(Long.MAX_VALUE);
         multiplier = (Integer) mulAttribute.readValue(Long.MAX_VALUE);
-        if (divisor == null || multiplier == null) {
+        if (divisor == null || multiplier == null || divisor == 0 || multiplier == 0) {
             divisor = 1;
             multiplier = 1;
         }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsCurrent.java
@@ -211,7 +211,7 @@ public class ZigBeeConverterMeasurementRmsCurrent extends ZigBeeBaseChannelConve
 
         divisor = (Integer) divAttribute.readValue(Long.MAX_VALUE);
         multiplier = (Integer) mulAttribute.readValue(Long.MAX_VALUE);
-        if (divisor == null || multiplier == null) {
+        if (divisor == null || multiplier == null || divisor == 0 || multiplier == 0) {
             divisor = 1;
             multiplier = 1;
         }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
@@ -13,15 +13,20 @@
 package org.openhab.binding.zigbee.internal.converter;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import javax.measure.quantity.ElectricPotential;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.openhab.binding.zigbee.ZigBeeBindingConstants;
 import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
 import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
+import org.openhab.binding.zigbee.internal.converter.config.ZclReportingConfig;
+import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.Channel;
@@ -46,10 +51,16 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
 public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConverter implements ZclAttributeListener {
     private Logger logger = LoggerFactory.getLogger(ZigBeeConverterMeasurementRmsVoltage.class);
 
+    private static BigDecimal CHANGE_DEFAULT = new BigDecimal(5);
+    private static BigDecimal CHANGE_MIN = new BigDecimal(1);
+    private static BigDecimal CHANGE_MAX = new BigDecimal(100);
+
     private ZclElectricalMeasurementCluster clusterMeasurement;
 
     private Integer divisor;
     private Integer multiplier;
+
+    private ZclReportingConfig configReporting;
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
@@ -72,14 +83,16 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
             return false;
         }
 
+        ZclReportingConfig reporting = new ZclReportingConfig(channel);
+
         try {
             CommandResult bindResponse = bind(serverClusterMeasurement).get();
             if (bindResponse.isSuccess()) {
                 ZclAttribute attribute = serverClusterMeasurement
                         .getAttribute(ZclElectricalMeasurementCluster.ATTR_RMSVOLTAGE);
                 // Configure reporting - no faster than once per second - no slower than 2 hours.
-                CommandResult reportingResponse = serverClusterMeasurement
-                        .setReporting(attribute, 3, REPORTING_PERIOD_DEFAULT_MAX, 1).get();
+                CommandResult reportingResponse = attribute.setReporting(reporting.getReportingTimeMin(),
+                        reporting.getReportingTimeMax(), reporting.getReportingChange()).get();
                 handleReportingResponse(reportingResponse, POLLING_PERIOD_HIGH, REPORTING_PERIOD_DEFAULT_MAX);
             } else {
                 pollingPeriod = POLLING_PERIOD_HIGH;
@@ -106,6 +119,13 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
 
         // Add a listener
         clusterMeasurement.addAttributeListener(this);
+
+        // Create a configuration handler and get the available options
+        configReporting = new ZclReportingConfig(channel);
+        configReporting.setAnalogue(CHANGE_DEFAULT, CHANGE_MIN, CHANGE_MAX);
+        configOptions = new ArrayList<>();
+        configOptions.addAll(configReporting.getConfiguration());
+
         return true;
     }
 
@@ -119,6 +139,24 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
     @Override
     public void handleRefresh() {
         clusterMeasurement.getRmsVoltage(0);
+    }
+
+    @Override
+    public void updateConfiguration(@NonNull Configuration currentConfiguration,
+            Map<String, Object> updatedParameters) {
+        if (configReporting.updateConfiguration(currentConfiguration, updatedParameters)) {
+            try {
+                ZclAttribute attribute = clusterMeasurement
+                        .getAttribute(ZclElectricalMeasurementCluster.ATTR_RMSVOLTAGE);
+                CommandResult reportingResponse;
+                reportingResponse = attribute.setReporting(configReporting.getReportingTimeMin(),
+                        configReporting.getReportingTimeMax(), configReporting.getReportingChange()).get();
+                handleReportingResponse(reportingResponse, configReporting.getPollingPeriod(),
+                        configReporting.getReportingTimeMax());
+            } catch (InterruptedException | ExecutionException e) {
+                logger.debug("{}: RMS voltage measurement exception setting reporting", endpoint.getIeeeAddress(), e);
+            }
+        }
     }
 
     @Override

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeasurementRmsVoltage.java
@@ -211,7 +211,7 @@ public class ZigBeeConverterMeasurementRmsVoltage extends ZigBeeBaseChannelConve
 
         divisor = (Integer) divAttribute.readValue(Long.MAX_VALUE);
         multiplier = (Integer) mulAttribute.readValue(Long.MAX_VALUE);
-        if (divisor == null || multiplier == null) {
+        if (divisor == null || multiplier == null || divisor == 0 || multiplier == 0) {
             divisor = 1;
             multiplier = 1;
         }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeteringInstantaneousDemand.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeteringInstantaneousDemand.java
@@ -172,7 +172,7 @@ public class ZigBeeConverterMeteringInstantaneousDemand extends ZigBeeBaseChanne
 
         Integer iDiv = (Integer) divisorAttribute.readValue(Long.MAX_VALUE);
         Integer iMult = (Integer) multiplierAttribute.readValue(Long.MAX_VALUE);
-        if (iDiv == null || iMult == null) {
+        if (iDiv == null || iMult == null || iDiv == 0 || iMult == 0) {
             iDiv = 1;
             iMult = 1;
         }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeteringSummationDelivered.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeteringSummationDelivered.java
@@ -211,7 +211,6 @@ public class ZigBeeConverterMeteringSummationDelivered extends ZigBeeBaseChannel
 
         Integer iDiv = (Integer) divisorAttribute.readValue(Long.MAX_VALUE);
         Integer iMult = (Integer) multiplierAttribute.readValue(Long.MAX_VALUE);
-        if (iDiv == null || iMult == null) {
         if (iDiv == null || iMult == null || iDiv == 0 || iMult == 0) {
             iDiv = 1;
             iMult = 1;

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeteringSummationDelivered.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterMeteringSummationDelivered.java
@@ -212,6 +212,7 @@ public class ZigBeeConverterMeteringSummationDelivered extends ZigBeeBaseChannel
         Integer iDiv = (Integer) divisorAttribute.readValue(Long.MAX_VALUE);
         Integer iMult = (Integer) multiplierAttribute.readValue(Long.MAX_VALUE);
         if (iDiv == null || iMult == null) {
+        if (iDiv == null || iMult == null || iDiv == 0 || iMult == 0) {
             iDiv = 1;
             iMult = 1;
         }


### PR DESCRIPTION
This adds reporting configuration to a number of power measurement channels. This allows reporting to be reduced on large networks to avoid congestion.