### PR TITLE
Ignore XY color updates in hue mode

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterColorColor.java
@@ -594,9 +594,9 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                         colorUpdateTimer = null;
                     }
 
-                    if (hueChanged && saturationChanged) {
+                    if (supportsHue && hueChanged && saturationChanged) {
                         updateColorHSB();
-                    } else if (xChanged && yChanged) {
+                    } else if (!supportsHue && xChanged && yChanged) {
                         updateColorXY();
                     } else {
                         // Wait some time and update anyway if only one attribute in each pair is updated
@@ -605,10 +605,10 @@ public class ZigBeeConverterColorColor extends ZigBeeBaseChannelConverter implem
                             public void run() {
                                 synchronized (colorUpdateSync) {
                                     try {
-                                        if ((hueChanged || saturationChanged) && lastHue >= 0.0f
+                                        if (supportsHue && (hueChanged || saturationChanged) && lastHue >= 0.0f
                                                 && lastSaturation >= 0.0f) {
                                             updateColorHSB();
-                                        } else if ((xChanged || yChanged) && lastX >= 0.0f && lastY >= 0.0f) {
+                                        } else if (!supportsHue && (xChanged || yChanged) && lastX >= 0.0f && lastY >= 0.0f) {
                                             updateColorXY();
                                         }
                                     } catch (Exception e) {


### PR DESCRIPTION
I am using the configuration `zigbee_levelcontrol_transitiontimedefault: 598` to have a smooth color change taking `59.8s`.
While the lamp does change the color, it reports the state back in hue and in xy color, so i see two updates of the state for each step. Even worse the xy color values are converted to a incorrect hue value (the lamp might use different gamma values internally), this will make the hue and saturation sliders in the UI jump around like crazy between different values.

This PR will ignore the XY color updates in case hue values are send to the lamp.

Signed-off-by: Jörg Sautter joerg.sautter@gmx.net