### PR TITLE
Add dimmer/switch mode for Legrand with Netatmo dimmers switch w/o neutral

### DIFF
--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/legrand/dimmer-switch-without-neutral.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/legrand/dimmer-switch-without-neutral.xml
@@ -27,6 +27,15 @@
 				<label>MAC Address</label>
 			</parameter>
 
+                        <parameter name="attribute_01_in_fc01_0000_09" type="integer">
+                                <label>Dimmer mode</label>
+                                <options>
+                                        <option value="256">Disabled</option>
+                                        <option value="257">Enabled</option>
+                                </options>
+                                <default>257</default>
+                        </parameter>
+
 			<parameter name="attribute_01_in_fc01_0001_10" type="boolean">
 				<label>Led in Dark</label>
 				<options>


### PR DESCRIPTION
Implement Dimmer/Switch mode configuration for Legrand Céliane with Netatmo dimmer switches (https://github.com/openhab/org.openhab.binding.zigbee/issues/733) now that DATA_16_BIT ZCL type (id: 0x09) is fully supported. Successfully tested on OpenHAB 4.3.1.