### PR TITLE
Fix regression with managing on/off state in color handler

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -98,6 +99,8 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
     private int lastY = -1;
     private boolean xChanged = false;
     private boolean yChanged = false;
+
+    private final AtomicBoolean currentOnOffState = new AtomicBoolean(true);
 
     private double lastMired = -1;
 
@@ -441,6 +444,8 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
 
     private void updateOnOff(OnOffType onOff) {
         boolean on = onOff == OnOffType.ON;
+        currentOnOffState.set(on);
+
         // Extra temp variable to avoid thread sync concurrency issues on lastHSB
         HSBType oldHSB = lastHSB;
         HSBType newHSB = on ? lastHSB : new HSBType(oldHSB.getHue(), oldHSB.getSaturation(), PercentType.ZERO);
@@ -452,7 +457,10 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
         HSBType oldHSB = lastHSB;
         HSBType newHSB = new HSBType(oldHSB.getHue(), oldHSB.getSaturation(), brightness);
         lastHSB = newHSB;
-        updateChannelState(newHSB);
+
+        if (currentOnOffState.get()) {
+            updateChannelState(newHSB);
+        }
     }
 
     private void updateColorHSB(DecimalType hue, PercentType saturation) {
@@ -460,7 +468,10 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
         HSBType oldHSB = lastHSB;
         HSBType newHSB = new HSBType(hue, saturation, oldHSB.getBrightness());
         lastHSB = newHSB;
-        updateChannelState(newHSB);
+
+        if (currentOnOffState.get()) {
+            updateChannelState(newHSB);
+        }
     }
 
     private void updateColorXY(PercentType x, PercentType y) {

--- a/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColorTest.java
+++ b/org.openhab.binding.zigbee/src/test/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColorTest.java
@@ -152,20 +152,20 @@ public class ZigBeeConverterColorColorTest {
         // No update here since state is OFF, but we remember the level (20%)...
         levelAttribute.updateValue(Integer.valueOf(101));
         converter.attributeUpdated(levelAttribute, levelAttribute.getLastValue());
-        Mockito.verify(thingHandler, Mockito.times(4)).setChannelState(channelCapture.capture(),
+        Mockito.verify(thingHandler, Mockito.times(3)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
 
         // When turned ON, we are set to the last level
         onAttribute.updateValue(Boolean.TRUE);
         converter.attributeUpdated(onAttribute, onAttribute.getLastValue());
-        Mockito.verify(thingHandler, Mockito.times(5)).setChannelState(channelCapture.capture(),
+        Mockito.verify(thingHandler, Mockito.times(4)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(new HSBType("0,0,40"), stateCapture.getValue());
 
         // Set the level and ensure it updates
         levelAttribute.updateValue(Integer.valueOf(50));
         converter.attributeUpdated(levelAttribute, levelAttribute.getLastValue());
-        Mockito.verify(thingHandler, Mockito.times(6)).setChannelState(channelCapture.capture(),
+        Mockito.verify(thingHandler, Mockito.times(5)).setChannelState(channelCapture.capture(),
                 stateCapture.capture());
         assertEquals(new HSBType("0,0,20"), stateCapture.getValue());
     }


### PR DESCRIPTION
This fixes a regression introduced in #855 which removed the management of the on/off state of a device and therefore propagates incorrect states into openHAB

Closes #888