### PR TITLE
trigger channel events for ON/OFF

### DIFF
--- a/org.openhab.binding.zigbee/README.md
+++ b/org.openhab.binding.zigbee/README.md
@@ -491,6 +491,19 @@ then
 end
 ```
 
+### Dimmer events
+
+`Level Control Button Events` channels support the following events:
+
+- `SHORT_PRESSED`: Pressed once within a short time
+- `DOUBLE_PRESSED`: Pressed twice within a short time
+
+These events can be combined with `But only if` of the item state to run rules depending on the button pressed, e.g.
+- a rule triggered on `SHORT_PRESSED` with `But only if dimmer_state != 0` to run on `ON` button pressed once
+- a rule triggered on `SHORT_PRESSED` with `But only if dimmer_state = 0` to run on `OFF` button pressed once
+- a rule triggered on `DOUBLE_PRESSED` with `But only if dimmer_state != 0` to run on `ON` button pressed twice
+- a rule triggered on `DOUBLE_PRESSED` with `But only if dimmer_state = 0` to run on `OFF` button pressed twice
+
 ## Reporting and Polling
 
 ZigBee has a standard way of configuring how a device sends status reports to the binding - this is called Reporting. Reporting is configured using three pieces of information -:

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/ZigBeeBindingConstants.java
@@ -46,6 +46,10 @@ public class ZigBeeBindingConstants {
     public static final String CHANNEL_LABEL_SWITCH_LEVEL = "Level Control";
     public static final ChannelTypeUID CHANNEL_SWITCH_LEVEL = new ChannelTypeUID("zigbee:switch_level");
 
+    public static final String CHANNEL_NAME_SWITCH_LEVEL_EVENTS = "dimmer_events";
+    public static final String CHANNEL_LABEL_SWITCH_LEVEL_EVENTS = "Level Control Button Events";
+    public static final ChannelTypeUID CHANNEL_SWITCH_LEVEL_EVENTS = new ChannelTypeUID("zigbee:switch_level_events");
+
     public static final String CHANNEL_NAME_WARNING_DEVICE = "warning_device";
     public static final String CHANNEL_LABEL_WARNING_DEVICE = "Warning Device";
     public static final ChannelTypeUID CHANNEL_WARNING_DEVICE = new ChannelTypeUID("zigbee:warning_device");

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/converter/ZigBeeBaseChannelConverter.java
@@ -294,6 +294,15 @@ public abstract class ZigBeeBaseChannelConverter {
     public abstract Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint);
 
     /**
+     * Connects the channel converter with the converter of the event channel.
+     * 
+     * @param maybeEventConverter a converter that might be a event channel
+     */
+    public void connectEventConverter(ZigBeeBaseChannelConverter maybeEventConverter) {
+        // Overridable if a channel can handle events
+    }
+
+    /**
      * Updates the channel state within the thing.
      *
      * @param state the updated {@link State}
@@ -302,6 +311,21 @@ public abstract class ZigBeeBaseChannelConverter {
         logger.debug("{}: Channel {} updated to {}", endpoint.getIeeeAddress(), channelUID, state);
 
         thing.setChannelState(channelUID, state);
+    }
+
+    /**
+     * Trigger the event to the channel within the thing.
+     *
+     * @param event the event to post
+     */
+    protected void triggerEventChannel(String event) {
+        if (channelUID == null) {
+            throw new UnsupportedOperationException("no event channel initialzied to trigger the event");
+        }
+
+        logger.debug("{}: Trigger event {} to channel {}", endpoint.getIeeeAddress(), event, channelUID);
+
+        thing.triggerChannel(channelUID, event);
     }
 
     /**

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/handler/ZigBeeThingHandler.java
@@ -432,6 +432,9 @@ public class ZigBeeThingHandler extends BaseThingHandler implements ZigBeeNetwor
                     stateDescriptions.put(channel.getUID(), stateDescription);
                 }
             }
+
+            // give all channels a chance to connect to each other to trigger events
+            channels.values().forEach((h) -> channels.values().forEach(h::connectEventConverter));
         } catch (Exception e) {
             logger.error("{}: Exception creating channels", nodeIeeeAddress, e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR);

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactoryImpl.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeChannelConverterFactoryImpl.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import java.util.List;
 
 @Component(immediate = true)
 public final class ZigBeeChannelConverterFactoryImpl implements ZigBeeChannelConverterFactory {
@@ -52,7 +53,7 @@ public final class ZigBeeChannelConverterFactoryImpl implements ZigBeeChannelCon
     /**
      * Map of all channels to be consolidated. Note that order is important.
      */
-    private final Map<ChannelTypeUID, ChannelTypeUID> channelConsolidation = new LinkedHashMap<>();
+    private final Map<ChannelTypeUID, List<ChannelTypeUID>> channelConsolidation = new LinkedHashMap<>();
 
     public ZigBeeChannelConverterFactoryImpl() {
         // Add the hierarchical list of channels that are to be removed due to inheritance
@@ -62,10 +63,11 @@ public final class ZigBeeChannelConverterFactoryImpl implements ZigBeeChannelCon
 
         // Remove ON/OFF if we support LEVEL
         channelConsolidation.put(ZigBeeBindingConstants.CHANNEL_SWITCH_LEVEL,
-                ZigBeeBindingConstants.CHANNEL_SWITCH_ONOFF);
+                List.of(ZigBeeBindingConstants.CHANNEL_SWITCH_ONOFF));
         // Remove LEVEL if we support COLOR
         channelConsolidation.put(ZigBeeBindingConstants.CHANNEL_COLOR_COLOR,
-                ZigBeeBindingConstants.CHANNEL_SWITCH_LEVEL);
+                List.of(ZigBeeBindingConstants.CHANNEL_SWITCH_LEVEL,
+                        ZigBeeBindingConstants.CHANNEL_SWITCH_LEVEL_EVENTS));
     }
 
     @Override
@@ -91,12 +93,14 @@ public final class ZigBeeChannelConverterFactoryImpl implements ZigBeeChannelCon
 
         // Perform a channel consolidation at endpoint level to remove unnecessary channels.
         // This removes channels that are covered through inheritance.
-        for (Map.Entry<ChannelTypeUID, ChannelTypeUID> consolidationChannel : channelConsolidation.entrySet()) {
-            if (channels.containsKey(consolidationChannel.getKey())
-                    && channels.containsKey(consolidationChannel.getValue())) {
-                logger.debug("{}: Removing channel {} in favor of {}", endpoint.getIeeeAddress(),
-                        consolidationChannel.getValue(), consolidationChannel.getKey());
-                channels.remove(consolidationChannel.getValue());
+        for (Map.Entry<ChannelTypeUID, List<ChannelTypeUID>> consolidationChannel : channelConsolidation.entrySet()) {
+            for (ChannelTypeUID toRemove : consolidationChannel.getValue()) {
+                if (channels.containsKey(consolidationChannel.getKey())
+                        && channels.containsKey(toRemove)) {
+                    logger.debug("{}: Removing channel {} in favor of {}", endpoint.getIeeeAddress(),
+                            toRemove, consolidationChannel.getKey());
+                    channels.remove(toRemove);
+                }
             }
         }
         return channels.values();

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevel.java
@@ -110,6 +110,7 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
 
     private ScheduledExecutorService updateScheduler;
     private ScheduledFuture<?> updateTimer = null;
+    private ZigBeeConverterSwitchLevelEvents eventConverter;
 
     @Override
     public Set<Integer> getImplementedClientClusters() {
@@ -485,6 +486,13 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
     }
 
     @Override
+    public void connectEventConverter(ZigBeeBaseChannelConverter maybeEventConverter) {
+        if (maybeEventConverter instanceof ZigBeeConverterSwitchLevelEvents converter) {
+            this.eventConverter = converter;
+        }
+    }
+
+    @Override
     public void updateConfiguration(@NonNull Configuration currentConfiguration,
             Map<String, Object> updatedParameters) {
         if (configReporting != null) {
@@ -550,6 +558,9 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
             currentOnOffState.set(true);
             lastLevel = PercentType.HUNDRED;
             updateChannelState(lastLevel);
+            if (eventConverter != null) {
+                eventConverter.planChannelEvent("ON");
+            }
             clusterOnOffClient.sendDefaultResponse(command, ZclStatus.SUCCESS);
             return true;
         }
@@ -566,12 +577,18 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
             currentOnOffState.set(false);
             lastLevel = PercentType.ZERO;
             updateChannelState(lastLevel);
+            if (eventConverter != null) {
+                eventConverter.planChannelEvent("OFF");
+            }
             return true;
         }
         if (command instanceof ToggleCommand) {
             currentOnOffState.set(!currentOnOffState.get());
             lastLevel = currentOnOffState.get() ? PercentType.HUNDRED : PercentType.ZERO;
             updateChannelState(lastLevel);
+            if (eventConverter != null) {
+                eventConverter.planChannelEvent("TOGGLE");
+            }
             clusterOnOffClient.sendDefaultResponse(command, ZclStatus.SUCCESS);
             return true;
         }
@@ -799,5 +816,4 @@ public class ZigBeeConverterSwitchLevel extends ZigBeeBaseChannelConverter
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
-
 }

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevelEvents.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeConverterSwitchLevelEvents.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.zigbee.internal.converter;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclLevelControlCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclOnOffCluster;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.openhab.binding.zigbee.ZigBeeBindingConstants;
+import org.openhab.binding.zigbee.converter.ZigBeeBaseChannelConverter;
+import org.openhab.binding.zigbee.handler.ZigBeeThingHandler;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.CommonTriggerEvents;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.builder.ChannelBuilder;
+import org.openhab.core.thing.type.ChannelKind;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This channel supports triggering events related to the buttons of the ZigBeeConverterSwitchLevel
+ *
+ * @author Jörg Sautter - Initial Contribution
+ *
+ */
+public class ZigBeeConverterSwitchLevelEvents extends ZigBeeBaseChannelConverter {
+    private final Logger logger = LoggerFactory.getLogger(ZigBeeConverterSwitchLevelEvents.class);
+
+    // The number of milliseconds after the last action is performed to raise the event
+    private static final int EVENT_TIMEFRAME = 800;
+
+    private record Event(String type, int count, ScheduledFuture<?> timer) { }
+    private ScheduledExecutorService eventScheduler;
+    private Event lastEvent = null;
+
+    @Override
+    public Set<Integer> getImplementedClientClusters() {
+        return Stream.of(ZclOnOffCluster.CLUSTER_ID, ZclLevelControlCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Integer> getImplementedServerClusters() {
+        return Stream.of(ZclOnOffCluster.CLUSTER_ID, ZclLevelControlCluster.CLUSTER_ID).collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean initializeConverter(ZigBeeThingHandler thing) {
+        super.initializeConverter(thing);
+        eventScheduler = Executors.newSingleThreadScheduledExecutor();
+        return true;
+    }
+
+    @Override
+    public boolean initializeDevice() {
+        return true;
+    }
+
+    @Override
+    public Channel getChannel(ThingUID thingUID, ZigBeeEndpoint endpoint) {
+        if (endpoint.getInputCluster(ZclLevelControlCluster.CLUSTER_ID) == null
+                && endpoint.getOutputCluster(ZclLevelControlCluster.CLUSTER_ID) == null) {
+            logger.trace("{}: Level control cluster not found", endpoint.getIeeeAddress());
+            return null;
+        }
+
+        return ChannelBuilder
+                .create(createChannelUID(thingUID, endpoint, ZigBeeBindingConstants.CHANNEL_NAME_SWITCH_LEVEL_EVENTS))
+                .withKind(ChannelKind.TRIGGER)
+                .withType(ZigBeeBindingConstants.CHANNEL_SWITCH_LEVEL_EVENTS)
+                .withLabel(getDeviceTypeLabel(endpoint) + ": " + ZigBeeBindingConstants.CHANNEL_LABEL_SWITCH_LEVEL_EVENTS)
+                .withProperties(createProperties(endpoint))
+                .build();
+    }
+
+    /**
+     * Plan the event to the trigger channel within the thing, to trigger the 
+     * event if there is no other action within the next EVENT_TIMEFRAME.
+     */
+    public void planChannelEvent(String type) {
+        logger.debug("{}: Plan {} event to channel {}", endpoint.getIeeeAddress(), type, channelUID);
+
+        int lastCount;
+
+        // is there a pending event?
+        if (lastEvent != null && lastEvent.timer.cancel(false) && type.equals(lastEvent.type)) {
+            lastCount = lastEvent.count;
+        } else {
+            lastCount = 0;
+        }
+
+        String plan = switch(lastCount) {
+            case 0 -> CommonTriggerEvents.SHORT_PRESSED;
+            case 1 -> CommonTriggerEvents.DOUBLE_PRESSED;
+            default -> null; // give the change to cancle raising the event
+        };
+
+        lastEvent = new Event(type, lastCount + 1, eventScheduler.schedule(() -> {
+            // ignore the button has been pressed more than two times
+            if (plan != null) {
+                triggerEventChannel(plan);
+            }
+        }, EVENT_TIMEFRAME, TimeUnit.MILLISECONDS));
+    }
+
+    @Override
+    public void disposeConverter() {
+        eventScheduler.shutdownNow();
+    }
+}

--- a/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeDefaultChannelConverterProvider.java
+++ b/org.openhab.binding.zigbee/src/main/java/org/openhab/binding/zigbee/internal/converter/ZigBeeDefaultChannelConverterProvider.java
@@ -63,6 +63,7 @@ public final class ZigBeeDefaultChannelConverterProvider implements ZigBeeChanne
         channelMap.put(ZigBeeBindingConstants.CHANNEL_PRESSURE_VALUE, ZigBeeConverterAtmosphericPressure.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_SWITCH_ONOFF, ZigBeeConverterSwitchOnoff.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_SWITCH_LEVEL, ZigBeeConverterSwitchLevel.class);
+        channelMap.put(ZigBeeBindingConstants.CHANNEL_SWITCH_LEVEL_EVENTS, ZigBeeConverterSwitchLevelEvents.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_WARNING_DEVICE, ZigBeeConverterWarningDevice.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_TEMPERATURE_VALUE, ZigBeeConverterTemperature.class);
         channelMap.put(ZigBeeBindingConstants.CHANNEL_ELECTRICAL_RMSVOLTAGE,

--- a/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/channels.xml
+++ b/org.openhab.binding.zigbee/src/main/resources/OH-INF/thing/channels.xml
@@ -411,6 +411,19 @@
         <autoUpdatePolicy>veto</autoUpdatePolicy>
     </channel-type>    
 
+    <!-- Level Switch Events -->
+    <channel-type id="switch_level_events">
+        <kind>trigger</kind>
+        <label>Dimmer Button Events</label>
+        <description>Events related to the buttons of a dimmer</description>
+        <event>
+            <options>
+                <option value="SHORT_PRESSED">Pressed a button once within a short time</option>
+                <option value="DOUBLE_PRESSED">Pressed a button twice within a short time</option>
+            </options>
+        </event>
+    </channel-type>
+
     <!-- Thermostat Local Temperature -->
     <channel-type id="thermostat_localtemp">
         <item-type>Number:Temperature</item-type>


### PR DESCRIPTION
This PR will add support for channel events to the new `Level Control Events` and `Switch Events` channels.
Allowing to create rules triggered everytime a button on a `Level Control` or `Switch` ignoring the state of the channel.

To have trigger different rules depending on the times the button is pressed there are the following events supported:
- `SINGLE_ON`: Pressed `On` once within a short time
- `DOUBLE_ON`: Pressed `On` twice within a short time
- `TRIPLE_ON`: Pressed `On` thrice within a short time
- `SINGLE_OFF`: Pressed `Off` once within a short time
- `DOUBLE_OFF`: Pressed `Off` twice within a short time
- `TRIPLE_OFF`: Pressed `Off` thrice within a short time
- `SINGLE_TOGGLE`: Pressed `Toggle` once within a short time
- `DOUBLE_TOGGLE`: Pressed `Toggle` twice within a short time
- `TRIPLE_TOGGLE`: Pressed `Toggle` thrice within a short time

This has been tested with a `IKEA RODRET`.