### PR TITLE
Change default to only add devices during a scan

### DIFF
--- a/org.openhab.binding.zigbee.slzb06/src/test/java/org/openhab/binding/zigbee/slzb06/internal/Slzb06NetworkPortTest.java
+++ b/org.openhab.binding.zigbee.slzb06/src/test/java/org/openhab/binding/zigbee/slzb06/internal/Slzb06NetworkPortTest.java
@@ -26,7 +26,7 @@ public class Slzb06NetworkPortTest {
     public void processReceivedData() {
         Slzb06NetworkPort port = new Slzb06NetworkPort(null, 0);
 
-        byte[] chunk = new byte[Slzb06NetworkPort.RX_BUFFER_LEN - 1];
+        byte[] chunk = new byte[Slzb06NetworkPort.RX_BUFFER_LEN - 2];
         byte[] extra = new byte[1];
 
         for (int i = 0; i < chunk.length; i++) {
@@ -37,7 +37,7 @@ public class Slzb06NetworkPortTest {
         extra[0] = 1;
         port.processReceivedData(extra, 1);
 
-        for (int i = 0; i < chunk.length - 1; i++) {
+        for (int i = 0; i < chunk.length; i++) {
             assertEquals(0, port.read(1));
         }
         assertEquals(1, port.read(1));
@@ -47,10 +47,10 @@ public class Slzb06NetworkPortTest {
     public void processReceivedDataOverflow() {
         Slzb06NetworkPort port = new Slzb06NetworkPort(null, 0);
 
-        byte[] chunk = new byte[Slzb06NetworkPort.RX_BUFFER_LEN];
+        byte[] chunk = new byte[Slzb06NetworkPort.RX_BUFFER_LEN - 1];
         byte[] extra = new byte[1];
 
-        for (int i = 0; i < Slzb06NetworkPort.RX_BUFFER_LEN; i++) {
+        for (int i = 0; i < chunk.length; i++) {
             chunk[i] = 0;
         }
         port.processReceivedData(chunk, chunk.length);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeDiscoveryService.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeDiscoveryService.java
@@ -69,7 +69,7 @@ public class ZigBeeDiscoveryService extends AbstractDiscoveryService {
     private final static int SEARCH_TIME = 60;
     private final static String CONFIG_PROPERTY_CREATE_RESULTS_ONLY_DURING_ACTIVE_SCANS = "createResultsOnlyDuringActiveScans";
 
-    private boolean createResultsOnlyDuringActiveScans = false;
+    private boolean createResultsOnlyDuringActiveScans = true;
     private volatile boolean scanStarted = false;
 
     private final Set<ZigBeeCoordinatorHandler> coordinatorHandlers = new CopyOnWriteArraySet<>();

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeCoordinatorHandler.java
@@ -1161,13 +1161,24 @@ public abstract class ZigBeeCoordinatorHandler extends BaseBridgeHandler
                 childThing.getUID(), children.size());
     }
 
+    /**
+     * Check if the child defined with the {@link IeeeAddress} has completed initialisation
+     *
+     * @param address the {@link IeeeAddress}
+     * @return true if the child is initialised
+     */
     public boolean isChildInitialized(IeeeAddress address) {
+        logger.debug("{}: ZigBee coordinator {} check if child is initialised", address, getThing().getUID());
         for (ZigBeeThingHandler child : children.values()) {
             if (child.getIeeeAddress().equals(address)) {
+                logger.debug("{}: ZigBee coordinator {} check if child is initialised - found {}", address,
+                        getThing().getUID(), child.isDeviceInitialized());
                 return child.isDeviceInitialized();
             }
         }
 
+        logger.debug("{}: ZigBee coordinator {} check if child is initialised - not found", address,
+                getThing().getUID());
         return false;
     }
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -433,7 +433,7 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
                 }
             }
         } catch (Exception e) {
-            logger.error("{}: Exception creating channels ", nodeIeeeAddress, e);
+            logger.error("{}: Exception creating channels", nodeIeeeAddress, e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR);
             return;
         }


### PR DESCRIPTION
This PR changes the default configuration to only add devices during an active scan. The changes in #859 mostly didn't work due to a race condition on startup - devices were added during startup, but the handler often wasn't instantiated, so the check to see if the thing configuration was complete didn't work.

With this change, the startup is much less chatty and it avoids a lot of unnecessarily reconfiguration.