### PR TITLE
Add auto generated semantic tags

### DIFF
--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/bitron/bitron-video-902010-23.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/bitron/bitron-video-902010-23.xml
@@ -5,6 +5,7 @@
                           xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
    <thing-type id="bitron-video-902010-23" listed="false">
       <label>BitronVideo 4-button Remote Control</label>
+      <semantic-equipment-tag>Button</semantic-equipment-tag>
       <channels>
          <channel id="key1" typeId="system.button">
             <label>Button 1</label>

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/bitron/bitron-video-av2010-34.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/bitron/bitron-video-av2010-34.xml
@@ -5,6 +5,7 @@
                           xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
    <thing-type id="bitron-video-av2010-34" listed="false">
       <label>Bitron Video Wall Switch AV2010/34</label>
+      <semantic-equipment-tag>WallSwitch</semantic-equipment-tag>
       <channels>
          <channel id="button1" typeId="system.button">
             <label>Button 1</label>

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/device.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/device.xml
@@ -7,6 +7,7 @@
 	<thing-type id="device" listed="false">
 		<label>ZigBee Device</label>
 		<description>Generic ZigBee Device</description>
+      <semantic-equipment-tag>IceMaker</semantic-equipment-tag>
 
         <config-description>
             <parameter name="zigbee_macaddress" type="text" readOnly="true" required="true">

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/innr/rc-110.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/innr/rc-110.xml
@@ -5,6 +5,7 @@
                           xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
    <thing-type id="innr-rc-110" listed="false">
       <label>Innr RC 110 Remote Control</label>
+      <semantic-equipment-tag>ControlDevice</semantic-equipment-tag>
       <channels>
          <channel id="scenesOn" typeId="system.button">
             <label>Button On</label>

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/legrand/dimmer-switch-without-neutral.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/legrand/dimmer-switch-without-neutral.xml
@@ -7,6 +7,7 @@
 	<thing-type id="legrand_dimmer_without_neutral" listed="false">
 		<label>Legrand with Netatmo Dimmer</label>
 		<description>Legrand with Netatmo Dimmer without neutral</description>
+      <semantic-equipment-tag>LightSource</semantic-equipment-tag>
 		<channels>
 			<channel id="switch_onoff" typeId="switch_onoff">
 				<properties>

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/philips/rwl021.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/philips/rwl021.xml
@@ -5,6 +5,7 @@
                           xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
    <thing-type id="philips_rwl021" listed="false">
       <label>Hue Dimmer Switch</label>
+      <semantic-equipment-tag>LightSource</semantic-equipment-tag>
       <channels>
          <channel id="switch_level" typeId="switch_level">
             <label>Level Control</label>

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/philips/rwl022.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/philips/rwl022.xml
@@ -5,6 +5,7 @@
                           xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
    <thing-type id="philips_rwl022" listed="false">
       <label>Hue Dimmer Switch</label>
+      <semantic-equipment-tag>LightSource</semantic-equipment-tag>
       <channels>
          <channel id="switch_level" typeId="switch_level">
             <label>Level Control</label>

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/philips/sml001.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/philips/sml001.xml
@@ -7,6 +7,7 @@
 	<thing-type id="philips_sml001" listed="false">
 		<label>Hue Motion Sensor</label>
 		<description>Hue Motion Illuminance and Temperature Sensor</description>
+      <semantic-equipment-tag>MotionDetector</semantic-equipment-tag>
 
 		<channels>
 			<channel id="motion" typeId="sensor_occupancy">

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/smartthings/motionv4.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/smartthings/motionv4.xml
@@ -6,6 +6,7 @@
     <thing-type id="smartthings_motionv4" listed="false">
         <label>SmartThings Motion Sensor V4</label>
         <description>SmartThings Motion and Temperature Sensor</description>
+      <semantic-equipment-tag>MotionDetector</semantic-equipment-tag>
 
         <channels>
             <channel id="temperature" typeId="measurement_temperature">

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/tuya/ts0041.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/tuya/ts0041.xml
@@ -8,6 +8,7 @@
 		<label>TS0041</label>
 		<description>Generic Tuya 1-Button Wall Switch</description>
 		<category>WallSwitch</category>
+      <semantic-equipment-tag>WallSwitch</semantic-equipment-tag>
 
 		<channels>
 

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/tuya/ts0042.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/tuya/ts0042.xml
@@ -8,6 +8,7 @@
 		<label>TS0042</label>
 		<description>Generic Tuya 2-Button Wall Switch</description>
 		<category>WallSwitch</category>
+      <semantic-equipment-tag>WallSwitch</semantic-equipment-tag>
 
 		<channels>
 

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/tuya/ts0043.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/tuya/ts0043.xml
@@ -8,6 +8,7 @@
 		<label>TS0043</label>
 		<description>Generic Tuya 3-Button Wall Switch</description>
 		<category>WallSwitch</category>
+      <semantic-equipment-tag>WallSwitch</semantic-equipment-tag>
 
 		<channels>
 

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/tuya/ts0044.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/tuya/ts0044.xml
@@ -8,6 +8,7 @@
 		<label>TS0044</label>
 		<description>Generic Tuya 4-Button Wall Switch</description>
 		<category>WallSwitch</category>
+      <semantic-equipment-tag>WallSwitch</semantic-equipment-tag>
 
 		<channels>
 

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/lumiremoteb286acn01.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/lumiremoteb286acn01.xml
@@ -8,6 +8,7 @@
 		<label>Xiaomi Wall Switch</label>
 		<description>Xiaomi Wall Switch</description>
 		<category>WallSwitch</category>
+      <semantic-equipment-tag>WallSwitch</semantic-equipment-tag>
 
 		<channels>
 			<channel id="left" typeId="system.button">

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/lumiremotemini.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/lumiremotemini.xml
@@ -8,6 +8,7 @@
 		<label>AQARA WXKG11LM</label>
 		<description>Smart Wireless Switch</description>
 		<category>WallSwitch</category>
+      <semantic-equipment-tag>WallSwitch</semantic-equipment-tag>
 
 		<channels>
 			<channel id="center" typeId="system.button">

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/lumisensor-magnet.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/lumisensor-magnet.xml
@@ -8,6 +8,7 @@
 
     <thing-type id="xiaomi_lumisensormagnet" listed="false">
         <label>Xiaomi Door Window Sensor</label>
+      <semantic-equipment-tag>Sensor</semantic-equipment-tag>
 
         <channels>
             <channel id="contact_switch" typeId="switch_onoff">

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/lumisensor-motion.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/lumisensor-motion.xml
@@ -7,6 +7,7 @@
 	<thing-type id="xiaomi_lumisensor-motion" listed="false">
 		<label>Xiaomi Lumi Motion Sensor</label>
 		<description>Xiaomi Motion Sensor</description>
+      <semantic-equipment-tag>MotionDetector</semantic-equipment-tag>
 
 		<channels>
 			<channel id="occupancy" typeId="sensor_occupancy">

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/lumisensor86sw2.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/lumisensor86sw2.xml
@@ -9,6 +9,7 @@
 	<thing-type id="xiaomi_lumisensor86sw2" listed="false">
 		<label>Xiaomi Wireless 2-Button Switch</label>
 		<description>Xiaomi Wireless 2-Button Switch</description>
+      <semantic-equipment-tag>Sensor</semantic-equipment-tag>
 
 		<channels>
 			<channel id="switch_1" typeId="switch_onoff">

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/lumisensorht.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/lumisensorht.xml
@@ -7,6 +7,7 @@
 	<thing-type id="xiaomi_lumisensorht" listed="false">
 		<label>Xiaomi Temperature and Humidity Sensor</label>
 		<description>Xiaomi Temperature and Humidity Sensor</description>
+      <semantic-equipment-tag>Sensor</semantic-equipment-tag>
 
 		<channels>
 			<channel id="temperature" typeId="measurement_temperature">

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/lumiwleak-aq1.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/lumiwleak-aq1.xml
@@ -7,6 +7,7 @@
     <thing-type id="xiaomi_lumisensorwaterleak" listed="false">
         <label>Xiaomi Water Leak Sensor</label>
         <description>Xiaomi Water Leak Sensor</description>
+      <semantic-equipment-tag>Sensor</semantic-equipment-tag>
 
         <channels>
             <channel id="alarm_water" typeId="ias_water">

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/xiaomi_lumisensor-switch.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/xiaomi_lumisensor-switch.xml
@@ -18,6 +18,7 @@
 	<thing-type id="xiaomi_lumisensor-switch" listed="false">
 		<label>Xiaomi LUMI Mijia Button</label>
 		<description>Single battery operated button (round model)</description>
+      <semantic-equipment-tag>Sensor</semantic-equipment-tag>
 
 		<channels>
 			<channel id="switch" typeId="switch_onoff">

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/xiaomi_lumisensor-switchaq2.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/xiaomi/xiaomi_lumisensor-switchaq2.xml
@@ -8,6 +8,7 @@
         <label>Xiaomi Wireless Mini Switch</label>
         <description>Xiaomi Wireless Mini Switch</description>
         <category>WallSwitch</category>
+      <semantic-equipment-tag>Sensor</semantic-equipment-tag>
 
         <channels>
             <channel id="center" typeId="system.button">


### PR DESCRIPTION
This is the Zigbee counterpart https://github.com/openhab/org.openhab.binding.zwave/pull/1983

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>