### PR TITLE
Provide serial speed options for 230k and 460k for Ember

### DIFF
--- a/org.openhab.binding.zigbee.ember/src/main/resources/OH-INF/thing/controller_ember.xml
+++ b/org.openhab.binding.zigbee.ember/src/main/resources/OH-INF/thing/controller_ember.xml
@@ -62,7 +62,9 @@
 				<options>
 					<option value="38400">38400</option>
 					<option value="57600">57600</option>
-					<option value="115200">115200</option>
+                    <option value="115200">115200</option>
+                    <option value="230400">230400</option>
+                    <option value="460800">460800</option>
 				</options>
 			</parameter>
 


### PR DESCRIPTION
Adds serial speeds 460800 and 230400 as options for Ember speeds.
Note that this has not been tested to see if the OH serial provider supports this speed.
Closes #808 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>
