### PR TITLE
Update On/Off Cluster configuration definition

### DIFF
--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclOnOffSwitchConfig.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/config/ZclOnOffSwitchConfig.java
@@ -70,16 +70,23 @@ public class ZclOnOffSwitchConfig implements ZclClusterConfigHandler {
         List<ParameterOption> options = new ArrayList<>();
 
         if (onoffCluster.isAttributeSupported(ZclOnOffCluster.ATTR_OFFWAITTIME)) {
+            options = new ArrayList<>();
+            options.add(new ParameterOption("0", "Disabled"));
             parameters.add(ConfigDescriptionParameterBuilder.create(CONFIG_OFFWAITTIME, Type.INTEGER)
                     .withLabel("Off Wait Time")
                     .withDescription("Time in 100ms steps to ignore ON commands after an OFF command").withDefault("0")
-                    .withMinimum(new BigDecimal(0)).withMaximum(new BigDecimal(60000)).build());
+                    .withMinimum(new BigDecimal(0)).withMaximum(new BigDecimal(60000)).withOptions(options)
+                    .withLimitToOptions(false).build());
+
         }
         if (onoffCluster.isAttributeSupported(ZclOnOffCluster.ATTR_ONTIME)) {
+            options = new ArrayList<>();
+            options.add(new ParameterOption("0", "Disabled"));
             parameters.add(ConfigDescriptionParameterBuilder.create(CONFIG_ONTIME, Type.INTEGER)
                     .withLabel("Auto OFF Time")
                     .withDescription("Time in 100ms steps to automatically turn off when sent with timed command")
-                    .withDefault("65535").withMinimum(new BigDecimal(0)).withMaximum(new BigDecimal(60000)).build());
+                    .withDefault("0").withMinimum(new BigDecimal(0)).withMaximum(new BigDecimal(60000))
+                    .withOptions(options).withLimitToOptions(false).build());
         }
         if (onoffCluster.isAttributeSupported(ZclOnOffCluster.ATTR_STARTUPONOFF)) {
             options = new ArrayList<>();


### PR DESCRIPTION
Updates the configuration options for the OnOff cluster. This adds a "Disabled" option and removes the previous 65535 default.

Closes #926 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>
