### PR TITLE
Trim blanks and invisible characters from property value for discovery.

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeThingTypeMatcher.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/ZigBeeThingTypeMatcher.java
@@ -128,7 +128,7 @@ public class ZigBeeThingTypeMatcher {
                 }
 
                 newProperties
-                        .add(new RequiredProperty(discoveryElement[0].trim(), unescape(discoveryElement[1].trim())));
+                        .add(new RequiredProperty(discoveryElement[0].trim(), unescape(discoveryElement[1]).trim()));
             }
 
             if (newProperties.isEmpty()) {

--- a/org.openhab.binding.zigbee/src/main/resources/discovery.txt
+++ b/org.openhab.binding.zigbee/src/main/resources/discovery.txt
@@ -15,7 +15,7 @@ xiaomi_lumisensormagnet,modelId=lumi.sensor_magnet
 xiaomi_lumiremotemini,modelId=lumi.remote.b1acn01
 innr-rc-110,vendor=innr,modelId=RC 110
 osram-switch-4x-eu,vendor=OSRAM,modelId=Switch 4x EU-LIGHTIFY
-legrand_dimmer_without_neutral,vendor=\u001f Legrand,modelId=\u001f Dimmer switch w/o neutral
+legrand_dimmer_without_neutral,vendor=Legrand,modelId=Dimmer switch w/o neutral
 tuya_ts0041,modelId=TS0041
 tuya_ts0042,modelId=TS0042
 tuya_ts0043,modelId=TS0043

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/ZigBeeThingTypeMatcherTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/ZigBeeThingTypeMatcherTest.java
@@ -61,5 +61,11 @@ public class ZigBeeThingTypeMatcherTest {
         properties = new HashMap<>();
         properties.put(Thing.PROPERTY_VENDOR, "Vendor3");
         assertEquals(null, matcher.matchThingType(properties));
+
+	// Match with invisible characters
+	properties = new HashMap<>();
+	properties.put(Thing.PROPERTY_VENDOR, "Vendor4");
+        properties.put(Thing.PROPERTY_MODEL_ID, "Model3");
+        assertEquals(new ThingTypeUID("zigbee:type5"), matcher.matchThingType(properties));
     }
 }

--- a/org.openhab.binding.zigbee/src/test/resources/discovery.txt
+++ b/org.openhab.binding.zigbee/src/test/resources/discovery.txt
@@ -3,3 +3,4 @@ type1,vendor=Vendor1,modelId=Model1
 type2,vendor=Vendor2,modelId=Model2
 type3,vendor=Vendor1,modelId=Model2
 type4,vendor=Vendor1,modelId=Model2,firmwareVersion=Version4
+type5,vendor=\u001F Vendor4,modelId= Model3\u001F


### PR DESCRIPTION
Fix for issue https://github.com/openhab/org.openhab.binding.zigbee/issues/834 on 4.2.x.

Initial PR: https://github.com/openhab/org.openhab.binding.zigbee/pull/836.