### PR TITLE
Fix Nullable issue in OH5 build

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeNodePropertyDiscoverer.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/discovery/ZigBeeNodePropertyDiscoverer.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import org.eclipse.jdt.annotation.NonNull;
@@ -33,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.ZigBeeNode;
 import com.zsmartsystems.zigbee.zcl.ZclAttribute;
+import com.zsmartsystems.zigbee.zcl.ZclCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclBasicCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclOtaUpgradeCluster;
 import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor;
@@ -136,9 +138,9 @@ public class ZigBeeNodePropertyDiscoverer {
     }
 
     private void addPropertiesFromBasicCluster(ZigBeeNode node) {
-        ZclBasicCluster basicCluster = (ZclBasicCluster) node.getEndpoints().stream()
-                .map(ep -> ep.getInputCluster(ZclBasicCluster.CLUSTER_ID)).filter(Objects::nonNull).findFirst()
-                .orElse(null);
+        Optional<ZclCluster> cluster = node.getEndpoints().stream()
+                .map(ep -> ep.getInputCluster(ZclBasicCluster.CLUSTER_ID)).filter(Objects::nonNull).findFirst();
+        ZclBasicCluster basicCluster = (ZclBasicCluster) cluster.orElse(null);
 
         if (basicCluster == null) {
             logger.debug("{}: Node doesn't support basic cluster", node.getIeeeAddress());
@@ -241,9 +243,9 @@ public class ZigBeeNodePropertyDiscoverer {
     }
 
     private void addPropertiesFromOtaCluster(ZigBeeNode node) {
-        ZclOtaUpgradeCluster otaCluster = (ZclOtaUpgradeCluster) node.getEndpoints().stream()
-                .map(ep -> ep.getOutputCluster(ZclOtaUpgradeCluster.CLUSTER_ID)).filter(Objects::nonNull).findFirst()
-                .orElse(null);
+        Optional<ZclCluster> cluster = node.getEndpoints().stream()
+                .map(ep -> ep.getOutputCluster(ZclOtaUpgradeCluster.CLUSTER_ID)).filter(Objects::nonNull).findFirst();
+        ZclOtaUpgradeCluster otaCluster = (ZclOtaUpgradeCluster) cluster.orElse(null);
 
         if (otaCluster != null) {
             logger.debug("{}: ZigBee node property discovery using OTA cluster on endpoint {}", node.getIeeeAddress(),


### PR DESCRIPTION
As reported [here](https://community.openhab.org/t/oh-5-0-snapshot-builds-failing/162137), our OH5 sandbox builds currently fail when building the zigbee addon.

On the local machine it builds against 4.3 and succeeds.
When I change `pom.xml` to use `5.0-SNAPSHOT`, I can reproduce the issue seen in the [Jenkins builds](https://ci.openhab.org/view/Sandbox/job/sandbox-openhab5-release/).

The proposed fix is probably not the most elegant way to do it.
However, compilation passes with OH5 and 4.3.