### PR TITLE
Adds support for Legrand Céliane with Netatmo dimmers with neutral

### DIFF
--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -285,7 +285,9 @@ The following devices have been tested by openHAB users with the binding. This l
 | Innr Bulbs                                     | _[<sup>[1]</sup>](#note1)_                                   |
 | Innr SP 120                                    | Smart Plug _[<sup>[1]</sup>](#note1)_                        |
 | LEDVANCE/Osram Bulbs                           |                                                              |
+| LEGRAND                                        | Céliane with Netatmo Connected micromodule for exhaust fan CMV 2 speeds 067766. |
 | LEGRAND                                        | Céliane with Netatmo Dimmer switch w/o neutral 067721.       |
+| LEGRAND                                        | Céliane with Netatmo Dimmer switch with neutral Cx0409.      |
 | LIVARNO Smart Home                             | Lidl Livarno Smart Home Bulbs _[<sup>[4]</sup>](#note4)_     |
 | LUMI weather sensor                            | temperature, pressure, humidity sensor                       |
 | Lupus Small Zigbee Temperature Sensor 12314    | Lupus-Electronics Temperature and Humidity sensor            |
@@ -316,6 +318,7 @@ The following devices have been tested by openHAB users with the binding. This l
 | SONOFF SNZB-02P                                | Sensor (Temperature, Humidity) eWeLink SNZB-02P              |
 | SONOFF SNZB-03                                 | Sensor (Motion Intrusion, Tamper, Low Battery) eWeLink MS01  |
 | SONOFF SNZB-04                                 | Sensor (Contact Portal 1, Tamper, Low Battery) eWeLink DS01  |
+| SONOFF SNZB-05P                                | Sensor (Water alarm, Tamper, Low Battery) SONOFF SNZB-05P    |
 | Telkonet EcoInsight Thermostat                 | Intelligent HVAC Thermostat                                  |
 | Trust Bulbs                                    | _[<sup>[1]</sup> ](#note1)_                                  |
 | Ubisys modules                                 | D1 Dimmer, S1/S2 Switch modules                              |

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/legrand/dimmer-switch-with-neutral.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/legrand/dimmer-switch-with-neutral.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zigbee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="legrand_dimmer_with_neutral" listed="false">
+		<label>Legrand with Netatmo Dimmer</label>
+		<description>Legrand with Netatmo Dimmer with neutral</description>
+      <semantic-equipment-tag>LightSource</semantic-equipment-tag>
+		<channels>
+			<channel id="switch_onoff" typeId="switch_onoff">
+				<properties>
+					<property name="zigbee_endpoint">1</property>
+				</properties>
+			</channel>
+			<channel id="switch_level" typeId="switch_level">
+				<label>Level Control</label>
+				<description></description>
+				<properties>
+					<property name="zigbee_endpoint">1</property>
+				</properties>
+			</channel>
+		</channels>
+
+		<config-description>
+			<parameter name="zigbee_macaddress" type="text" readOnly="true" required="true">
+				<label>MAC Address</label>
+			</parameter>
+
+                        <parameter name="attribute_01_in_fc01_0000_09" type="integer">
+                                <label>Dimmer mode</label>
+                                <options>
+                                        <option value="256">Disabled</option>
+                                        <option value="257">Enabled</option>
+                                </options>
+                                <default>257</default>
+                        </parameter>
+
+			<parameter name="attribute_01_in_fc01_0001_10" type="boolean">
+				<label>Led in Dark</label>
+				<options>
+					<option value="false">Disabled</option>
+					<option value="true">Enabled</option>
+				</options>
+				<default>false</default>
+			</parameter>
+
+			<parameter name="attribute_01_in_fc01_0002_10" type="boolean">
+				<label>Led if On</label>
+				<options>
+					<option value="false">Disabled</option>
+					<option value="true">Enabled</option>
+				</options>
+				<default>false</default>
+			</parameter>
+		</config-description>
+
+	</thing-type>
+</thing:thing-descriptions>

--- a/org.openhab.binding.zigbee/src/main/resources/discovery.txt
+++ b/org.openhab.binding.zigbee/src/main/resources/discovery.txt
@@ -16,6 +16,7 @@ xiaomi_lumiremotemini,modelId=lumi.remote.b1acn01
 innr-rc-110,vendor=innr,modelId=RC 110
 osram-switch-4x-eu,vendor=OSRAM,modelId=Switch 4x EU-LIGHTIFY
 legrand_dimmer_without_neutral,vendor=Legrand,modelId=Dimmer switch w/o neutral
+legrand_dimmer_with_neutral,vendor=Legrand,modelId=Dimmer switch with neutral
 tuya_ts0041,modelId=TS0041
 tuya_ts0042,modelId=TS0042
 tuya_ts0043,modelId=TS0043


### PR DESCRIPTION
Also reports SONOFF Water leak sensor SNZB-05P and Legrand Céliane with Netatmo Connected micromodule for exhaust fan CMV 2 speeds as tested successfully.

It should close or nearly close #711.