### PR TITLE
Check if node is already initialised in discovery before reinitialising

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -1116,4 +1116,23 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
         // Always allow the firmware to be updated
         return true;
     }
+
+    /**
+     * Returns the {@link IeeeAddress} for the node
+     *
+     * @return the {@link IeeeAddress} for the node
+     */
+    public Object getIeeeAddress() {
+        return nodeIeeeAddress;
+    }
+
+    /**
+     * Returns true if the device has been initialised, and all channel converters have initialised.
+     *
+     * @return
+     */
+    public boolean isDeviceInitialized() {
+        return Boolean
+                .parseBoolean(thing.getProperties().get(ZigBeeBindingConstants.THING_PROPERTY_DEVICE_INITIALIZED));
+    }
 }


### PR DESCRIPTION
This avoids performing a reinitialisation on the node (ie calling the channel handler `initializeDevice` every time the binding starts. This was caused by the discovery handler not checking to see if the device was already initialised.